### PR TITLE
MODINV-194: Add 'Claimed returned' to allowed item statuses list. 

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "10.0",
+      "version": "10.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -193,7 +193,7 @@
   "requires": [
     {
       "id": "item-storage",
-      "version": "8.0"
+      "version": "8.1"
     },
     {
       "id": "instance-storage",

--- a/ramls/inventory.raml
+++ b/ramls/inventory.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory API
-version: v10.0
+version: v10.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -257,7 +257,7 @@
             "Paged",
             "Declared lost",
             "Order closed",
-            "Claim returned"
+            "Claimed returned"
           ]
         },
         "date": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -256,7 +256,8 @@
             "On order",
             "Paged",
             "Declared lost",
-            "Order closed"
+            "Order closed",
+            "Claim returned"
           ]
         },
         "date": {

--- a/src/main/java/org/folio/inventory/domain/items/ItemStatusName.java
+++ b/src/main/java/org/folio/inventory/domain/items/ItemStatusName.java
@@ -16,7 +16,8 @@ public enum ItemStatusName {
   ON_ORDER("On order"),
   PAGED("Paged"),
   DECLARED_LOST("Declared lost"),
-  ORDER_CLOSED("Order closed");
+  ORDER_CLOSED("Order closed"),
+  CLAIM_RETURNED("Claim returned");
 
   private static final Map<String, ItemStatusName> VALUE_TO_INSTANCE_MAP = initValueToInstanceMap();
   private final String value;

--- a/src/main/java/org/folio/inventory/domain/items/ItemStatusName.java
+++ b/src/main/java/org/folio/inventory/domain/items/ItemStatusName.java
@@ -17,7 +17,7 @@ public enum ItemStatusName {
   PAGED("Paged"),
   DECLARED_LOST("Declared lost"),
   ORDER_CLOSED("Order closed"),
-  CLAIM_RETURNED("Claim returned");
+  CLAIMED_RETURNED("Claimed returned");
 
   private static final Map<String, ItemStatusName> VALUE_TO_INSTANCE_MAP = initValueToInstanceMap();
   private final String value;

--- a/src/test/java/api/ApiTestSuite.java
+++ b/src/test/java/api/ApiTestSuite.java
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import api.isbns.IsbnUtilsApiExamples;
+import api.items.ItemAllowedStatusesSchemaTest;
 import api.items.ItemApiExamples;
 import api.items.ItemApiTitleExamples;
 import api.support.ControlledVocabularyPreparation;
@@ -35,7 +36,8 @@ import support.fakes.FakeOkapi;
   ItemApiExamples.class,
   ItemApiTitleExamples.class,
   ModsIngestExamples.class,
-  IsbnUtilsApiExamples.class
+  IsbnUtilsApiExamples.class,
+  ItemAllowedStatusesSchemaTest.class
 })
 public class ApiTestSuite {
   public static final int INVENTORY_VERTICLE_TEST_PORT = 9603;

--- a/src/test/java/api/items/ItemAllowedStatusesSchemaTest.java
+++ b/src/test/java/api/items/ItemAllowedStatusesSchemaTest.java
@@ -1,0 +1,103 @@
+package api.items;
+
+import static api.support.InstanceSamples.smallAngryPlanet;
+import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.Paths.get;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import org.folio.inventory.domain.items.ItemStatusName;
+import org.folio.inventory.support.http.client.IndividualResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import api.support.ApiTests;
+import api.support.builders.HoldingRequestBuilder;
+import api.support.builders.ItemRequestBuilder;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+/**
+ * This test verifies that ramls/item.json and {@link ItemStatusName} is consistent.
+ * <p>
+ * If you're introducing a new status for an item you have to update both item.json
+ * and the {@link ItemStatusName} enum, otherwise item won't pass validation
+ * and will be rejected.
+ */
+@RunWith(JUnitParamsRunner.class)
+public class ItemAllowedStatusesSchemaTest extends ApiTests {
+
+  @Test
+  public void schemaAndEnumIsConsistent() throws IOException {
+    final Set<String> enumAllowedItemStatuses = getItemStatusNameEnumAllowedItemStatuses();
+    final Set<String> schemaAllowedItemStatuses = getSchemaAllowedItemStatuses();
+
+    assertTrue(enumAllowedItemStatuses.size() > 0);
+    assertTrue(schemaAllowedItemStatuses.size() > 0);
+
+    assertEquals("Schema enum does not match ItemStatusName values",
+      enumAllowedItemStatuses, schemaAllowedItemStatuses);
+  }
+
+  @Test
+  @Parameters(method = "getItemStatusNameEnumAllowedItemStatuses")
+  public void canCreateItemsWithAllStatuses(String itemStatus) throws Exception {
+    final UUID holdingsId = createInstanceAndHolding();
+
+    final IndividualResource createResponse = itemsClient.create(
+      new ItemRequestBuilder()
+        .forHolding(holdingsId)
+        .canCirculate()
+        .withStatus(itemStatus)
+    );
+
+    assertThat(createResponse.getJson().getJsonObject("status").getString("name"),
+      is(itemStatus));
+  }
+
+  private UUID createInstanceAndHolding() throws MalformedURLException,
+    InterruptedException, ExecutionException, TimeoutException {
+
+    final IndividualResource instance = instancesClient
+      .create(smallAngryPlanet(UUID.randomUUID()));
+
+    return holdingsStorageClient
+      .create(new HoldingRequestBuilder().forInstance(instance.getId()))
+      .getId();
+  }
+
+  private Set<String> getSchemaAllowedItemStatuses() throws IOException {
+    final String itemJson = new String(readAllBytes(get("ramls/item.json")),
+      StandardCharsets.UTF_8);
+
+    final JsonObject itemSchema = new JsonObject(itemJson);
+
+    JsonArray allowedStatuses = itemSchema.getJsonObject("properties")
+      .getJsonObject("status").getJsonObject("properties")
+      .getJsonObject("name").getJsonArray("enum");
+
+    return allowedStatuses.stream()
+      .map(element -> (String) element)
+      .collect(Collectors.toSet());
+  }
+
+  private Set<String> getItemStatusNameEnumAllowedItemStatuses() {
+    return Arrays.stream(ItemStatusName.values())
+      .map(ItemStatusName::value)
+      .collect(Collectors.toSet());
+  }
+}

--- a/src/test/java/api/items/ItemAllowedStatusesSchemaTest.java
+++ b/src/test/java/api/items/ItemAllowedStatusesSchemaTest.java
@@ -62,8 +62,7 @@ public class ItemAllowedStatusesSchemaTest extends ApiTests {
       new ItemRequestBuilder()
         .forHolding(holdingsId)
         .canCirculate()
-        .withStatus(itemStatus)
-    );
+        .withStatus(itemStatus));
 
     assertThat(createResponse.getJson().getJsonObject("status").getString("name"),
       is(itemStatus));

--- a/src/test/java/api/support/ApiTests.java
+++ b/src/test/java/api/support/ApiTests.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeoutException;
 
 public abstract class ApiTests {
   private static boolean runningOnOwn;
-  protected final OkapiHttpClient okapiClient;
+  protected static OkapiHttpClient okapiClient;
 
   protected final ResourceClient holdingsStorageClient;
   protected final ResourceClient itemsStorageClient;
@@ -22,8 +22,7 @@ public abstract class ApiTests {
   protected final ResourceClient isbnClient;
   protected final ResourceClient usersClient;
 
-  public ApiTests() throws MalformedURLException {
-    okapiClient = ApiTestSuite.createOkapiHttpClient();
+  public ApiTests() {
     holdingsStorageClient = ResourceClient.forHoldingsStorage(okapiClient);
     itemsStorageClient = ResourceClient.forItemsStorage(okapiClient);
     itemsClient = ResourceClient.forItems(okapiClient);
@@ -44,6 +43,8 @@ public abstract class ApiTests {
       runningOnOwn = true;
       ApiTestSuite.before();
     }
+
+    okapiClient = ApiTestSuite.createOkapiHttpClient();
   }
 
   @AfterClass

--- a/src/test/java/api/support/builders/ItemRequestBuilder.java
+++ b/src/test/java/api/support/builders/ItemRequestBuilder.java
@@ -763,4 +763,29 @@ public class ItemRequestBuilder implements Builder {
       this.hrid,
       copyNumber);
   }
+
+  public ItemRequestBuilder withStatus(String status) {
+    return new ItemRequestBuilder(
+      this.id,
+      this.holdingId,
+      this.readOnlyTitle,
+      this.readOnlyCallNumber,
+      this.barcode,
+      status,
+      this.materialType,
+      this.readOnlyEffectiveLocation,
+      this.permanentLocation,
+      this.temporaryLocation,
+      this.permanentLoanType,
+      this.temporaryLoanType,
+      this.circulationNotes,
+      this.tags,
+      this.lastCheckIn,
+      this.itemLevelCallNumber,
+      this.itemLevelCallNumberPrefix,
+      this.itemLevelCallNumberSuffix,
+      this.itemLevelCallNumberTypeId,
+      this.hrid,
+      this.copyNumber);
+  }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-194: Backend: Claim returned: mark an item claim returned.

* Add `Claimed returned` to allowed item statuses list;
* Add test to verify schema enum is consistent to `org.folio.inventory.domain.items.ItemStatusName` enum.