### PR TITLE
MODINV-119 fix raml errors

### DIFF
--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -26,15 +26,15 @@
         "type": "object",
         "properties": {
           "id": {
-            "description": "parent instance id",
+            "description": "Id of the parent instance",
             "type": "string"
           },
           "superInstanceId": {
-            "description": "super instance id",
+            "description": "Id of the super instance",
             "type": "string"
           },
           "instanceRelationshipTypeId": {
-            "description": "relationship type id",
+            "description": "Id of the relationship type",
             "type": "string"
           }
         },
@@ -59,7 +59,7 @@
             "type": "string"
           },
           "instanceRelationshipTypeId": {
-            "description": "relationship type id",
+            "description": "Id of the relationship type",
             "type": "string"
           }
         },

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -4,6 +4,7 @@
   "type": "object",
   "properties": {
     "@context": {
+      "description": "Instance context",
       "type": "string"
     },
     "id": {
@@ -19,17 +20,21 @@
       "description": "The metadata source and its format of the underlying record to the instance record. (e.g. FOLIO if it's a record created in Inventory;  MARC if it's a MARC record created in MARCcat or EPKB if it's a record coming from eHoldings)"
     },
     "parentInstances": {
+      "description": "Array of parent instances",
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
           "id": {
+            "description": "parent instance id",
             "type": "string"
           },
           "superInstanceId": {
+            "description": "super instance id",
             "type": "string"
           },
           "instanceRelationshipTypeId": {
+            "description": "relationship type id",
             "type": "string"
           }
         },
@@ -41,6 +46,7 @@
       }
     },
     "childInstances": {
+      "description": "Child instances",
       "type": "array",
       "items": {
         "type": "object",
@@ -49,9 +55,11 @@
             "type": "string"
           },
           "subInstanceId": {
+            "description": "Id of sub Instance",
             "type": "string"
           },
           "instanceRelationshipTypeId": {
+            "description": "relationship type id",
             "type": "string"
           }
         },
@@ -348,9 +356,11 @@
       "readonly": true
     },
     "links": {
+        "description": "Links",
         "type": "object",
         "properties": {
           "self": {
+            "description": "self",
             "type": "string"
           }
         },

--- a/ramls/instance_context.json
+++ b/ramls/instance_context.json
@@ -4,15 +4,15 @@
   "type": "object",
   "properties": {
     "@context": {
-      "description": "context of an instance record",
+      "description": "Context of an instance record",
       "type": "object",
       "properties": {
         "dcterms": {
-          "description": "dcterms",
+          "description": "Dcterms",
           "type": "string"
         },
         "title": {
-          "description": "title",
+          "description": "Title",
           "type": "string"
         }
       },

--- a/ramls/instance_context.json
+++ b/ramls/instance_context.json
@@ -4,12 +4,15 @@
   "type": "object",
   "properties": {
     "@context": {
+      "description": "context of an instance record",
       "type": "object",
       "properties": {
         "dcterms": {
+          "description": "dcterms",
           "type": "string"
         },
         "title": {
+          "description": "title",
           "type": "string"
         }
       },

--- a/ramls/inventory-batch.raml
+++ b/ramls/inventory-batch.raml
@@ -13,26 +13,26 @@ types:
   instancesBatchResponse: !include instances-batch-response.json
 
 /inventory/instances/batch:
-    displayName: Instances batch API
-      type:
-        collection:
-          schemaCollection: instances
-          exampleCollection: !include examples/instancesBatch_post.json
-          schemaItem: instances
-          exampleItem: !include examples/instancesBatch_post.json
-    post:
-      description: "Create collection of instances in one request"
-      body:
-        application/json:
-          type: instances
-      responses:
-        201:
-          description: "Instances are created"
-          body:
-            application/json:
-              type: instancesBatchResponse
-        500:
-          description: "Internal server error"
-          body:
-            application/json:
-              type: instancesBatchResponse
+  displayName: Instances batch API
+    type:
+      collection:
+        schemaCollection: instances
+        exampleCollection: !include examples/instancesBatch_post.json
+        schemaItem: instances
+        exampleItem: !include examples/instancesBatch_post.json
+  post:
+    description: "Create collection of instances in one request"
+    body:
+      application/json:
+        type: instances
+    responses:
+      201:
+        description: "Instances are created"
+        body:
+          application/json:
+            type: instancesBatchResponse
+      500:
+        description: "Internal server error"
+        body:
+          application/json:
+            type: instancesBatchResponse

--- a/ramls/inventory-batch.raml
+++ b/ramls/inventory-batch.raml
@@ -14,12 +14,12 @@ types:
 
 /inventory/instances/batch:
   displayName: Instances batch API
-    type:
-      collection:
-        schemaCollection: instances
-        exampleCollection: !include examples/instancesBatch_post.json
-        schemaItem: instances
-        exampleItem: !include examples/instancesBatch_post.json
+  type:
+    collection:
+      schemaCollection: instances
+      exampleCollection: !include examples/instancesBatch_post.json
+      schemaItem: instances
+      exampleItem: !include examples/instancesBatch_post.json
   post:
     description: "Create collection of instances in one request"
     body:

--- a/ramls/inventory-batch.raml
+++ b/ramls/inventory-batch.raml
@@ -12,21 +12,8 @@ types:
   instances: !include instances.json
   instancesBatchResponse: !include instances-batch-response.json
 
-traits:
-  language: !include raml-util/traits/language.raml
-
-resourceTypes:
-  collection: !include raml-util/rtypes/collection.raml
-  collection-item: !include raml-util/rtypes/item-collection.raml
-
 /inventory/instances/batch:
   displayName: Instances batch API
-  type:
-    collection:
-      schemaCollection: instances
-      exampleCollection: !include examples/instancesBatch_post.json
-      schemaItem: instances
-      exampleItem: !include examples/instancesBatch_post.json
   post:
     description: "Create collection of instances in one request"
     body:

--- a/ramls/inventory-batch.raml
+++ b/ramls/inventory-batch.raml
@@ -12,6 +12,13 @@ types:
   instances: !include instances.json
   instancesBatchResponse: !include instances-batch-response.json
 
+traits:
+  language: !include raml-util/traits/language.raml
+
+resourceTypes:
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
+
 /inventory/instances/batch:
   displayName: Instances batch API
   type:

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -120,7 +120,7 @@
       "type": "string"
     },
     "missingPieces": {
-      "description": "missingPieces",
+      "description": "Missing pieces",
       "type": "string"
     },
     "missingPiecesDate": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -60,7 +60,7 @@
     },
 
     "itemLevelCallNumber": {
-      "description": "Level call number",
+      "description": "Call number of the item",
       "type": "string"
     },
     "itemLevelCallNumberPrefix": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -200,12 +200,14 @@
       ]
     },
     "materialType": {
+      "description": "Material type",
       "type": "object",
       "properties": {
         "id": {
           "type": "string"
         },
         "name": {
+          "description": "Material type name",
           "type": "string"
         }
       },
@@ -215,12 +217,14 @@
       ]
     },
     "permanentLoanType": {
+      "description": "Permanent loan type",
       "type": "object",
       "properties": {
         "id": {
           "type": "string"
         },
         "name": {
+          "description": "Permanent loan type name",
           "type": "string"
         }
       },
@@ -230,12 +234,14 @@
       ]
     },
     "temporaryLoanType": {
+      "description": "Temporary loan type",
       "type": "object",
       "properties": {
         "id": {
           "type": "string"
         },
         "name": {
+          "description": "Temporary loan type name",
           "type": "string"
         }
       },
@@ -245,12 +251,14 @@
       ]
     },
     "permanentLocation": {
+      "description": "Permanent location",
       "type": "object",
       "properties": {
         "id": {
           "type": "string"
         },
         "name": {
+          "description": "Permanent location type name",
           "type": "string"
         }
       },
@@ -260,12 +268,14 @@
       ]
     },
     "temporaryLocation": {
+      "description": "Temporary location",
       "type": "object",
       "properties": {
         "id": {
           "type": "string"
         },
         "name": {
+          "description": "Temporary location name",
           "type": "string"
         }
       },
@@ -284,6 +294,7 @@
            "readonly": true
          },
          "name": {
+           "description": "Effective location name",
            "type": "string",
            "readonly": true
          }

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -96,7 +96,7 @@
       "uniqueItems": true
     },
     "itemIdentifier": {
-      "description": "itemIdentifier",
+      "description": "Item identifier",
       "type": "string"
     },
     "copyNumbers": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -76,7 +76,7 @@
       "type": "string"
     },
     "volume": {
-      "description": "volume",
+      "description": "Volume",
       "type": "string"
     },
     "enumeration": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -108,7 +108,7 @@
       "uniqueItems": true
     },
     "numberOfPieces": {
-      "description": "numberOfPieces",
+      "description": "Number of pieces",
       "type": "string"
     },
     "descriptionOfPieces": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -204,6 +204,7 @@
       "type": "object",
       "properties": {
         "id": {
+          "description": "UUID of the material type",
           "type": "string"
         },
         "name": {
@@ -238,6 +239,7 @@
       "type": "object",
       "properties": {
         "id": {
+          "description": "UUID of the temporary loan type",
           "type": "string"
         },
         "name": {
@@ -255,6 +257,7 @@
       "type": "object",
       "properties": {
         "id": {
+          "description": "UUID of the permanent location",
           "type": "string"
         },
         "name": {
@@ -272,6 +275,7 @@
       "type": "object",
       "properties": {
         "id": {
+          "description": "UUID of the temporary location",
           "type": "string"
         },
         "name": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -64,7 +64,7 @@
       "type": "string"
     },
     "itemLevelCallNumberPrefix": {
-      "description": "Level call number",
+      "description": "Call number prefix",
       "type": "string"
     },
     "itemLevelCallNumberSuffix": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -72,7 +72,7 @@
       "type": "string"
     },
     "itemLevelCallNumberTypeId": {
-      "description": "itemLevelCallNumberTypeId",
+      "description": "Call number type, refers to a call-number-type reference record",
       "type": "string"
     },
     "volume": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -142,7 +142,7 @@
         "type": "object",
         "properties": {
           "itemNoteTypeId": {
-            "description": "itemNoteTypeId",
+            "description": "Item note type, refers to a item-note-type reference record",
             "type": "string"
           },
           "note": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -174,7 +174,7 @@
           },
           "staffOnly": {
             "type": "boolean",
-            "description": "Flag to restrict display of this note",
+            "description": "Whether a note should only be available to staff",
             "default": false
           }
         },

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -68,7 +68,7 @@
       "type": "string"
     },
     "itemLevelCallNumberSuffix": {
-      "description": "Suffix for level call number",
+      "description": "Call number suffix",
       "type": "string"
     },
     "itemLevelCallNumberTypeId": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -80,7 +80,7 @@
       "type": "string"
     },
     "enumeration": {
-      "description": "enumeration",
+      "description": "Enumeration",
       "type": "string"
     },
     "chronology": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -132,7 +132,7 @@
       "type": "string"
     },
     "itemDamagedStatusDate": {
-      "description": "damaged status date",
+      "description": "Date when damage status was last changed",
       "type": "string"
     },
     "notes": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -116,7 +116,7 @@
       "type": "string"
     },
     "numberOfMissingPieces": {
-      "description": "numberOfMissingPieces",
+      "description": "number of missing pieces",
       "type": "string"
     },
     "missingPieces": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -301,7 +301,7 @@
        }
     },
     "electronicAccess": {
-      "description": "electronic access",
+      "description": "Whether an item is available electronically",
       "type": "array",
       "items": {
         "type": "object",

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -150,7 +150,7 @@
             "type": "string"
           },
           "staffOnly": {
-            "description": "staffOnly",
+            "description": "Whether a note should only be available to staff",
             "type": "boolean",
             "default": false
           }

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -128,7 +128,7 @@
       "type": "string"
     },
     "itemDamagedStatusId": {
-      "description": "Id of damaged status",
+      "description": "Damage status",
       "type": "string"
     },
     "itemDamagedStatusDate": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -146,7 +146,7 @@
             "type": "string"
           },
           "note": {
-            "description": "Text to display",
+            "description": "Text of the note",
             "type": "string"
           },
           "staffOnly": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -112,7 +112,7 @@
       "type": "string"
     },
     "descriptionOfPieces": {
-      "description": "description of pieces",
+      "description": "Description of pieces",
       "type": "string"
     },
     "numberOfMissingPieces": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -88,7 +88,7 @@
       "type": "string"
     },
     "yearCaption": {
-      "description": "yearCaption",
+      "description": "year captions",
       "type": "array",
       "items": {
         "type": "string"

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -124,7 +124,7 @@
       "type": "string"
     },
     "missingPiecesDate": {
-      "description": "missingPiecesDate",
+      "description": "Date when pieces went missing",
       "type": "string"
     },
     "itemDamagedStatusId": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -4,6 +4,7 @@
   "type": "object",
   "properties": {
     "id": {
+      "description": "Item id",
       "type": "string"
     },
     "hrid": {
@@ -50,6 +51,7 @@
       "readonly": true
     },
     "barcode": {
+      "description": "Barcode",
       "type": "string"
     },
     "accessionNumber": {
@@ -58,27 +60,35 @@
     },
 
     "itemLevelCallNumber": {
+      "description": "Level call number",
       "type": "string"
     },
     "itemLevelCallNumberPrefix": {
+      "description": "Level call number",
       "type": "string"
     },
     "itemLevelCallNumberSuffix": {
+      "description": "Suffix for level call number",
       "type": "string"
     },
     "itemLevelCallNumberTypeId": {
+      "description": "itemLevelCallNumberTypeId",
       "type": "string"
     },
     "volume": {
+      "description": "volume",
       "type": "string"
     },
     "enumeration": {
+      "description": "enumeration",
       "type": "string"
     },
     "chronology": {
+      "description": "Chronology",
       "type": "string"
     },
     "yearCaption": {
+      "description": "yearCaption",
       "type": "array",
       "items": {
         "type": "string"
@@ -86,9 +96,11 @@
       "uniqueItems": true
     },
     "itemIdentifier": {
+      "description": "itemIdentifier",
       "type": "string"
     },
     "copyNumbers": {
+      "description": "Copy numbers",
       "type": "array",
       "items": {
         "type": "string"
@@ -96,38 +108,49 @@
       "uniqueItems": true
     },
     "numberOfPieces": {
+      "description": "numberOfPieces",
       "type": "string"
     },
     "descriptionOfPieces": {
+      "description": "description of pieces",
       "type": "string"
     },
     "numberOfMissingPieces": {
+      "description": "numberOfMissingPieces",
       "type": "string"
     },
     "missingPieces": {
+      "description": "missingPieces",
       "type": "string"
     },
     "missingPiecesDate": {
+      "description": "missingPiecesDate",
       "type": "string"
     },
     "itemDamagedStatusId": {
+      "description": "Id of damaged status",
       "type": "string"
     },
     "itemDamagedStatusDate": {
+      "description": "damaged status date",
       "type": "string"
     },
     "notes": {
+      "description": "notes",
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
           "itemNoteTypeId": {
+            "description": "itemNoteTypeId",
             "type": "string"
           },
           "note": {
+            "description": "Text to display",
             "type": "string"
           },
           "staffOnly": {
+            "description": "staffOnly",
             "type": "boolean",
             "default": false
           }
@@ -151,7 +174,7 @@
           },
           "staffOnly": {
             "type": "boolean",
-            "default": "Flag to restrict display of this note",
+            "description": "Flag to restrict display of this note",
             "default": false
           }
         },
@@ -267,6 +290,7 @@
        }
     },
     "electronicAccess": {
+      "description": "electronic access",
       "type": "array",
       "items": {
         "type": "object",

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -56,7 +56,7 @@
     },
     "accessionNumber": {
       "type": "string",
-      "description": "Also called inventar number"
+      "description": "Also called inventory number"
     },
 
     "itemLevelCallNumber": {
@@ -88,7 +88,7 @@
       "type": "string"
     },
     "yearCaption": {
-      "description": "year captions",
+      "description": "Year captions",
       "type": "array",
       "items": {
         "type": "string"

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -247,7 +247,7 @@ public class InstancesApiExamples extends ApiTests {
   }
 
   @Test
-  public void shouldReturnBadRequestIfOneInstancePostedWithoutTitle() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+  public void shouldReturnServerErrorIfOneInstancePostedWithoutTitle() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
     // Prepare request data
     String angryPlanetInstanceId = UUID.randomUUID().toString();
     JsonObject angryPlanetInstance = new JsonObject()
@@ -271,7 +271,7 @@ public class InstancesApiExamples extends ApiTests {
   }
 
   @Test
-  public void shouldReturnBadRequestIfOneOfInstancesPostedWithoutTitle() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+  public void shouldReturnServerErrorIfOneOfInstancesPostedWithoutTitle() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
     // Prepare request data
     String angryPlanetInstanceId = UUID.randomUUID().toString();
     JsonObject angryPlanetInstance = new JsonObject()


### PR DESCRIPTION
The raml-cop was reporting validation errors on pull #116

The initial complaint was about indentation errors. As noted in the documentation, these often also mask other errors. So i have fixed various stuff -- see the individual commit messages.

There is now only one error reported: that the example is "Missing required property: errorMessages"
