### PR TITLE
update suppress from discovery flag in SRS on instance update (MODINV-144)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -100,7 +100,8 @@
           "modulePermissions": ["inventory-storage.instances.item.put",
                                 "inventory-storage.instances.item.get",
                                 "inventory-storage.instances.item.post",
-                                "inventory-storage.instances.item.delete"]
+                                "inventory-storage.instances.item.delete",
+                                "source-storage.record.update"]
         }, {
           "methods": ["DELETE"],
           "pathPattern": "/inventory/instances/{id}",
@@ -232,6 +233,10 @@
     {
       "id": "users",
       "version": "15.0"
+    },
+    {
+      "id": "source-record-storage",
+      "version": "2.2"
     }
   ],
   "permissionSets": [

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
       <artifactId>joda-time</artifactId>
       <version>2.10.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>mod-source-record-storage-client</artifactId>
+      <version>2.6.0-SNAPSHOT</version>
+      <type>jar</type>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -173,7 +173,6 @@ public class Instances extends AbstractInstances {
             JsonResponse.unprocessableEntity(rContext.response(), errorMessage);
           } else {
             updateInstance(updatedInstance, rContext, wContext);
-            updateSuppressFromDiscoveryFlag(wContext, updatedInstance);
           }
         } else {
           ClientErrorResponse.notFound(rContext.response());
@@ -230,7 +229,12 @@ public class Instances extends AbstractInstances {
     InstanceCollection instanceCollection = storage.getInstanceCollection(wContext);
     instanceCollection.update(
       instance,
-      v -> updateInstanceRelationships(instance, rContext, wContext, (x) -> noContent(rContext.response())),
+      v -> {
+        updateInstanceRelationships(instance, rContext, wContext, (x) -> noContent(rContext.response()));
+        if (isInstanceControlledByRecord(instance)) {
+          updateSuppressFromDiscoveryFlag(wContext, instance);
+        }
+      },
       FailureResponseConsumer.serverError(rContext.response()));
   }
 


### PR DESCRIPTION
Libraries sometimes want to suppress records from discovery by their patrons. Much of the discovery work involves harvesting SRS MARC Bib records via OAI-PMH. When a user updates this flag in the FOLIO instance, the corresponding change should be made to the related SRS MARC Bib record, which then in turn updates the flag in the MARCcat MARC Bib record  