### PR TITLE
MODINV-202: Allow editing of the Cataloged date when Instance has underlying MARC record.

### DIFF
--- a/src/main/java/org/folio/inventory/config/InventoryConfigurationImpl.java
+++ b/src/main/java/org/folio/inventory/config/InventoryConfigurationImpl.java
@@ -27,7 +27,6 @@ public class InventoryConfigurationImpl implements InventoryConfiguration {
     Instance.ELECTRONIC_ACCESS_KEY,
     Instance.SUBJECTS_KEY,
     Instance.CLASSIFICATIONS_KEY,
-    Instance.CATALOGED_DATE_KEY,
     Instance.TITLE_KEY,
     Instance.INDEX_TITLE_KEY,
     Instance.INSTANCE_TYPE_ID_KEY

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -560,7 +560,7 @@ public class InstancesApiExamples extends ApiTests {
     assertThat(errors.getString(0), is(
       "Instance is controlled by MARC record, these fields are blocked and can not be updated: " +
         "physicalDescriptions,notes,languages,identifiers,instanceTypeId,subjects," +
-        "catalogedDate,source,title,indexTitle,publicationFrequency,electronicAccess,publicationRange," +
+        "source,title,indexTitle,publicationFrequency,electronicAccess,publicationRange," +
         "classifications,editions,hrid,series,instanceFormatIds,publication,contributors," +
         "alternativeTitles"));
 


### PR DESCRIPTION
1. "CATALOGED_DATE_KEY"-field removed from InventoryConfigurationImpl.java.

JIRA-ticket: https://issues.folio.org/browse/MODINV-202