### PR TITLE
MODINV-162, MODINV-160: Handle HRID for instance and item.

### DIFF
--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -1,12 +1,21 @@
 package org.folio.inventory.resources;
 
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.BodyHandler;
+import static io.netty.util.internal.StringUtil.COMMA;
+import static java.lang.String.format;
+import static org.folio.inventory.support.http.server.SuccessResponse.noContent;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.HttpStatus;
@@ -31,21 +40,13 @@ import org.folio.inventory.support.http.server.ServerErrorResponse;
 import org.folio.rest.client.SourceStorageClient;
 import org.folio.rest.jaxrs.model.SuppressFromDiscoveryDto;
 
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import static io.netty.util.internal.StringUtil.COMMA;
-import static java.lang.String.format;
-import static org.folio.inventory.support.http.server.SuccessResponse.noContent;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
 
 public class Instances extends AbstractInstances {
   private static final String INSTANCES_CONTEXT_PATH = INSTANCES_PATH + "/context";
@@ -171,6 +172,14 @@ public class Instances extends AbstractInstances {
             String errorMessage = BLOCKED_FIELDS_UPDATE_ERROR_MESSAGE + StringUtils.join(config.getInstanceBlockedFields(), COMMA);
             log.error(errorMessage);
             JsonResponse.unprocessableEntity(rContext.response(), errorMessage);
+          } else if (!Objects.equals(existingInstance.getHrid(), updatedInstance.getHrid())) {
+            log.warn("The HRID property can not be updated, old value is '{}' but new is '{}'",
+              existingInstance.getHrid(), updatedInstance.getHrid()
+            );
+
+            JsonResponse.unprocessableEntity(rContext.response(),
+              "HRID can not be updated", "hrid", updatedInstance.getHrid()
+            );
           } else {
             updateInstance(updatedInstance, rContext, wContext);
           }

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -173,6 +173,17 @@ public class Items {
     itemCollection.findById(routingContext.request().getParam("id"), getItemResult -> {
       Item oldItem = getItemResult.getResult();
       if (oldItem != null) {
+        if (!Objects.equals(newItem.getHrid(), oldItem.getHrid())) {
+          log.warn("The HRID property can not be updated, old value is '{}' but new is '{}'",
+            oldItem.getHrid(), newItem.getHrid()
+          );
+
+          JsonResponse.unprocessableEntity(routingContext.response(),
+            "HRID can not be updated", "hrid", newItem.getHrid()
+          );
+          return;
+        }
+
         if (hasSameBarcode(newItem, oldItem)) {
           findUserAndUpdateItem(routingContext, newItem, oldItem, userCollection, itemCollection);
         } else {

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -68,7 +68,7 @@ public class InstancesApiExamples extends ApiTests {
   }
 
   @Test
-  public void canCreateAnInstance()
+  public void canCreateInstanceWithoutAnIDAndHRID()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -156,7 +156,7 @@ public class InstancesApiExamples extends ApiTests {
   }
 
   @Test
-  public void canCreateAnInstanceWithAnIDAndHrid()
+  public void canCreateAnInstanceWithAnIDAndHRID()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -833,7 +833,7 @@ public class InstancesApiExamples extends ApiTests {
   }
 
   @Test
-  public void cannotUpdateHrid() throws Exception {
+  public void cannotChangeHRID() throws Exception {
     UUID instanceId = UUID.randomUUID();
     JsonObject createdInstance = createInstance(smallAngryPlanet(instanceId));
 

--- a/src/test/java/api/items/ItemApiExamples.java
+++ b/src/test/java/api/items/ItemApiExamples.java
@@ -79,7 +79,7 @@ public class ItemApiExamples extends ApiTests {
   }
 
   @Test
-  public void canCreateAnItemWithoutIdAndHRID()
+  public void canCreateAnItemWithoutIDAndHRID()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,

--- a/src/test/java/api/items/ItemApiExamples.java
+++ b/src/test/java/api/items/ItemApiExamples.java
@@ -79,7 +79,7 @@ public class ItemApiExamples extends ApiTests {
   }
 
   @Test
-  public void canCreateAnItem()
+  public void canCreateAnItemWithoutIdAndHRID()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -149,7 +149,7 @@ public class ItemApiExamples extends ApiTests {
   }
 
   @Test
-  public void canCreateItemWithAnIDAndHrid()
+  public void canCreateItemWithAnIDAndHRID()
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
@@ -1318,7 +1318,7 @@ public class ItemApiExamples extends ApiTests {
   }
 
   @Test
-  public void cannotUpdateHrid() throws Exception {
+  public void cannotChangeHRID() throws Exception {
     JsonObject createdInstance = createInstance(smallAngryPlanet(UUID.randomUUID()));
 
     UUID holdingId = holdingsStorageClient.create(

--- a/src/test/java/api/support/builders/ItemRequestBuilder.java
+++ b/src/test/java/api/support/builders/ItemRequestBuilder.java
@@ -3,8 +3,6 @@ package api.support.builders;
 import java.util.Collections;
 import java.util.UUID;
 
-import org.folio.inventory.domain.items.CirculationNote;
-
 import api.ApiTestSuite;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -30,12 +28,14 @@ public class ItemRequestBuilder implements Builder {
   private final String itemLevelCallNumber;
   private final String itemLevelCallNumberPrefix;
   private final String itemLevelCallNumberSuffix;
+  private final String hrid;
 
   public ItemRequestBuilder() {
     this(UUID.randomUUID(), null, null, null, "645398607547",
       AVAILABLE_STATUS, bookMaterialType(), null, null, null,
       canCirculateLoanType(), null, null, null,
-      null, null, null
+      null, null, null,
+      null
     );
   }
 
@@ -56,7 +56,8 @@ public class ItemRequestBuilder implements Builder {
     JsonObject tags,
     String itemLevelCallNumber,
     String itemLevelCallNumberPrefix,
-    String itemLevelCallNumberSuffix) {
+    String itemLevelCallNumberSuffix,
+    String hrid) {
 
     this.id = id;
     this.holdingId = holdingId;
@@ -75,6 +76,7 @@ public class ItemRequestBuilder implements Builder {
     this.itemLevelCallNumber = itemLevelCallNumber;
     this.itemLevelCallNumberPrefix = itemLevelCallNumberPrefix;
     this.itemLevelCallNumberSuffix = itemLevelCallNumberSuffix;
+    this.hrid = hrid;
   }
 
   public JsonObject create() {
@@ -108,6 +110,7 @@ public class ItemRequestBuilder implements Builder {
     includeWhenPresent(itemRequest, "itemLevelCallNumber", itemLevelCallNumber);
     includeWhenPresent(itemRequest, "itemLevelCallNumberSuffix", itemLevelCallNumberSuffix);
     includeWhenPresent(itemRequest, "itemLevelCallNumberPrefix", itemLevelCallNumberPrefix);
+    includeWhenPresent(itemRequest, "hrid", hrid);
 
     return itemRequest;
   }
@@ -130,7 +133,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder forHolding(UUID holdingId) {
@@ -151,7 +155,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder withReadOnlyTitle(String title) {
@@ -172,7 +177,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder withReadOnlyCallNumber(String callNumber) {
@@ -193,7 +199,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder withBarcode(String barcode) {
@@ -214,7 +221,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder withNoBarcode() {
@@ -239,7 +247,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   private ItemRequestBuilder withMaterialType(JsonObject materialType) {
@@ -260,7 +269,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder book() {
@@ -293,7 +303,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   private ItemRequestBuilder withTemporaryLocation(JsonObject location) {
@@ -314,7 +325,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
     private ItemRequestBuilder withPermanentLocation(JsonObject location) {
@@ -335,7 +347,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder permanentlyInThirdFloor() {
@@ -372,7 +385,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder canCirculate() {
@@ -405,7 +419,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder withTagList(JsonObject tags) {
@@ -426,7 +441,8 @@ public class ItemRequestBuilder implements Builder {
       tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder temporarilyCourseReserves() {
@@ -462,7 +478,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   private static JsonObject bookMaterialType() {
@@ -559,7 +576,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder withItemLevelCallNumberSuffix(String itemLevelCallNumberSuffix) {
@@ -580,7 +598,8 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
-      itemLevelCallNumberSuffix);
+      itemLevelCallNumberSuffix,
+      this.hrid);
   }
 
   public ItemRequestBuilder withItemLevelCallNumberPrefix(String itemLevelCallNumberPrefix) {
@@ -601,6 +620,29 @@ public class ItemRequestBuilder implements Builder {
       this.tags,
       this.itemLevelCallNumber,
       itemLevelCallNumberPrefix,
-      this.itemLevelCallNumberSuffix);
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
+  }
+
+  public ItemRequestBuilder withHrid(String hrid) {
+    return new ItemRequestBuilder(
+      this.id,
+      this.holdingId,
+      this.readOnlyTitle,
+      this.readOnlyCallNumber,
+      this.barcode,
+      this.status,
+      this.materialType,
+      this.readOnlyEffectiveLocation,
+      this.permanentLocation,
+      this.temporaryLocation,
+      this.permanentLoanType,
+      this.temporaryLoanType,
+      this.circulationNotes,
+      this.tags,
+      this.itemLevelCallNumber,
+      this.itemLevelCallNumberPrefix,
+      this.itemLevelCallNumberSuffix,
+      hrid);
   }
 }

--- a/src/test/java/support/fakes/FakeOkapi.java
+++ b/src/test/java/support/fakes/FakeOkapi.java
@@ -71,7 +71,9 @@ public class FakeOkapi extends AbstractVerticle {
       .withRootPath("/instance-storage/instances")
       .withCollectionPropertyName("instances")
       .withRequiredProperties("source", "title", "contributors", "instanceTypeId")
-      .create();
+      .withRecordPreProcessors(
+        StorageRecordPreProcessors.setHridProcessor("in")
+      ).create();
     fakeInstanceStorageModule.register(router);
     fakeInstanceStorageModule.registerBatch(router, "/instance-storage/batch/instances");
 
@@ -99,6 +101,7 @@ public class FakeOkapi extends AbstractVerticle {
       .withRequiredProperties("materialTypeId", "permanentLoanTypeId")
       .withDefault("status", new JsonObject().put("name", "Available"))
       .withRecordPreProcessors(
+        StorageRecordPreProcessors.setHridProcessor("it"),
         StorageRecordPreProcessors::setEffectiveLocationForItem,
         StorageRecordPreProcessors::setEffectiveCallNumberComponents
       )

--- a/src/test/java/support/matchers/ResponseMatchers.java
+++ b/src/test/java/support/matchers/ResponseMatchers.java
@@ -1,0 +1,58 @@
+package support.matchers;
+
+import java.util.Objects;
+
+import org.folio.inventory.support.http.client.Response;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ResponseMatchers {
+
+  public static Matcher<Response> hasValidationError(
+    String expectedMessage, String expectedKey, String expectedValue) {
+
+    return new TypeSafeMatcher<Response>() {
+      @Override
+      protected boolean matchesSafely(Response response) {
+        if (response.getStatusCode() != 422) {
+          return false;
+        }
+
+        try {
+          JsonArray errors = response.getJson().getJsonArray("errors");
+          if (errors != null && errors.size() == 1) {
+            JsonObject error = errors.getJsonObject(0);
+            JsonArray parameters = error.getJsonArray("parameters");
+
+            if (parameters != null && parameters.size() == 1) {
+              String message = error.getString("message");
+              String key = parameters.getJsonObject(0).getString("key");
+              String value = parameters.getJsonObject(0).getString("value");
+
+              return Objects.equals(expectedMessage, message)
+                && Objects.equals(expectedKey, key)
+                && Objects.equals(expectedValue, value);
+            }
+          }
+
+          return false;
+        } catch (DecodeException ex) {
+          return false;
+        }
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description
+          .appendText("Response has 422 status and 'message' - ").appendValue(expectedMessage)
+          .appendText(", 'key' - ").appendValue(expectedKey)
+          .appendText(" and 'value' - ").appendValue(expectedValue);
+      }
+    };
+  }
+}


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-160 - HRID handling in Inventory for Instance records.
https://issues.folio.org/browse/MODINV-162 - HRID handling in Inventory for Item records.

### Changes:
* Added Item/Instance fake pre-processors to generate a HRID if nothing has specified;
* Disallow changing of hrid for item and instance;
* Added unit tests.