### PR TITLE
UIDATIMP-359 Added "inventory-storage.instances.batch.post" permission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -147,7 +147,8 @@
             "inventory-storage.instances.item.post",
             "inventory-storage.instances.item.get",
             "inventory-storage.instances.item.put",
-            "inventory-storage.instances.item.delete"
+            "inventory-storage.instances.item.delete",
+            "inventory-storage.instances.batch.post"
           ]
         }
       ]


### PR DESCRIPTION
"inventory-storage.instances.batch.post" permission is missing for /inventory/instances/batch endpoint of inventory-batch 0.3 interface, which causes data-import process to fail if it is initiated by any user other than diku_admin. See [UIDATIMP-359](https://issues.folio.org/browse/UIDATIMP-359).