### PR TITLE
Fix tests when run via Okapi

### DIFF
--- a/src/test/java/api/ApiTestSuite.java
+++ b/src/test/java/api/ApiTestSuite.java
@@ -1,22 +1,5 @@
 package api;
 
-import api.items.ItemApiCallNumberExamples;
-import api.items.ItemApiExamples;
-import api.items.ItemApiLocationExamples;
-import api.items.ItemApiTitleExamples;
-import api.support.ControlledVocabularyPreparation;
-import api.support.http.ResourceClient;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import org.folio.inventory.InventoryVerticle;
-import org.folio.inventory.common.VertxAssistant;
-import org.folio.inventory.support.http.client.OkapiHttpClient;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import support.fakes.FakeOkapi;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
@@ -27,6 +10,25 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import org.folio.inventory.InventoryVerticle;
+import org.folio.inventory.common.VertxAssistant;
+import org.folio.inventory.support.http.client.OkapiHttpClient;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import api.items.ItemApiCallNumberExamples;
+import api.items.ItemApiExamples;
+import api.items.ItemApiLocationExamples;
+import api.items.ItemApiTitleExamples;
+import api.support.ControlledVocabularyPreparation;
+import api.support.http.ResourceClient;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import support.fakes.FakeOkapi;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -327,13 +329,18 @@ public class ApiTestSuite {
 
     ResourceClient locationsClient = ResourceClient.forLocations(client);
 
+    final UUID fakeServicePointId = UUID.randomUUID();
+
     thirdFloorLocationId = createReferenceRecord(locationsClient,
       new JsonObject()
         .put("name", "3rd Floor")
         .put("code", "NU/JC/DL/3F")
         .put("institutionId", nottinghamUniversityInstitution.toString())
         .put("campusId", jubileeCampus.toString())
-        .put("libraryId", djanoglyLibrary.toString()));
+        .put("libraryId", djanoglyLibrary.toString())
+        //TODO: Replace with created service point
+        .put("primaryServicePoint", fakeServicePointId.toString())
+        .put("servicePointIds", new JsonArray().add(fakeServicePointId.toString())));
 
     mezzanineDisplayCaseLocationId = createReferenceRecord(locationsClient,
       new JsonObject()
@@ -341,15 +348,21 @@ public class ApiTestSuite {
         .put("code", "NU/JC/BL/DM")
         .put("institutionId", nottinghamUniversityInstitution.toString())
         .put("campusId", jubileeCampus.toString())
-        .put("libraryId", businessLibrary.toString()));
+        .put("libraryId", businessLibrary.toString())
+        //TODO: Replace with created service point
+        .put("primaryServicePoint", fakeServicePointId.toString())
+        .put("servicePointIds", new JsonArray().add(fakeServicePointId.toString())));
 
     readingRoomLocationId = createReferenceRecord(locationsClient,
       new JsonObject()
-         .put("name", "Reading Room")
-         .put("code","NU/JC/BL/PR")
-         .put("institutionId", nottinghamUniversityInstitution.toString())
-         .put("campusId", jubileeCampus.toString())
-         .put("libraryId", businessLibrary.toString()));
+        .put("name", "Reading Room")
+        .put("code","NU/JC/BL/PR")
+        .put("institutionId", nottinghamUniversityInstitution.toString())
+        .put("campusId", jubileeCampus.toString())
+        .put("libraryId", businessLibrary.toString())
+        //TODO: Replace with created service point
+        .put("primaryServicePoint", fakeServicePointId.toString())
+        .put("servicePointIds", new JsonArray().add(fakeServicePointId.toString())));
 
     //Need to create a main library location otherwise MODS ingestion will fail
     //TODO: Need to remove this when MODS uses different example location
@@ -359,7 +372,10 @@ public class ApiTestSuite {
         .put("code", "NU/JC/DL/ML")
         .put("institutionId", nottinghamUniversityInstitution.toString())
         .put("campusId", jubileeCampus.toString())
-        .put("libraryId", djanoglyLibrary.toString()));
+        .put("libraryId", djanoglyLibrary.toString())
+        //TODO: Replace with created service point
+        .put("primaryServicePoint", fakeServicePointId.toString())
+        .put("servicePointIds", new JsonArray().add(fakeServicePointId.toString())));
   }
 
   private static void createIdentifierTypes()

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -1,23 +1,15 @@
 package api;
 
-import api.support.ApiRoot;
-import api.support.ApiTests;
-import api.support.InstanceApiClient;
-import com.github.jsonldjava.core.DocumentLoader;
-import com.github.jsonldjava.core.JsonLdError;
-import com.github.jsonldjava.core.JsonLdOptions;
-import com.github.jsonldjava.core.JsonLdProcessor;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import org.apache.http.Header;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
-import org.apache.http.message.BasicHeader;
-import org.folio.inventory.support.JsonArrayHelper;
-import org.folio.inventory.support.http.client.Response;
-import org.folio.inventory.support.http.client.ResponseHandler;
-import org.junit.Assert;
-import org.junit.Test;
+import static api.support.InstanceSamples.leviathanWakes;
+import static api.support.InstanceSamples.nod;
+import static api.support.InstanceSamples.smallAngryPlanet;
+import static api.support.InstanceSamples.taoOfPooh;
+import static api.support.InstanceSamples.temeraire;
+import static api.support.InstanceSamples.uprooted;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -30,9 +22,26 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static api.support.InstanceSamples.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import org.apache.http.Header;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.folio.inventory.support.JsonArrayHelper;
+import org.folio.inventory.support.http.client.Response;
+import org.folio.inventory.support.http.client.ResponseHandler;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.github.jsonldjava.core.DocumentLoader;
+import com.github.jsonldjava.core.JsonLdError;
+import com.github.jsonldjava.core.JsonLdOptions;
+import com.github.jsonldjava.core.JsonLdProcessor;
+
+import api.support.ApiRoot;
+import api.support.ApiTests;
+import api.support.InstanceApiClient;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public class InstancesApiExamples extends ApiTests {
   public InstancesApiExamples() throws MalformedURLException {
@@ -443,7 +452,7 @@ public class InstancesApiExamples extends ApiTests {
 
     CompletableFuture<Response> searchGetCompleted = new CompletableFuture<>();
 
-    okapiClient.get(ApiRoot.instances("query=title=*Small%20Angry*"),
+    okapiClient.get(ApiRoot.instances("query=title=Small%20Angry*"),
       ResponseHandler.json(searchGetCompleted));
 
     Response searchGetResponse = searchGetCompleted.get(5, TimeUnit.SECONDS);

--- a/src/test/java/api/items/ItemApiCallNumberExamples.java
+++ b/src/test/java/api/items/ItemApiCallNumberExamples.java
@@ -1,13 +1,8 @@
 package api.items;
 
-import api.support.ApiTests;
-import api.support.builders.HoldingRequestBuilder;
-import api.support.fixtures.InstanceRequestExamples;
-import api.support.fixtures.ItemRequestExamples;
-import io.vertx.core.json.JsonObject;
-import org.folio.inventory.support.http.client.IndividualResource;
-import org.folio.inventory.support.http.client.Response;
-import org.junit.Test;
+import static api.support.JsonCollectionAssistant.getRecordById;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.util.List;
@@ -15,9 +10,16 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import static api.support.JsonCollectionAssistant.getRecordById;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import org.folio.inventory.support.http.client.IndividualResource;
+import org.folio.inventory.support.http.client.Response;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import api.support.ApiTests;
+import api.support.builders.HoldingRequestBuilder;
+import api.support.fixtures.InstanceRequestExamples;
+import api.support.fixtures.ItemRequestExamples;
+import io.vertx.core.json.JsonObject;
 
 //TODO: When converted to RAML module builder, no longer redirect to content and do separate GET
 public class ItemApiCallNumberExamples extends ApiTests {
@@ -51,6 +53,7 @@ public class ItemApiCallNumberExamples extends ApiTests {
       createdItem.getString("callNumber"), is("R11.A38"));
   }
 
+  @Ignore("mod-inventory-storage disallows this scenario, change to be isolated test")
   @Test
   public void noCallNumberWhenNoHoldingsRecord()
     throws InterruptedException,
@@ -131,6 +134,7 @@ public class ItemApiCallNumberExamples extends ApiTests {
       secondFetchedItem.getString("callNumber"), is("D15.H63 A3 2002"));
   }
 
+  @Ignore("mod-inventory-storage disallows this scenario, change to be isolated test")
   @Test
   public void noCallNumberWhenNoHoldingForMultipleItems()
     throws InterruptedException,

--- a/src/test/java/api/items/ItemApiTitleExamples.java
+++ b/src/test/java/api/items/ItemApiTitleExamples.java
@@ -1,24 +1,25 @@
 package api.items;
 
-import api.support.ApiTests;
-import api.support.builders.HoldingRequestBuilder;
-import api.support.fixtures.InstanceRequestExamples;
-import api.support.fixtures.ItemRequestExamples;
-import io.vertx.core.json.JsonObject;
-import org.folio.inventory.support.http.client.IndividualResource;
-import org.folio.inventory.support.http.client.Response;
-import org.junit.Test;
+import static api.support.JsonCollectionAssistant.getRecordById;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import static api.support.JsonCollectionAssistant.getRecordById;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import org.folio.inventory.support.http.client.IndividualResource;
+import org.folio.inventory.support.http.client.Response;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import api.support.ApiTests;
+import api.support.builders.HoldingRequestBuilder;
+import api.support.fixtures.InstanceRequestExamples;
+import api.support.fixtures.ItemRequestExamples;
+import io.vertx.core.json.JsonObject;
 
 //TODO: When converted to RAML module builder, no longer redirect to content and do separate GET
 public class ItemApiTitleExamples extends ApiTests {
@@ -31,8 +32,7 @@ public class ItemApiTitleExamples extends ApiTests {
     throws InterruptedException,
     ExecutionException,
     TimeoutException,
-    MalformedURLException,
-    UnsupportedEncodingException {
+    MalformedURLException {
 
     UUID instanceId = instancesClient.create(
       InstanceRequestExamples.smallAngryPlanet()).getId();
@@ -52,13 +52,13 @@ public class ItemApiTitleExamples extends ApiTests {
       createdItem.getString("title"), is("The Long Way to a Small, Angry Planet"));
   }
 
+  @Ignore("mod-inventory-storage disallows this scenario, change to be isolated test")
   @Test
   public void noTitleWhenNoInstance()
     throws InterruptedException,
     ExecutionException,
     TimeoutException,
-    MalformedURLException,
-    UnsupportedEncodingException {
+    MalformedURLException {
 
     UUID instanceId = instancesClient.create(
       InstanceRequestExamples.smallAngryPlanet()).getId();
@@ -80,13 +80,13 @@ public class ItemApiTitleExamples extends ApiTests {
       createdItem.containsKey("title"), is(false));
   }
 
+  @Ignore("mod-inventory-storage disallows this scenario, change to be isolated test")
   @Test
   public void noTitleWhenNoHolding()
     throws InterruptedException,
     ExecutionException,
     TimeoutException,
-    MalformedURLException,
-    UnsupportedEncodingException {
+    MalformedURLException {
 
     UUID instanceId = instancesClient.create(
       InstanceRequestExamples.smallAngryPlanet()).getId();
@@ -113,8 +113,7 @@ public class ItemApiTitleExamples extends ApiTests {
     throws InterruptedException,
     ExecutionException,
     TimeoutException,
-    MalformedURLException,
-    UnsupportedEncodingException {
+    MalformedURLException {
 
     UUID firstInstanceId = instancesClient.create(
       InstanceRequestExamples.smallAngryPlanet()).getId();
@@ -159,6 +158,7 @@ public class ItemApiTitleExamples extends ApiTests {
       secondFetchedItem.getString("title"), is("Temeraire"));
   }
 
+  @Ignore("mod-inventory-storage disallows this scenario, change to be isolated test")
   @Test
   public void noTitleWhenHoldingOrInstanceNotFound()
     throws InterruptedException,
@@ -221,8 +221,7 @@ public class ItemApiTitleExamples extends ApiTests {
     throws InterruptedException,
     ExecutionException,
     TimeoutException,
-    MalformedURLException,
-    UnsupportedEncodingException {
+    MalformedURLException {
 
     UUID instanceId = instancesClient.create(
       InstanceRequestExamples.smallAngryPlanet()).getId();
@@ -248,8 +247,7 @@ public class ItemApiTitleExamples extends ApiTests {
     throws InterruptedException,
     ExecutionException,
     TimeoutException,
-    MalformedURLException,
-    UnsupportedEncodingException {
+    MalformedURLException {
 
     UUID instanceId = instancesClient.create(
       InstanceRequestExamples.smallAngryPlanet()).getId();

--- a/src/test/java/support/fakes/FakeOkapi.java
+++ b/src/test/java/support/fakes/FakeOkapi.java
@@ -147,7 +147,8 @@ public class FakeOkapi extends AbstractVerticle {
         "code",
         "institutionId",
         "campusId",
-        "libraryId")
+        "libraryId",
+        "primaryServicePoint")
       .create()
       .register(router);
   }

--- a/test-via-okapi.sh
+++ b/test-via-okapi.sh
@@ -7,7 +7,7 @@ okapi_proxy_address="http://localhost:9130"
 inventory_direct_address=http://localhost:9603
 inventory_instance_id=localhost-9603
 #Needs to be the specific version of Inventory Storage you want to use for testing
-inventory_storage_module_id="mod-inventory-storage-12.5.2-SNAPSHOT"
+inventory_storage_module_id="mod-inventory-storage-13.1.0-SNAPSHOT"
 
 echo "Check if Okapi is contactable"
 curl -w '\n' -X GET -D -   \


### PR DESCRIPTION
* Update version of mod-inventory-storage to use to 13.1.0-SNAPSHOT
* Introduce service point properties for locations in API test preparation
* Ignore tests which break constraints around instance, holdings record and item relationships
* Change instance title searching example to use right truncation

The tests need to be replaced with isolated failure tests using fakes at a later point.