### PR TITLE
MODINV-138 - Updated list of Instance blocked fields

### DIFF
--- a/src/main/java/org/folio/inventory/config/InventoryConfigurationImpl.java
+++ b/src/main/java/org/folio/inventory/config/InventoryConfigurationImpl.java
@@ -10,11 +10,7 @@ import java.util.Set;
  */
 public class InventoryConfigurationImpl implements InventoryConfiguration {
   private static final Set<String> INSTANCE_BLOCKED_FIELDS = Sets.newHashSet(
-    Instance.DISCOVERY_SUPPRESS_KEY,
-    Instance.PREVIOUSLY_HELD_KEY,
-    Instance.STATUS_ID_KEY,
     Instance.HRID_KEY,
-    Instance.STAFF_SUPPRESS_KEY,
     Instance.SOURCE_KEY,
     Instance.ALTERNATIVE_TITLES_KEY,
     Instance.SERIES_KEY,
@@ -32,7 +28,12 @@ public class InventoryConfigurationImpl implements InventoryConfiguration {
     Instance.SUBJECTS_KEY,
     Instance.CLASSIFICATIONS_KEY,
     Instance.PARENT_INSTANCES_KEY,
-    Instance.CHILD_INSTANCES_KEY);
+    Instance.CHILD_INSTANCES_KEY,
+    Instance.CATALOGED_DATE_KEY,
+    Instance.TITLE_KEY,
+    Instance.INDEX_TITLE_KEY,
+    Instance.INSTANCE_TYPE_ID_KEY
+    );
 
   public InventoryConfigurationImpl() {
   }

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -499,9 +499,10 @@ public class InstancesApiExamples extends ApiTests {
     assertThat(errors.size(), is(1));
     assertThat(errors.getString(0), is(
       "Instance is controlled by MARC record, these fields are blocked and can not be updated: " +
-        "physicalDescriptions,previouslyHeld,notes,languages,parentInstances,identifiers,subjects,source," +
-        "publicationFrequency,electronicAccess,publicationRange,classifications,discoverySuppress,editions," +
-        "statusId,childInstances,hrid,series,instanceFormatIds,staffSuppress,publication,contributors,alternativeTitles"));
+        "physicalDescriptions,notes,languages,parentInstances,identifiers,instanceTypeId,subjects," +
+        "catalogedDate,source,title,indexTitle,publicationFrequency,electronicAccess,publicationRange," +
+        "classifications,editions,childInstances,hrid,series,instanceFormatIds,publication,contributors," +
+        "alternativeTitles"));
 
     // Get existing Instance
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();

--- a/src/test/java/api/support/InstanceSamples.java
+++ b/src/test/java/api/support/InstanceSamples.java
@@ -159,14 +159,8 @@ public class InstanceSamples {
   public static JsonObject marcInstanceWithDefaultBlockedFields(UUID id) {
     return new JsonObject()
       .put("id", id.toString())
-      .put("title", "Treasure Island")
-      .put("instanceTypeId", getTextInstanceType())
       // blocked fields
-      .put("discoverySuppress", true)
-      .put("previouslyHeld", true)
-      .put("statusId", "test status id")
       .put("hrid", UUID.randomUUID().toString())
-      .put("staffSuppress", true)
       .put("alternativeTitles", new JsonArray()
         .add(JsonObject.mapFrom(new AlternativeTitle("test id", "test title"))))
       .put("series", new JsonArray().add("test series"))
@@ -184,7 +178,7 @@ public class InstanceSamples {
       .put("publicationFrequency", new JsonArray().add("test publication frequency"))
       .put("publicationRange", new JsonArray().add("test publication range"))
       .put("notes", new JsonArray()
-        .add(JsonObject.mapFrom(new Note("test id", "test note", true))))
+        .add(JsonObject.mapFrom(new JsonObject().put("note", "test note").put("staffOnly", false))))
       .put("electronicAccess", new JsonArray()
         .add(JsonObject.mapFrom(new ElectronicAccess("test uri", "test link text", "test materials specification", "test public note", "test relationship id"))))
       .put("subjects", new JsonArray().add("test subject"))
@@ -193,7 +187,11 @@ public class InstanceSamples {
       .put("parentInstances", new JsonArray()
         .add(JsonObject.mapFrom(new InstanceRelationshipToParent("test id", "test super instance id", "test type id"))))
       .put("childInstances", new JsonArray()
-        .add(JsonObject.mapFrom(new InstanceRelationshipToChild("test id", "test sub instance id", "test type id"))));
+        .add(JsonObject.mapFrom(new InstanceRelationshipToChild("test id", "test sub instance id", "test type id"))))
+      .put("catalogedDate", LocalDate.now().toString())
+      .put("title", "Treasure Island")
+      .put("indexTitle", "Index Title")
+      .put("instanceTypeId", getTextInstanceType());
   }
 
   private static JsonObject identifier(


### PR DESCRIPTION
Description
It is required to remove the following fields from blockable list:
0: "discoverySuppress"
1: "previouslyHeld"
2: "statusId"
3: "staffSuppress"
4: "statisticalCodeIds"

It is also required to add the following fields to the blockables list:
0: "catalogedDate"
1: "title"
2: "indexTitle"
3: "instanceTypeId"