### PR TITLE
Remove UUID constraints for Instance TypeIds

### DIFF
--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -309,8 +309,8 @@
         "type": "object",
         "properties": {
           "instanceNoteTypeId": {
-            "description": "ID of the type of note",
-            "$ref": "uuid.json"
+            "type": "string",
+            "description": "ID of the type of note"
           },
           "note": {
             "type": "string",


### PR DESCRIPTION
Instance creation fails (Unprocessable Entity) during Record-to-Instance mapping, because of many types in Instance schema are limited to receive only UUID. But some types can be not only UUID, also plain text. 

We need to skip UUID constraints out of Instance schema for the next fields: 
* identifiers.identifierTypeId
* contributors.contributorTypeId,  contributorNameTypeId
* classifications.classificationTypeId
* notes.instanceNoteTypeId

**In mod-inventory only instanceNoteTypeId is limited by UUID constraint.**