### PR TITLE
MODINV-192: Disallow editing of the Mode of issuance field when Instance has underlying MARC record.

### DIFF
--- a/src/main/java/org/folio/inventory/config/InventoryConfigurationImpl.java
+++ b/src/main/java/org/folio/inventory/config/InventoryConfigurationImpl.java
@@ -30,7 +30,8 @@ public class InventoryConfigurationImpl implements InventoryConfiguration {
     Instance.CATALOGED_DATE_KEY,
     Instance.TITLE_KEY,
     Instance.INDEX_TITLE_KEY,
-    Instance.INSTANCE_TYPE_ID_KEY
+    Instance.INSTANCE_TYPE_ID_KEY,
+    Instance.MODE_OF_ISSUANCE_ID_KEY
     );
 
   public InventoryConfigurationImpl() {

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -559,7 +559,7 @@ public class InstancesApiExamples extends ApiTests {
     assertThat(errors.size(), is(1));
     assertThat(errors.getString(0), is(
       "Instance is controlled by MARC record, these fields are blocked and can not be updated: " +
-        "physicalDescriptions,notes,languages,identifiers,instanceTypeId,subjects," +
+        "physicalDescriptions,notes,languages,identifiers,instanceTypeId,modeOfIssuanceId,subjects," +
         "catalogedDate,source,title,indexTitle,publicationFrequency,electronicAccess,publicationRange," +
         "classifications,editions,hrid,series,instanceFormatIds,publication,contributors," +
         "alternativeTitles"));

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -560,8 +560,6 @@ public class InstancesApiExamples extends ApiTests {
     assertThat(errors.getString(0), is(
       "Instance is controlled by MARC record, these fields are blocked and can not be updated: " +
         "physicalDescriptions,notes,languages,identifiers,instanceTypeId,modeOfIssuanceId,subjects," +
-        "catalogedDate,source,title,indexTitle,publicationFrequency,electronicAccess,publicationRange," +
-        "physicalDescriptions,notes,languages,identifiers,instanceTypeId,subjects," +
         "source,title,indexTitle,publicationFrequency,electronicAccess,publicationRange," +
         "classifications,editions,hrid,series,instanceFormatIds,publication,contributors," +
         "alternativeTitles"));


### PR DESCRIPTION
1. "modeOfIssuanceId" was marked as a Blocked field.
2. Test fixed.