### PR TITLE
MODINV-190: Most recent check in information clears when item record is edited.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "9.7",
+      "version": "9.8",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -421,7 +421,6 @@
       "type": "object",
       "additionalProperties": false,
       "description": "Information about when an item was last checked in",
-      "readonly": true,
       "properties": {
         "dateTime": {
           "type": "string",

--- a/src/main/java/org/folio/inventory/domain/items/Item.java
+++ b/src/main/java/org/folio/inventory/domain/items/Item.java
@@ -37,6 +37,7 @@ public class Item {
   public static final String NOTES_KEY = "notes";
   public static final String CIRCULATION_NOTES_KEY = "circulationNotes";
   public static final String PURCHASE_ORDER_LINE_IDENTIFIER = "purchaseOrderLineIdentifier";
+  public static final String LAST_CHECK_IN = "lastCheckIn";
 
   public final String id;
   private String hrid;

--- a/src/main/java/org/folio/inventory/domain/items/Item.java
+++ b/src/main/java/org/folio/inventory/domain/items/Item.java
@@ -459,6 +459,7 @@ public class Item {
             .withYearCaption(this.yearCaption)
             .withElectronicAccess(this.electronicAccess)
             .withStatisticalCodeIds(this.statisticalCodeIds)
+            .withLastCheckIn(this.lastCheckIn)
             .withPurchaseOrderLineidentifier(this.purchaseOrderLineidentifier);
   }
 

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -324,7 +324,7 @@ public class Items {
             .withElectronicAccess(electronicAccess)
             .withStatisticalCodeIds(statisticalCodeIds)
             .withPurchaseOrderLineidentifier(itemRequest.getString(Item.PURCHASE_ORDER_LINE_IDENTIFIER))
-            .withLastCheckIn(LastCheckIn.from(itemRequest.getJsonObject("lastCheckIn")))
+            .withLastCheckIn(LastCheckIn.from(itemRequest.getJsonObject(Item.LAST_CHECK_IN)))
             .withTags(tags);
   }
 

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -29,6 +29,7 @@ import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.domain.items.CirculationNote;
 import org.folio.inventory.domain.items.Item;
 import org.folio.inventory.domain.items.ItemCollection;
+import org.folio.inventory.domain.items.LastCheckIn;
 import org.folio.inventory.domain.items.Note;
 import org.folio.inventory.domain.items.Status;
 import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
@@ -323,6 +324,7 @@ public class Items {
             .withElectronicAccess(electronicAccess)
             .withStatisticalCodeIds(statisticalCodeIds)
             .withPurchaseOrderLineidentifier(itemRequest.getString(Item.PURCHASE_ORDER_LINE_IDENTIFIER))
+            .withLastCheckIn(LastCheckIn.from(itemRequest.getJsonObject("lastCheckIn")))
             .withTags(tags);
   }
 

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleItemCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleItemCollection.java
@@ -136,6 +136,10 @@ class ExternalStorageModuleItemCollection
       itemToSend.put("status", item.getStatus());
     }
 
+    if(item.getLastCheckIn() != null) {
+      itemToSend.put(Item.LAST_CHECK_IN, item.getLastCheckIn().toJson());
+    }
+
     includeIfPresent(itemToSend, Item.HRID_KEY, item.getHrid());
     itemToSend.put(Item.FORMER_IDS_KEY, item.getFormerIds());
     itemToSend.put(Item.DISCOVERY_SUPPRESS_KEY, item.getDiscoverySuppress());
@@ -170,7 +174,6 @@ class ExternalStorageModuleItemCollection
     itemToSend.put(Item.STATISTICAL_CODE_IDS_KEY, item.getStatisticalCodeIds());
     itemToSend.put(Item.PURCHASE_ORDER_LINE_IDENTIFIER, item.getPurchaseOrderLineidentifier());
     itemToSend.put(Item.TAGS_KEY, new JsonObject().put(Item.TAG_LIST_KEY, new JsonArray(item.getTags())));
-    itemToSend.put(Item.LAST_CHECK_IN, item.getLastCheckIn().toJson());
 
     return itemToSend;
   }

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleItemCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleItemCollection.java
@@ -170,6 +170,7 @@ class ExternalStorageModuleItemCollection
     itemToSend.put(Item.STATISTICAL_CODE_IDS_KEY, item.getStatisticalCodeIds());
     itemToSend.put(Item.PURCHASE_ORDER_LINE_IDENTIFIER, item.getPurchaseOrderLineidentifier());
     itemToSend.put(Item.TAGS_KEY, new JsonObject().put(Item.TAG_LIST_KEY, new JsonArray(item.getTags())));
+    itemToSend.put(Item.LAST_CHECK_IN, item.getLastCheckIn().toJson());
 
     return itemToSend;
   }

--- a/src/test/java/api/items/ItemApiExamples.java
+++ b/src/test/java/api/items/ItemApiExamples.java
@@ -458,9 +458,12 @@ public class ItemApiExamples extends ApiTests {
     assertThat(updatedItem.getString("title"), is("Long Way to a Small Angry Planet"));
     assertThat(updatedItem.getString("barcode"), is("645398607547"));
     assertThat(updatedItem.getJsonObject("status").getString("name"), is("Checked Out"));
-    assertThat(updatedItem.getJsonObject("lastCheckIn").getString("servicePointId"), is("7c5abc9f-f3d7-4856-b8d7-6712462ca007"));
-    assertThat(updatedItem.getJsonObject("lastCheckIn").getString("staffMemberId"), is("12115707-d7c8-54e7-8287-22e97f7250a4"));
-    assertThat(updatedItem.getJsonObject("lastCheckIn").getString("dateTime"), is("2020-01-02T13:02:46.000Z"));
+    assertThat(updatedItem.getJsonObject(Item.LAST_CHECK_IN).getString("servicePointId"),
+      is("7c5abc9f-f3d7-4856-b8d7-6712462ca007"));
+    assertThat(updatedItem.getJsonObject(Item.LAST_CHECK_IN).getString("staffMemberId"),
+      is("12115707-d7c8-54e7-8287-22e97f7250a4"));
+    assertThat(updatedItem.getJsonObject(Item.LAST_CHECK_IN).getString("dateTime"),
+      is("2020-01-02T13:02:46.000Z"));
 
     JsonObject materialType = updatedItem.getJsonObject("materialType");
 

--- a/src/test/java/api/items/ItemApiExamples.java
+++ b/src/test/java/api/items/ItemApiExamples.java
@@ -417,6 +417,12 @@ public class ItemApiExamples extends ApiTests {
 
     UUID itemId = UUID.randomUUID();
 
+    JsonObject lastCheckIn = new JsonObject()
+      .put("servicePointId", "7c5abc9f-f3d7-4856-b8d7-6712462ca007")
+      .put("staffMemberId", "12115707-d7c8-54e7-8287-22e97f7250a4")
+      .put("dateTime", "2020-01-02T13:02:46.000Z");
+
+
     JsonObject newItemRequest = new ItemRequestBuilder()
       .withId(itemId)
       .forHolding(holdingId)
@@ -424,6 +430,7 @@ public class ItemApiExamples extends ApiTests {
       .canCirculate()
       .temporarilyInReadingRoom()
       .withTagList(new JsonObject().put(Item.TAG_LIST_KEY, new JsonArray().add("test-tag")))
+      .withLastCheckIn(lastCheckIn)
       .create();
 
     newItemRequest = itemsClient.create(newItemRequest).getJson();
@@ -451,6 +458,9 @@ public class ItemApiExamples extends ApiTests {
     assertThat(updatedItem.getString("title"), is("Long Way to a Small Angry Planet"));
     assertThat(updatedItem.getString("barcode"), is("645398607547"));
     assertThat(updatedItem.getJsonObject("status").getString("name"), is("Checked Out"));
+    assertThat(updatedItem.getJsonObject("lastCheckIn").getString("servicePointId"), is("7c5abc9f-f3d7-4856-b8d7-6712462ca007"));
+    assertThat(updatedItem.getJsonObject("lastCheckIn").getString("staffMemberId"), is("12115707-d7c8-54e7-8287-22e97f7250a4"));
+    assertThat(updatedItem.getJsonObject("lastCheckIn").getString("dateTime"), is("2020-01-02T13:02:46.000Z"));
 
     JsonObject materialType = updatedItem.getJsonObject("materialType");
 

--- a/src/test/java/api/support/builders/ItemRequestBuilder.java
+++ b/src/test/java/api/support/builders/ItemRequestBuilder.java
@@ -462,7 +462,7 @@ public class ItemRequestBuilder implements Builder {
       this.hrid);
   }
 
-  public ItemRequestBuilder withLastCheckInt(JsonObject lastCheckIn) {
+  public ItemRequestBuilder withLastCheckIn(JsonObject lastCheckIn) {
     return new ItemRequestBuilder(
       this.id,
       this.holdingId,
@@ -477,8 +477,8 @@ public class ItemRequestBuilder implements Builder {
       this.permanentLoanType,
       this.temporaryLoanType,
       this.circulationNotes,
-      tags,
-      this.lastCheckIn,
+      this.tags,
+      lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,

--- a/src/test/java/api/support/builders/ItemRequestBuilder.java
+++ b/src/test/java/api/support/builders/ItemRequestBuilder.java
@@ -25,6 +25,7 @@ public class ItemRequestBuilder implements Builder {
   private final JsonObject temporaryLoanType;
   private final JsonArray circulationNotes;
   private final JsonObject tags;
+  private final JsonObject lastCheckIn;
   private final String itemLevelCallNumber;
   private final String itemLevelCallNumberPrefix;
   private final String itemLevelCallNumberSuffix;
@@ -35,7 +36,7 @@ public class ItemRequestBuilder implements Builder {
       AVAILABLE_STATUS, bookMaterialType(), null, null, null,
       canCirculateLoanType(), null, null, null,
       null, null, null,
-      null
+      null, null
     );
   }
 
@@ -54,6 +55,7 @@ public class ItemRequestBuilder implements Builder {
     JsonObject temporaryLoanType,
     JsonArray circulationNotes,
     JsonObject tags,
+    JsonObject lastCheckIn,
     String itemLevelCallNumber,
     String itemLevelCallNumberPrefix,
     String itemLevelCallNumberSuffix,
@@ -73,6 +75,7 @@ public class ItemRequestBuilder implements Builder {
     this.materialType = materialType;
     this.circulationNotes = circulationNotes;
     this.tags = tags;
+    this.lastCheckIn = lastCheckIn;
     this.itemLevelCallNumber = itemLevelCallNumber;
     this.itemLevelCallNumberPrefix = itemLevelCallNumberPrefix;
     this.itemLevelCallNumberSuffix = itemLevelCallNumberSuffix;
@@ -111,6 +114,7 @@ public class ItemRequestBuilder implements Builder {
     includeWhenPresent(itemRequest, "itemLevelCallNumberSuffix", itemLevelCallNumberSuffix);
     includeWhenPresent(itemRequest, "itemLevelCallNumberPrefix", itemLevelCallNumberPrefix);
     includeWhenPresent(itemRequest, "hrid", hrid);
+    includeWhenPresent(itemRequest, "lastCheckIn", lastCheckIn);
 
     return itemRequest;
   }
@@ -131,6 +135,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -153,6 +158,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -175,6 +181,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -197,6 +204,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -219,6 +227,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -245,6 +254,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -267,6 +277,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -301,6 +312,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -323,6 +335,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -345,6 +358,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -383,6 +397,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -417,6 +432,7 @@ public class ItemRequestBuilder implements Builder {
       loanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -439,6 +455,30 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       tags,
+      this.lastCheckIn,
+      this.itemLevelCallNumber,
+      this.itemLevelCallNumberPrefix,
+      this.itemLevelCallNumberSuffix,
+      this.hrid);
+  }
+
+  public ItemRequestBuilder withLastCheckInt(JsonObject lastCheckIn) {
+    return new ItemRequestBuilder(
+      this.id,
+      this.holdingId,
+      this.readOnlyTitle,
+      this.readOnlyCallNumber,
+      this.barcode,
+      this.status,
+      this.materialType,
+      this.readOnlyEffectiveLocation,
+      this.permanentLocation,
+      this.temporaryLocation,
+      this.permanentLoanType,
+      this.temporaryLoanType,
+      this.circulationNotes,
+      tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -476,6 +516,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -574,6 +615,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -596,6 +638,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       itemLevelCallNumberSuffix,
@@ -618,6 +661,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
@@ -640,6 +684,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,

--- a/src/test/java/api/support/builders/ItemRequestBuilder.java
+++ b/src/test/java/api/support/builders/ItemRequestBuilder.java
@@ -35,7 +35,7 @@ public class ItemRequestBuilder implements Builder {
   public ItemRequestBuilder() {
     this(UUID.randomUUID(), null, null, null, "645398607547",
       AVAILABLE_STATUS, bookMaterialType(), null, null, null,
-      canCirculateLoanType(), null, null, null,
+      canCirculateLoanType(), null, null, null, null,
       null, null, null,
       null, null
     );
@@ -475,6 +475,7 @@ public class ItemRequestBuilder implements Builder {
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
       this.hrid);
   }
 
@@ -705,6 +706,7 @@ public class ItemRequestBuilder implements Builder {
       this.temporaryLoanType,
       this.circulationNotes,
       this.tags,
+      this.lastCheckIn,
       this.itemLevelCallNumber,
       this.itemLevelCallNumberPrefix,
       this.itemLevelCallNumberSuffix,


### PR DESCRIPTION
JIRA-ticket: https://issues.folio.org/browse/MODINV-190

The main purpose of this PR is to fix the problem with "lastCheckIn" field in response to the item.

