### PR TITLE
Require `locations' interface 2.0 or 3.0 MODINV-89

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 10.0.0 Unreleased
 
+* Requires `locations` interface 2.0 or 3.0 (MODINV-89)
 * Upgrades to RAML 1.0 (MODINV-85)
 * Removes `instance.edition` (MODINV-78)
 * Adds `instance.editions` (MODINV-78)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -149,7 +149,7 @@
     },
     {
       "id": "locations",
-      "version": "1.1 2.0"
+      "version": "2.0 3.0"
     },
     {
       "id": "instance-types",


### PR DESCRIPTION
  The interface change involves new mandatory fields but mod-inventory
  only reads from the API so no code changes should be necessary.