### PR TITLE
MODINVSTOR-346 - Cover Instance schema with unit tests

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -155,3 +155,12 @@ If these methods don't work for you, please do get in touch, so this section can
 On Linux, `ifconfig docker0 | grep 'inet addr:'` should give output similar to `inet addr:192.168.X.X  Bcast:0.0.0.0  Mask:255.255.0.0`, , the first IP address is usually routable from within containers.
 
 On Mac OS X (using Docker Native), `ifconfig en0 | grep 'inet '` should give output similar to `inet 192.168.X.X netmask 0xffffff00 broadcast 192.168.X.X`, the first IP address is usually routable from within containers.
+
+# Instance schema
+The [instance schema](https://github.com/folio-org/mod-inventory/blob/master/ramls/instance.json) defined in this module
+is also used by mod-source-record-manager for data import flow. Therefore changing the instance schema only in this module is a critical changes.
+To avoid the failure of the data import flow when changing the schema, you should also update [the instance schema in mod-source-record-manager](https://github.com/folio-org/mod-source-record-manager/blob/master/ramls/instance.json).
+This module contains a test that serves as a notification of an instance schema change.
+The test covers the current state of the instance schema and fails if the schema has been changed.
+In this case, appropriate measures should be taken to update the instance schema in mod-source-record-manager before test fixing.
+To fix the test you should copy the changed instance schema and copy/add other related schemas to the 'schema' directory in test resources.

--- a/src/test/java/schema/InstanceSchemaTest.java
+++ b/src/test/java/schema/InstanceSchemaTest.java
@@ -1,0 +1,86 @@
+package schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+
+import static java.lang.String.format;
+
+public class InstanceSchemaTest {
+
+  private static final String EXPECTED_INSTANCE_SCHEMA_PATH = "ramls/instance.json";
+  private static final String ACTUAL_INSTANCE_SCHEMA_PATH = "schema/instance.json";
+  private static final String EXPECTED_SCHEMAS_PARENT_PATH = "ramls/";
+  private static final String ACTUAL_SCHEMAS_PARENT_PATH = "schema/";
+
+
+  /**
+   * This test is a kind of notification that the instance schema has been changed.
+   * Changing the instance schema breaks file processing workflow (data-import), to avoid file processing failure
+   * should update instance schema in mod-source-record-manager module.
+   * Please, update the instance schema in mod-source-record-manager repo
+   * by link https://github.com/folio-org/mod-source-record-manager/blob/master/ramls/instance.json.
+   * To fix this test one should update instance schema and update/add other related schemas to 'schema' directory in tests resources.
+   */
+  @Test
+  public void instanceSchemaIsNotChanged() throws IOException {
+    assertSchemasEquals(EXPECTED_INSTANCE_SCHEMA_PATH, ACTUAL_INSTANCE_SCHEMA_PATH);
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode instanceSchemaAsJson = mapper.readTree(new File(EXPECTED_INSTANCE_SCHEMA_PATH));
+    ArrayList<String> referencesList = new ArrayList<>();
+    getReferencesToExternalSchemas(instanceSchemaAsJson, referencesList);
+
+    for (String referenceToSchema : referencesList) {
+      String expectedSchemaPath = EXPECTED_SCHEMAS_PARENT_PATH + referenceToSchema;
+      String actualSchemaPath = ACTUAL_SCHEMAS_PARENT_PATH + referenceToSchema;
+      assertSchemasEquals(expectedSchemaPath, actualSchemaPath);
+    }
+  }
+
+  private void assertSchemasEquals(String expectedSchemaPath, String actualSchemaPath) throws IOException {
+    String expectedSchemaContent = FileUtils.readFileToString(new File(expectedSchemaPath));
+
+    URL expectedInstanceSchemaUrl = InstanceSchemaTest.class.getClassLoader().getResource(actualSchemaPath);
+    Assert.assertNotNull(format("Schema file '%s' not found in test resources", actualSchemaPath), expectedInstanceSchemaUrl);
+    String actualSchemaContent = FileUtils.readFileToString(new File(expectedInstanceSchemaUrl.getFile()));
+
+    JsonObject expectedSchemaAsJson = new JsonObject(expectedSchemaContent);
+    JsonObject actualSchemaAsJson = new JsonObject(actualSchemaContent);
+    Assert.assertEquals(expectedSchemaAsJson, actualSchemaAsJson);
+  }
+
+  private void getReferencesToExternalSchemas(JsonNode jsonNode, List<String> referencesList) throws IOException {
+    Iterator<Entry<String, JsonNode>> fieldsIterator = jsonNode.fields();
+
+    while (fieldsIterator.hasNext()) {
+      Entry<String, JsonNode> field = fieldsIterator.next();
+      if (field.getKey().equals("$ref")) {
+        referencesList.add(field.getValue().asText());
+        JsonNode jsonNodeByReference = getJsonNodeByReference(EXPECTED_SCHEMAS_PARENT_PATH + field.getValue().asText());
+        getReferencesToExternalSchemas(jsonNodeByReference, referencesList);
+      } else {
+        JsonNode fieldValue = field.getValue();
+        if (fieldValue.isObject()) {
+          getReferencesToExternalSchemas(fieldValue, referencesList);
+        }
+      }
+    }
+  }
+
+  private JsonNode getJsonNodeByReference(String reference) throws IOException {
+    return new ObjectMapper().readTree(new File(reference));
+  }
+
+}

--- a/src/test/resources/schema/instance.json
+++ b/src/test/resources/schema/instance.json
@@ -1,0 +1,409 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "An instance record",
+  "type": "object",
+  "properties": {
+    "@context": {
+      "description": "Instance context",
+      "type": "string"
+    },
+    "id": {
+      "type": "string",
+      "description": "The system assigned unique ID of the instance record"
+    },
+    "hrid": {
+      "type": "string",
+      "description": "The human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"
+    },
+    "source": {
+      "type": "string",
+      "description": "The metadata source and its format of the underlying record to the instance record. (e.g. FOLIO if it's a record created in Inventory;  MARC if it's a MARC record created in MARCcat or EPKB if it's a record coming from eHoldings)"
+    },
+    "parentInstances": {
+      "description": "Array of parent instances",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Id of the parent instance",
+            "type": "string"
+          },
+          "superInstanceId": {
+            "description": "Id of the super instance",
+            "type": "string"
+          },
+          "instanceRelationshipTypeId": {
+            "description": "Id of the relationship type",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "superInstanceId",
+          "instanceRelationshipTypeId"
+        ]
+      }
+    },
+    "childInstances": {
+      "description": "Child instances",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "subInstanceId": {
+            "description": "Id of sub Instance",
+            "type": "string"
+          },
+          "instanceRelationshipTypeId": {
+            "description": "Id of the relationship type",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "subInstanceId",
+          "instanceRelationshipTypeId"
+        ]
+      }
+    },
+    "title": {
+      "type": "string",
+      "description": "The primary title (or label) associated with the resource"
+    },
+    "indexTitle": {
+      "type": "string",
+      "description": "Title normalized for browsing and searching; based on the title with articles removed"
+    },
+    "alternativeTitles": {
+      "type": "array",
+      "description": "List of alternative titles for the resource (e.g. original language version title of a movie)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "alternativeTitleTypeId": {
+            "type": "string",
+            "description": "ID for an alternative title qualifier"
+          },
+          "alternativeTitle": {
+            "type": "string",
+            "description": "An alternative title for the resource"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "editions": {
+      "type": "array",
+      "description": "The edition statement, imprint and other publication source information",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "series": {
+      "type": "array",
+      "description": "List of series titles associated with the resource (e.g. Harry Potter)",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "identifiers": {
+      "type": "array",
+      "description": "An extensible set of name-value pairs of identifiers associated with the resource",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "Resource identifier value"
+          },
+          "identifierTypeId": {
+            "type": "string",
+            "description": "Resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers)"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "value",
+          "identifierTypeId"
+        ]
+      }
+    },
+    "contributors": {
+      "type": "array",
+      "description": "List of contributors",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Personal name, corporate name, meeting name"
+          },
+          "contributorTypeId": {
+            "type": "string",
+            "description": "ID for the contributor type term defined as a referencetable in settings"
+          },
+          "contributorTypeText": {
+            "type": "string",
+            "description": "Free text element for adding contributor type terms other that defined by the MARC code list for relators"
+          },
+          "contributorNameTypeId": {
+            "type": "string",
+            "description": "Contributor type terms defined by the MARC code list for relators"
+          },
+          "primary": {
+            "type": "boolean",
+            "description": "Whether this is the primary contributor"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "contributorNameTypeId"
+        ]
+      }
+    },
+    "subjects": {
+      "type": "array",
+      "description": "List of subject headings",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "classifications": {
+      "type": "array",
+      "description": "List of classifications",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "properties": {
+          "classificationNumber": {
+            "type": "string",
+            "description": "Classification (e.g. classification scheme, classification schedule)"
+          },
+          "classificationTypeId": {
+            "type": "string",
+            "description": "List of classification schemas (e.g. LC, Canadian Classification, NLM, National Agricultural Library, UDC, and Dewey)"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "classificationNumber",
+          "classificationTypeId"
+        ]
+      }
+    },
+    "publication": {
+      "type": "array",
+      "description": "List of publication items",
+      "items": {
+        "type": "object",
+        "properties": {
+          "publisher": {
+            "type": "string",
+            "description": "Name of publisher, distributor, etc."
+          },
+          "place": {
+            "type": "string",
+            "description": "Place of publication, distribution, etc."
+          },
+          "dateOfPublication": {
+            "type": "string",
+            "description": "Date (year YYYY) of publication, distribution, etc."
+          },
+          "role": {
+            "type": "string",
+            "description": "The role of the publisher, distributor, etc."
+          }
+        }
+      }
+    },
+    "publicationFrequency": {
+      "type": "array",
+      "description": "List of intervals at which a serial appears (e.g. daily, weekly, monthly, quarterly, etc.)",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "publicationRange": {
+      "type": "array",
+      "description": "The range of sequential designation/chronology of publication, or date range",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "electronicAccess": {
+      "type": "array",
+      "description": "List of electronic access items",
+      "items": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "description": "Uniform Resource Identifier (URI) is a string of characters designed for unambiguous identification of resources"
+          },
+          "linkText": {
+            "type": "string",
+            "description": "The value of the MARC tag field 856 2nd indicator, where the values are: no information provided, resource, version of resource, related resource, no display constant generated"
+          },
+          "materialsSpecification": {
+            "type": "string",
+            "description": "Materials specified is used to specify to what portion or aspect of the resource the electronic location and access information applies (e.g. a portion or subset of the item is electronic, or a related electronic resource is being linked to the record)"
+          },
+          "publicNote": {
+            "type": "string",
+            "description": "URL public note to be displayed in the discovery"
+          },
+          "relationshipId": {
+            "type": "string",
+            "description": "Relationship between the electronic resource at the location identified and the item described in the record as a whole"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "uri"
+        ]
+      }
+    },
+    "instanceTypeId": {
+      "type": "string",
+      "description": "The unique term for the resource type whether it's from the RDA content term list of locally defined"
+    },
+    "instanceFormatIds": {
+      "type": "array",
+      "description": "The unique term for the format whether it's from the RDA carrier term list of locally defined",
+      "items": {
+        "type": "string"
+      }
+    },
+    "physicalDescriptions": {
+      "type": "array",
+      "description": "Physical description of the described resource, including its extent, dimensions, and such other physical details as a description of any accompanying materials and unit type and size",
+      "items": {
+        "type": "string"
+      }
+    },
+    "languages": {
+      "type": "array",
+      "description": "The set of languages used by the resource",
+      "minItems": 0,
+      "items": {
+        "type": "string"
+      }
+    },
+    "notes": {
+      "type": "array",
+      "description": "Bibliographic notes (e.g. general notes, specialized notes), and administrative notes",
+      "items": {
+        "type": "object",
+        "properties": {
+          "instanceNoteTypeId": {
+            "description": "ID of the type of note",
+            "$ref": "uuid.json"
+          },
+          "note": {
+            "type": "string",
+            "description": "Text content of the note"
+          },
+          "staffOnly": {
+            "type": "boolean",
+            "description": "If true, determines that the note should not be visible for others than staff",
+            "default": false
+          }
+        }
+      }
+    },
+    "modeOfIssuanceId": {
+      "type": "string",
+      "description": "RDA mode of issuance is a categorization reflecting whether a resource is issued in one or more parts, the way it is updated, and whether its termination is predetermined or not (e.g. monograph,  sequential monograph, serial; integrating Resource, other)"
+    },
+    "catalogedDate": {
+      "type": "string",
+      "description": "Date or timestamp on an instance for when is was considered cataloged"
+    },
+    "previouslyHeld": {
+      "type": "boolean",
+      "description": "Records the fact that the resource was previously held by the library for things like Hathi access, etc."
+    },
+    "staffSuppress": {
+      "type": "boolean",
+      "description": "Records the fact that the record should not be displayed for others than catalogers"
+    },
+    "discoverySuppress": {
+      "type": "boolean",
+      "description": "Records the fact that the record should not be displayed in a discovery system"
+    },
+    "statisticalCodeIds": {
+      "type": "array",
+      "description": "List of statistical code IDs",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sourceRecordFormat": {
+      "description": "Format of the instance source record, if a source record exists",
+      "type": "string",
+      "enum": ["MARC-JSON"],
+      "readonly": true
+    },
+    "statusId": {
+      "type": "string",
+      "description": "Instance status term (e.g. cataloged, uncatalogued, batch loaded, temporary, other, not yet assigned)"
+    },
+    "statusUpdatedDate": {
+      "type": "string",
+      "description": "Date [or timestamp] for when the instance status was updated"
+    },
+    "tags": {
+      "description": "arbitrary tags associated with this instance",
+      "id": "tags",
+      "type": "object",
+      "$ref": "raml-util/schemas/tags.schema"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
+    },
+    "links": {
+        "description": "Links",
+        "type": "object",
+        "properties": {
+          "self": {
+            "description": "self",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "self"
+        ]
+    },
+    "natureOfContentTermIds": {
+      "type": "array",
+      "description": "Array of UUID for the Instance nature of content (e.g. bibliography, biography, exhibition catalogue, festschrift, newspaper, proceedings, research report, thesis or website)",
+      "items": {
+        "type": "string",
+        "description": "Single UUID for the Instance nature of content",
+        "$ref": "uuid.json"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "source",
+    "title",
+    "instanceTypeId"
+  ]
+}

--- a/src/test/resources/schema/raml-util/schemas/metadata.schema
+++ b/src/test/resources/schema/raml-util/schemas/metadata.schema
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Metadata Schema",
+  "type": "object",
+  "properties": {
+    "createdDate": {
+      "description": "Date and time when the record was created",
+      "type": "string",
+      "format": "date-time"
+    },
+    "createdByUserId": {
+      "description": "ID of the user who created the record",
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "createdByUsername": {
+      "description": "Username of the user who created the record (when available)",
+      "type": "string"
+    },
+    "updatedDate": {
+      "description": "Date and time when the record was last updated",
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedByUserId": {
+      "description": "ID of the user who last updated the record",
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "updatedByUsername": {
+      "description": "Username of the user who last updated the record (when available)",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "createdDate",
+    "createdByUserId"
+  ]
+}

--- a/src/test/resources/schema/raml-util/schemas/tags.schema
+++ b/src/test/resources/schema/raml-util/schemas/tags.schema
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "tags",
+  "description": "List of simple tags that can be added to an object",
+  "type": "object",
+    "properties": {
+      "tagList": {
+        "type": "array",
+        "items": {
+          "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/test/resources/schema/uuid.json
+++ b/src/test/resources/schema/uuid.json
@@ -1,0 +1,6 @@
+{
+  "description": "UUID",
+  "type": "string",
+  "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+}
+


### PR DESCRIPTION
mod-source-record-manager uses copy of the Instance schema.
Because of change of Instance schema often breaks file processing workflow (data-import), We wrote a test in order to cover the current state of it. This test notifies that the instance schema has been changed and the instance schema also should be updated in the [mod-source-record-manager](https://github.com/folio-org/mod-source-record-manager/blob/master/ramls/instance.json).