### PR TITLE
Pass X-Okapi-Request-Id MODINV-156

### DIFF
--- a/src/main/java/org/folio/inventory/common/Context.java
+++ b/src/main/java/org/folio/inventory/common/Context.java
@@ -5,8 +5,4 @@ public interface Context {
   String getToken();
   String getOkapiLocation();
   String getUserId();
-  String getRequestId();
-  String getHeader(String header);
-  String getHeader(String header, String defaultValue);
-  boolean hasHeader(String header);
 }

--- a/src/main/java/org/folio/inventory/common/Context.java
+++ b/src/main/java/org/folio/inventory/common/Context.java
@@ -5,6 +5,7 @@ public interface Context {
   String getToken();
   String getOkapiLocation();
   String getUserId();
+  String getRequestId();
   String getHeader(String header);
   String getHeader(String header, String defaultValue);
   boolean hasHeader(String header);

--- a/src/main/java/org/folio/inventory/common/MessagingContext.java
+++ b/src/main/java/org/folio/inventory/common/MessagingContext.java
@@ -3,6 +3,12 @@ package org.folio.inventory.common;
 import io.vertx.core.MultiMap;
 
 public class MessagingContext implements Context {
+
+  public final static String TENANT_ID = "tenantId";
+  public final static String TOKEN = "token";
+  public final static String OKAPI_LOCATION = "okapiLocation";
+  public final static String JOB_ID = "jobId";
+
   private final MultiMap headers;
 
   public MessagingContext(final MultiMap headers) {
@@ -11,17 +17,17 @@ public class MessagingContext implements Context {
 
   @Override
   public String getTenantId() {
-    return getHeader("tenantId");
+    return getHeader(TENANT_ID);
   }
 
   @Override
   public String getToken() {
-    return getHeader("token");
+    return getHeader(TOKEN);
   }
 
   @Override
   public String getOkapiLocation() {
-    return getHeader("okapiLocation");
+    return getHeader(OKAPI_LOCATION);
   }
 
   @Override
@@ -50,6 +56,6 @@ public class MessagingContext implements Context {
   }
 
   public String getJobId() {
-    return getHeader("jobId");
+    return getHeader(JOB_ID);
   }
 }

--- a/src/main/java/org/folio/inventory/common/MessagingContext.java
+++ b/src/main/java/org/folio/inventory/common/MessagingContext.java
@@ -35,24 +35,8 @@ public class MessagingContext implements Context {
     return null;
   }
 
-  @Override
-  public String getRequestId() {
-    return null;
-  }
-
-  @Override
-  public String getHeader(String header) {
+  private String getHeader(String header) {
     return headers.get(header);
-  }
-
-  @Override
-  public String getHeader(String header, String defaultValue) {
-    return hasHeader(header) ? getHeader(header) : defaultValue;
-  }
-
-  @Override
-  public boolean hasHeader(String header) {
-    return headers.contains(header);
   }
 
   public String getJobId() {

--- a/src/main/java/org/folio/inventory/common/MessagingContext.java
+++ b/src/main/java/org/folio/inventory/common/MessagingContext.java
@@ -30,6 +30,11 @@ public class MessagingContext implements Context {
   }
 
   @Override
+  public String getRequestId() {
+    return null;
+  }
+
+  @Override
   public String getHeader(String header) {
     return headers.get(header);
   }

--- a/src/main/java/org/folio/inventory/common/MessagingContext.java
+++ b/src/main/java/org/folio/inventory/common/MessagingContext.java
@@ -4,10 +4,10 @@ import io.vertx.core.MultiMap;
 
 public class MessagingContext implements Context {
 
-  public final static String TENANT_ID = "tenantId";
-  public final static String TOKEN = "token";
-  public final static String OKAPI_LOCATION = "okapiLocation";
-  public final static String JOB_ID = "jobId";
+  public static final String TENANT_ID = "tenantId";
+  public static final String TOKEN = "token";
+  public static final String OKAPI_LOCATION = "okapiLocation";
+  public static final String JOB_ID = "jobId";
 
   private final MultiMap headers;
 

--- a/src/main/java/org/folio/inventory/common/WebContext.java
+++ b/src/main/java/org/folio/inventory/common/WebContext.java
@@ -11,6 +11,7 @@ public class WebContext implements Context {
   private static final String OKAPI_TOKEN_HEADER = "X-Okapi-Token";
   private static final String OKAPI_URL_HEADER = "X-Okapi-Url";
   private static final String OKAPI_USER_ID_HEADER = "X-Okapi-User-Id";
+  private static final String OKAPI_REQUEST_ID = "X-Okapi-Request-Id";
 
   public WebContext(RoutingContext routingContext) {
     this.routingContext = routingContext;
@@ -34,6 +35,11 @@ public class WebContext implements Context {
   @Override
   public String getUserId() {
     return getHeader(OKAPI_USER_ID_HEADER, "");
+  }
+
+  @Override
+  public String getRequestId() {
+    return getHeader(OKAPI_REQUEST_ID);
   }
 
   @Override

--- a/src/main/java/org/folio/inventory/common/WebContext.java
+++ b/src/main/java/org/folio/inventory/common/WebContext.java
@@ -37,23 +37,19 @@ public class WebContext implements Context {
     return getHeader(OKAPI_USER_ID_HEADER, "");
   }
 
-  @Override
   public String getRequestId() {
     return getHeader(OKAPI_REQUEST_ID);
   }
 
-  @Override
-  public String getHeader(String header) {
+  private String getHeader(String header) {
     return routingContext.request().getHeader(header);
   }
 
-  @Override
-  public String getHeader(String header, String defaultValue) {
+  private String getHeader(String header, String defaultValue) {
     return hasHeader(header) ? getHeader(header) : defaultValue;
   }
 
-  @Override
-  public boolean hasHeader(String header) {
+  private boolean hasHeader(String header) {
     return routingContext.request().headers().contains(header);
   }
 

--- a/src/main/java/org/folio/inventory/domain/ingest/IngestMessages.java
+++ b/src/main/java/org/folio/inventory/domain/ingest/IngestMessages.java
@@ -4,6 +4,7 @@ import io.vertx.core.json.JsonObject;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.messaging.JsonMessage;
 import org.folio.inventory.domain.Messages;
+import org.folio.inventory.common.MessagingContext;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -39,10 +40,10 @@ public class IngestMessages {
 
   private static Map<String, String> headers(String jobId, Context context) {
     LinkedHashMap<String, String> map = new LinkedHashMap<>(4);
-    map.put("jobId", jobId);
-    map.put("tenantId", context.getTenantId());
-    map.put("token", context.getToken());
-    map.put("okapiLocation", context.getOkapiLocation());
+    map.put(MessagingContext.JOB_ID, jobId);
+    map.put(MessagingContext.TENANT_ID, context.getTenantId());
+    map.put(MessagingContext.TOKEN, context.getToken());
+    map.put(MessagingContext.OKAPI_LOCATION, context.getOkapiLocation());
     return map;
   }
 }

--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -408,7 +408,7 @@ public abstract class AbstractInstances {
 
     return new OkapiHttpClient(client,
       new URL(context.getOkapiLocation()), context.getTenantId(),
-      context.getToken(), context.getUserId(),
+      context.getToken(), context.getUserId(), context.getRequestId(),
       exception -> {
         ServerErrorResponse.internalError(routingContext.response(), format("Failed to contact storage module: %s",
           exception.toString()));

--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -406,9 +406,7 @@ public abstract class AbstractInstances {
     WebContext context)
     throws MalformedURLException {
 
-    return new OkapiHttpClient(client,
-      new URL(context.getOkapiLocation()), context.getTenantId(),
-      context.getToken(), context.getUserId(), context.getRequestId(),
+    return new OkapiHttpClient(client, context,
       exception -> {
         ServerErrorResponse.internalError(routingContext.response(), format("Failed to contact storage module: %s",
           exception.toString()));

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -531,7 +531,7 @@ public class Items {
 
     return new OkapiHttpClient(client,
       new URL(context.getOkapiLocation()), context.getTenantId(),
-      context.getToken(), context.getUserId(),
+      context.getToken(), context.getUserId(), context.getRequestId(),
       exception -> ServerErrorResponse.internalError(routingContext.response(),
       String.format("Failed to contact storage module: %s",
         exception.toString())));

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -529,9 +529,7 @@ public class Items {
     WebContext context)
     throws MalformedURLException {
 
-    return new OkapiHttpClient(client,
-      new URL(context.getOkapiLocation()), context.getTenantId(),
-      context.getToken(), context.getUserId(), context.getRequestId(),
+    return new OkapiHttpClient(client, context,
       exception -> ServerErrorResponse.internalError(routingContext.response(),
       String.format("Failed to contact storage module: %s",
         exception.toString())));

--- a/src/main/java/org/folio/inventory/resources/ingest/ModsIngestion.java
+++ b/src/main/java/org/folio/inventory/resources/ingest/ModsIngestion.java
@@ -238,9 +238,7 @@ public class ModsIngestion {
 
     throws MalformedURLException {
 
-    return new OkapiHttpClient(client,
-      new URL(context.getOkapiLocation()), context.getTenantId(),
-      context.getToken(), context.getUserId(), context.getRequestId(),
+    return new OkapiHttpClient(client, context,
       exception -> ServerErrorResponse.internalError(routingContext.response(),
         String.format("Failed to contact storage module: %s",
           exception.toString())));

--- a/src/main/java/org/folio/inventory/resources/ingest/ModsIngestion.java
+++ b/src/main/java/org/folio/inventory/resources/ingest/ModsIngestion.java
@@ -240,7 +240,7 @@ public class ModsIngestion {
 
     return new OkapiHttpClient(client,
       new URL(context.getOkapiLocation()), context.getTenantId(),
-      context.getToken(), context.getUserId(),
+      context.getToken(), context.getUserId(), context.getRequestId(),
       exception -> ServerErrorResponse.internalError(routingContext.response(),
         String.format("Failed to contact storage module: %s",
           exception.toString())));

--- a/src/main/java/org/folio/inventory/support/http/client/OkapiHttpClient.java
+++ b/src/main/java/org/folio/inventory/support/http/client/OkapiHttpClient.java
@@ -23,12 +23,14 @@ public class OkapiHttpClient {
   private static final String TOKEN_HEADER = "X-Okapi-Token";
   private static final String OKAPI_URL_HEADER = "X-Okapi-Url";
   private static final String OKAPI_USER_ID_HEADER = "X-Okapi-User-Id";
+  private static final String OKAPI_REQUEST_ID = "X-Okapi-Request-Id";
 
   private final HttpClient client;
   private final URL okapiUrl;
   private final String tenantId;
   private final String token;
   private final String userId;
+  private final String requestId;
   private final Consumer<Throwable> exceptionHandler;
 
   public OkapiHttpClient(HttpClient httpClient,
@@ -36,6 +38,7 @@ public class OkapiHttpClient {
                          String tenantId,
                          String token,
                          String userId,
+                         String requestId,
                          Consumer<Throwable> exceptionHandler) {
 
     this.client = httpClient;
@@ -43,6 +46,7 @@ public class OkapiHttpClient {
     this.tenantId = tenantId;
     this.userId = userId;
     this.token = token;
+    this.requestId = requestId;
     this.exceptionHandler = exceptionHandler;
   }
 
@@ -148,6 +152,10 @@ public class OkapiHttpClient {
 
     if(StringUtils.isNotBlank(this.token)) {
       request.headers().add(TOKEN_HEADER, this.token);
+    }
+
+    if (this.requestId != null) {
+      request.headers().add(OKAPI_REQUEST_ID, this.requestId);
     }
 
     request.headers().add(OKAPI_URL_HEADER, okapiUrl.toString());

--- a/src/main/java/org/folio/inventory/support/http/client/OkapiHttpClient.java
+++ b/src/main/java/org/folio/inventory/support/http/client/OkapiHttpClient.java
@@ -9,6 +9,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
+import org.folio.inventory.common.WebContext;
 import org.folio.inventory.support.http.ContentType;
 
 import java.lang.invoke.MethodHandles;
@@ -34,12 +35,21 @@ public class OkapiHttpClient {
   private final Consumer<Throwable> exceptionHandler;
 
   public OkapiHttpClient(HttpClient httpClient,
-                         URL okapiUrl,
-                         String tenantId,
-                         String token,
-                         String userId,
-                         String requestId,
-                         Consumer<Throwable> exceptionHandler) {
+    WebContext context, Consumer<Throwable> exceptionHandler)
+    throws MalformedURLException {
+
+    this(httpClient, new URL(context.getOkapiLocation()),
+      context.getTenantId(), context.getToken(), context.getUserId(),
+      context.getRequestId(), exceptionHandler);
+  }
+
+  public OkapiHttpClient(HttpClient httpClient,
+    URL okapiUrl,
+    String tenantId,
+    String token,
+    String userId,
+    String requestId,
+    Consumer<Throwable> exceptionHandler) {
 
     this.client = httpClient;
     this.okapiUrl = okapiUrl;

--- a/src/main/java/org/folio/inventory/support/http/client/OkapiHttpClient.java
+++ b/src/main/java/org/folio/inventory/support/http/client/OkapiHttpClient.java
@@ -43,6 +43,16 @@ public class OkapiHttpClient {
       context.getRequestId(), exceptionHandler);
   }
 
+  /** HTTP client that calls via Okapi
+   *
+   * @param httpClient as returned from vertx createHttpClient
+   * @param okapiUrl OkapiUrl string (must not be null)
+   * @param tenantId Okapi tenantId - ignored if blank/empty
+   * @param token - Okapi token - ignored if blank/empty
+   * @param userId - Folio User ID - ignored if blank/empty
+   * @param requestId - Okapi Request ID - ignored if null
+   * @param exceptionHandler - exceptionHandler (for POST only, not PUT??)
+   */
   public OkapiHttpClient(HttpClient httpClient,
     URL okapiUrl,
     String tenantId,

--- a/src/main/java/org/folio/inventory/support/http/client/OkapiHttpClient.java
+++ b/src/main/java/org/folio/inventory/support/http/client/OkapiHttpClient.java
@@ -46,7 +46,7 @@ public class OkapiHttpClient {
   /** HTTP client that calls via Okapi
    *
    * @param httpClient as returned from vertx createHttpClient
-   * @param okapiUrl OkapiUrl string (must not be null)
+   * @param okapiUrl Okapi URL (java.net.URL)
    * @param tenantId Okapi tenantId - ignored if blank/empty
    * @param token - Okapi token - ignored if blank/empty
    * @param userId - Folio User ID - ignored if blank/empty

--- a/src/test/java/api/ApiTestSuite.java
+++ b/src/test/java/api/ApiTestSuite.java
@@ -185,7 +185,7 @@ public class ApiTestSuite {
 
     return new OkapiHttpClient(
       vertxAssistant.createUsingVertx(Vertx::createHttpClient),
-      new URL(storageOkapiUrl()), TENANT_ID, TOKEN, USER_ID, it ->
+      new URL(storageOkapiUrl()), TENANT_ID, TOKEN, USER_ID, null, it ->
       System.out.println(
         String.format("Request failed: %s",
           it.toString())));

--- a/src/test/java/org/folio/inventory/storage/external/ExternalStorageSuite.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalStorageSuite.java
@@ -87,7 +87,7 @@ public class ExternalStorageSuite {
 
     return new OkapiHttpClient(
       vertxAssistant.createUsingVertx(Vertx::createHttpClient),
-      new URL(getStorageAddress()), TENANT_ID, TENANT_TOKEN, USER_ID, it ->
+      new URL(getStorageAddress()), TENANT_ID, TENANT_TOKEN, USER_ID, "1234", it ->
       System.out.println(
         String.format("Request failed: %s",
           it.toString())));


### PR DESCRIPTION
I can't believe how many classes I had to touch for this. There should
be an "OkapiClient" that just takes context from outer request
and relay headers as necessary.. Now the Okapi headers definitions
are duplicated.