### PR TITLE
MODINV-177: Forward call number type ID from item storage.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "9.6",
+      "version": "9.7",
       "handlers": [
         {
           "methods": ["GET"],
@@ -192,7 +192,7 @@
   "requires": [
     {
       "id": "item-storage",
-      "version": "7.8"
+      "version": "7.9"
     },
     {
       "id": "instance-storage",

--- a/ramls/inventory.raml
+++ b/ramls/inventory.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory API
-version: v9.6
+version: v9.7
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -93,6 +93,12 @@
           "type": "string",
           "description": "Effective Call Number Suffix is the suffix of the identifier assigned to an item or its holding and associated with the item.",
           "readonly": true
+        },
+        "typeId": {
+          "type": "string",
+          "description": "Effective Call Number Type Id is the call number type id assigned to the item or associated holding.",
+          "$ref": "uuid.json",
+          "readonly": true
         }
       }
     },

--- a/src/main/java/org/folio/inventory/domain/items/EffectiveCallNumberComponents.java
+++ b/src/main/java/org/folio/inventory/domain/items/EffectiveCallNumberComponents.java
@@ -6,11 +6,14 @@ public class EffectiveCallNumberComponents {
     private String callNumber;
     private String prefix;
     private String suffix;
+    private String typeId;
 
-    public EffectiveCallNumberComponents(String callNumber, String prefix, String suffix) {
+    public EffectiveCallNumberComponents(String callNumber, String prefix,
+                                         String suffix, String typeId) {
       this.callNumber = callNumber;
       this.prefix = prefix;
       this.suffix = suffix;
+      this.typeId = typeId;
     }
 
     public static EffectiveCallNumberComponents from(JsonObject representation) {
@@ -21,7 +24,8 @@ public class EffectiveCallNumberComponents {
       return new EffectiveCallNumberComponents(
         representation.getString("callNumber"),
         representation.getString("prefix"),
-        representation.getString("suffix"));
+        representation.getString("suffix"),
+        representation.getString("typeId"));
     }
 
     public JsonObject toJson() {
@@ -29,6 +33,7 @@ public class EffectiveCallNumberComponents {
       components.put("callNumber", callNumber);
       components.put("prefix", prefix);
       components.put("suffix", suffix);
+      components.put("typeId", typeId);
       return components;
     }
 }

--- a/src/test/java/api/items/ItemApiExamples.java
+++ b/src/test/java/api/items/ItemApiExamples.java
@@ -73,6 +73,7 @@ public class ItemApiExamples extends ApiTests {
   private static final String CALL_NUMBER = "callNumber";
   private static final String CALL_NUMBER_SUFFIX = "callNumberSuffix";
   private static final String CALL_NUMBER_PREFIX = "callNumberPrefix";
+  private static final String CALL_NUMBER_TYPE_ID = UUID.randomUUID().toString();
 
   public ItemApiExamples() throws MalformedURLException {
     super();
@@ -100,6 +101,7 @@ public class ItemApiExamples extends ApiTests {
       .withItemLevelCallNumber(CALL_NUMBER)
       .withItemLevelCallNumberSuffix(CALL_NUMBER_SUFFIX)
       .withItemLevelCallNumberPrefix(CALL_NUMBER_PREFIX)
+      .withItemLevelCallNumberTypeId(CALL_NUMBER_TYPE_ID)
       .withTagList(new JsonObject().put(Item.TAG_LIST_KEY, new JsonArray().add("test-tag")))
       .temporarilyCourseReserves());
 
@@ -597,6 +599,7 @@ public class ItemApiExamples extends ApiTests {
         .withCallNumber(CALL_NUMBER)
         .withCallNumberSuffix(CALL_NUMBER_SUFFIX)
         .withCallNumberPrefix(CALL_NUMBER_PREFIX)
+        .withCallNumberTypeId(CALL_NUMBER_TYPE_ID)
     ).getId();
 
     itemsClient.create(new ItemRequestBuilder()
@@ -619,6 +622,7 @@ public class ItemApiExamples extends ApiTests {
         .withCallNumber(CALL_NUMBER)
         .withCallNumberSuffix(CALL_NUMBER_SUFFIX)
         .withCallNumberPrefix(CALL_NUMBER_PREFIX)
+        .withCallNumberTypeId(CALL_NUMBER_TYPE_ID)
     ).getId();
 
     itemsClient.create(new ItemRequestBuilder()
@@ -636,6 +640,7 @@ public class ItemApiExamples extends ApiTests {
         .withCallNumber(CALL_NUMBER)
         .withCallNumberSuffix(CALL_NUMBER_SUFFIX)
         .withCallNumberPrefix(CALL_NUMBER_PREFIX)
+        .withCallNumberTypeId(CALL_NUMBER_TYPE_ID)
     ).getId();
 
     itemsClient.create(new ItemRequestBuilder()
@@ -1537,5 +1542,6 @@ public class ItemApiExamples extends ApiTests {
     assertThat(callNumberComponents.getString("callNumber"), is(CALL_NUMBER));
     assertThat(callNumberComponents.getString("suffix"), is(CALL_NUMBER_SUFFIX));
     assertThat(callNumberComponents.getString("prefix"), is(CALL_NUMBER_PREFIX));
+    assertThat(callNumberComponents.getString("typeId"), is(CALL_NUMBER_TYPE_ID));
   }
 }

--- a/src/test/java/api/support/builders/HoldingRequestBuilder.java
+++ b/src/test/java/api/support/builders/HoldingRequestBuilder.java
@@ -13,12 +13,14 @@ public class HoldingRequestBuilder implements Builder {
   private final String callNumber;
   private final String callNumberSuffix;
   private final String callNumberPrefix;
+  private final String callNumberTypeId;
 
   public HoldingRequestBuilder() {
     this(
       null,
       UUID.fromString(ApiTestSuite.getThirdFloorLocation()),
       UUID.fromString(ApiTestSuite.getReadingRoomLocation()),
+      null,
       null,
       null,
       null);
@@ -30,7 +32,8 @@ public class HoldingRequestBuilder implements Builder {
     UUID temporaryLocationId,
     String callNumber,
     String callNumberSuffix,
-    String callNumberPrefix) {
+    String callNumberPrefix,
+    String callNumberTypeId) {
 
     this.instanceId = instanceId;
     this.permanentLocationId = permanentLocationId;
@@ -38,6 +41,7 @@ public class HoldingRequestBuilder implements Builder {
     this.callNumber = callNumber;
     this.callNumberSuffix = callNumberSuffix;
     this.callNumberPrefix = callNumberPrefix;
+    this.callNumberTypeId = callNumberTypeId;
   }
 
   @Override
@@ -54,6 +58,7 @@ public class HoldingRequestBuilder implements Builder {
     holding.put("callNumber", callNumber);
     holding.put("callNumberPrefix", callNumberPrefix);
     holding.put("callNumberSuffix", callNumberSuffix);
+    holding.put("callNumberTypeId", callNumberTypeId);
 
     return holding;
   }
@@ -65,7 +70,8 @@ public class HoldingRequestBuilder implements Builder {
       this.temporaryLocationId,
       callNumber,
       this.callNumberSuffix,
-      this.callNumberPrefix);
+      this.callNumberPrefix,
+      this.callNumberTypeId);
   }
 
   private HoldingRequestBuilder withTemporaryLocation(UUID temporaryLocationId) {
@@ -75,7 +81,8 @@ public class HoldingRequestBuilder implements Builder {
       temporaryLocationId,
       this.callNumber,
       this.callNumberSuffix,
-      this.callNumberPrefix);
+      this.callNumberPrefix,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder permanentlyInMainLibrary() {
@@ -97,7 +104,8 @@ public class HoldingRequestBuilder implements Builder {
       this.temporaryLocationId,
       this.callNumber,
       this.callNumberSuffix,
-      this.callNumberPrefix);
+      this.callNumberPrefix,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder withCallNumber(String callNumber) {
@@ -107,7 +115,8 @@ public class HoldingRequestBuilder implements Builder {
       this.temporaryLocationId,
       callNumber,
       this.callNumberSuffix,
-      this.callNumberPrefix);
+      this.callNumberPrefix,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder withCallNumberSuffix(String suffix) {
@@ -117,7 +126,8 @@ public class HoldingRequestBuilder implements Builder {
       this.temporaryLocationId,
       this.callNumber,
       suffix,
-      this.callNumberPrefix);
+      this.callNumberPrefix,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder withCallNumberPrefix(String prefix) {
@@ -127,6 +137,18 @@ public class HoldingRequestBuilder implements Builder {
       this.temporaryLocationId,
       this.callNumber,
       this.callNumberSuffix,
-      prefix);
+      prefix,
+      this.callNumberTypeId);
+  }
+
+  public HoldingRequestBuilder withCallNumberTypeId(String callNumberTypeId) {
+    return new HoldingRequestBuilder(
+      this.instanceId,
+      this.permanentLocationId,
+      this.temporaryLocationId,
+      this.callNumber,
+      this.callNumberSuffix,
+      this.callNumberPrefix,
+      callNumberTypeId);
   }
 }

--- a/src/test/java/api/support/builders/ItemRequestBuilder.java
+++ b/src/test/java/api/support/builders/ItemRequestBuilder.java
@@ -28,6 +28,7 @@ public class ItemRequestBuilder implements Builder {
   private final String itemLevelCallNumber;
   private final String itemLevelCallNumberPrefix;
   private final String itemLevelCallNumberSuffix;
+  private final String itemLevelCallNumberTypeId;
   private final String hrid;
 
   public ItemRequestBuilder() {
@@ -35,7 +36,7 @@ public class ItemRequestBuilder implements Builder {
       AVAILABLE_STATUS, bookMaterialType(), null, null, null,
       canCirculateLoanType(), null, null, null,
       null, null, null,
-      null
+      null, null
     );
   }
 
@@ -57,6 +58,7 @@ public class ItemRequestBuilder implements Builder {
     String itemLevelCallNumber,
     String itemLevelCallNumberPrefix,
     String itemLevelCallNumberSuffix,
+    String itemLevelCallNumberTypeId,
     String hrid) {
 
     this.id = id;
@@ -76,6 +78,7 @@ public class ItemRequestBuilder implements Builder {
     this.itemLevelCallNumber = itemLevelCallNumber;
     this.itemLevelCallNumberPrefix = itemLevelCallNumberPrefix;
     this.itemLevelCallNumberSuffix = itemLevelCallNumberSuffix;
+    this.itemLevelCallNumberTypeId = itemLevelCallNumberTypeId;
     this.hrid = hrid;
   }
 
@@ -110,6 +113,7 @@ public class ItemRequestBuilder implements Builder {
     includeWhenPresent(itemRequest, "itemLevelCallNumber", itemLevelCallNumber);
     includeWhenPresent(itemRequest, "itemLevelCallNumberSuffix", itemLevelCallNumberSuffix);
     includeWhenPresent(itemRequest, "itemLevelCallNumberPrefix", itemLevelCallNumberPrefix);
+    includeWhenPresent(itemRequest, "itemLevelCallNumberTypeId", itemLevelCallNumberTypeId);
     includeWhenPresent(itemRequest, "hrid", hrid);
 
     return itemRequest;
@@ -134,6 +138,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -156,6 +161,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -178,6 +184,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -200,6 +207,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -222,6 +230,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -248,6 +257,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -270,6 +280,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -304,6 +315,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -326,6 +338,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -348,6 +361,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -386,6 +400,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -420,6 +435,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -442,6 +458,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -479,6 +496,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -577,6 +595,7 @@ public class ItemRequestBuilder implements Builder {
       itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -599,6 +618,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -621,6 +641,30 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
+      this.hrid);
+  }
+
+  public ItemRequestBuilder withItemLevelCallNumberTypeId(String itemLevelCallNumberTypeId) {
+    return new ItemRequestBuilder(
+      this.id,
+      this.holdingId,
+      this.readOnlyTitle,
+      this.readOnlyCallNumber,
+      this.barcode,
+      this.status,
+      this.materialType,
+      this.readOnlyEffectiveLocation,
+      this.permanentLocation,
+      this.temporaryLocation,
+      this.permanentLoanType,
+      this.temporaryLoanType,
+      this.circulationNotes,
+      this.tags,
+      this.itemLevelCallNumber,
+      this.itemLevelCallNumberPrefix,
+      this.itemLevelCallNumberSuffix,
+      itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -643,6 +687,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       hrid);
   }
 }

--- a/src/test/java/org/folio/inventory/storage/external/ExternalItemCollectionExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalItemCollectionExamples.java
@@ -351,7 +351,8 @@ public class ExternalItemCollectionExamples {
       // otherwise we will get timeout on retrieve holdings in preprocessor
       .withItemLevelCallNumber("123456")
       .withItemLevelCallNumberPrefix("prefix")
-      .withItemLevelCallNumberSuffix("suffix");
+      .withItemLevelCallNumberSuffix("suffix")
+      .withItemLevelCallNumberTypeId(UUID.randomUUID().toString());
   }
 
   private Item nod() {
@@ -362,7 +363,8 @@ public class ExternalItemCollectionExamples {
       .withTemporaryLocationId(annexLibraryLocationId)
       .withItemLevelCallNumber("123456")
       .withItemLevelCallNumberPrefix("prefix")
-      .withItemLevelCallNumberSuffix("suffix");
+      .withItemLevelCallNumberSuffix("suffix")
+      .withItemLevelCallNumberTypeId(UUID.randomUUID().toString());
   }
 
   private Item uprooted() {
@@ -373,7 +375,8 @@ public class ExternalItemCollectionExamples {
       .withTemporaryLocationId(annexLibraryLocationId)
       .withItemLevelCallNumber("123456")
       .withItemLevelCallNumberPrefix("prefix")
-      .withItemLevelCallNumberSuffix("suffix");
+      .withItemLevelCallNumberSuffix("suffix")
+      .withItemLevelCallNumberTypeId(UUID.randomUUID().toString());
   }
 
   private Item temeraire() {
@@ -385,7 +388,8 @@ public class ExternalItemCollectionExamples {
       .withTemporaryLocationId(annexLibraryLocationId)
       .withItemLevelCallNumber("123456")
       .withItemLevelCallNumberPrefix("prefix")
-      .withItemLevelCallNumberSuffix("suffix");
+      .withItemLevelCallNumberSuffix("suffix")
+      .withItemLevelCallNumberTypeId(UUID.randomUUID().toString());
   }
 
   private Item interestingTimes() {
@@ -396,7 +400,8 @@ public class ExternalItemCollectionExamples {
       .withTemporaryLocationId(annexLibraryLocationId)
       .withItemLevelCallNumber("123456")
       .withItemLevelCallNumberPrefix("prefix")
-      .withItemLevelCallNumberSuffix("suffix");
+      .withItemLevelCallNumberSuffix("suffix")
+      .withItemLevelCallNumberTypeId(UUID.randomUUID().toString());
   }
 
   private Item getItem(List<Item> allItems, String barcode) {

--- a/src/test/java/support/fakes/processors/StorageRecordPreProcessors.java
+++ b/src/test/java/support/fakes/processors/StorageRecordPreProcessors.java
@@ -27,7 +27,8 @@ public final class StorageRecordPreProcessors {
   private static final List<Triple<String, String, String>> CALL_NUMBER_PROPERTIES = Arrays.asList(
     new ImmutableTriple<>("callNumber", "itemLevelCallNumber", "callNumber"),
     new ImmutableTriple<>("callNumberPrefix", "itemLevelCallNumberPrefix", "prefix"),
-    new ImmutableTriple<>("callNumberSuffix", "itemLevelCallNumberSuffix", "suffix")
+    new ImmutableTriple<>("callNumberSuffix", "itemLevelCallNumberSuffix", "suffix"),
+    new ImmutableTriple<>("callNumberTypeId", "itemLevelCallNumberTypeId", "typeId")
   );
 
   private static final String HOLDINGS_RECORD_PROPERTY_NAME = "holdingsRecordId";


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-177: Forward effective call number typeId property.

* Forward the `effectiveCallNumberComponents.typeId` property from item;
* Update the inventory API version.

**Have to be merged after** https://github.com/folio-org/mod-inventory-storage/pull/372