### PR TITLE
MODINV-198 Preceding titles ability to add "unconnected" and "connected" title (create, edit)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -97,7 +97,12 @@
           "permissionsRequired": ["inventory.instances.item.post"],
           "modulePermissions": [
             "inventory-storage.instances.item.post",
-            "inventory-storage.instances.item.get"]
+            "inventory-storage.instances.item.get",
+            "inventory-storage.preceding-succeeding-titles.collection.get",
+            "inventory-storage.preceding-succeeding-titles.item.post",
+            "inventory-storage.preceding-succeeding-titles.item.put",
+            "inventory-storage.preceding-succeeding-titles.item.delete"
+          ]
         }, {
           "methods": ["PUT"],
           "pathPattern": "/inventory/instances/{id}",
@@ -281,6 +286,10 @@
     },
     {
       "id": "pubsub-publish",
+      "version": "0.1"
+    },
+    {
+      "id": "instance-preceding-succeeding-titles",
       "version": "0.1"
     }
   ],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "10.1",
+      "version": "10.2",
       "handlers": [
         {
           "methods": ["GET"],
@@ -81,27 +81,37 @@
           "methods": ["GET"],
           "pathPattern": "/inventory/instances",
           "permissionsRequired": ["inventory.instances.collection.get"],
-          "modulePermissions": ["inventory-storage.instances.collection.get"]
+          "modulePermissions": [
+            "inventory-storage.instances.collection.get",
+            "inventory-storage.preceding-succeeding-titles.collection.get"]
         }, {
           "methods": ["GET"],
           "pathPattern": "/inventory/instances/{id}",
           "permissionsRequired": ["inventory.instances.item.get"],
-          "modulePermissions": ["inventory-storage.instances.item.get"]
+          "modulePermissions": [
+            "inventory-storage.instances.item.get",
+            "inventory-storage.preceding-succeeding-titles.collection.get"]
         }, {
           "methods": ["POST"],
           "pathPattern": "/inventory/instances",
           "permissionsRequired": ["inventory.instances.item.post"],
-          "modulePermissions": ["inventory-storage.instances.item.post",
-                                "inventory-storage.instances.item.get"]
+          "modulePermissions": [
+            "inventory-storage.instances.item.post",
+            "inventory-storage.instances.item.get"]
         }, {
           "methods": ["PUT"],
           "pathPattern": "/inventory/instances/{id}",
           "permissionsRequired": ["inventory.instances.item.put"],
-          "modulePermissions": ["inventory-storage.instances.item.put",
-                                "inventory-storage.instances.item.get",
-                                "inventory-storage.instances.item.post",
-                                "inventory-storage.instances.item.delete",
-                                "source-storage.record.update"]
+          "modulePermissions": [
+            "inventory-storage.instances.item.put",
+            "inventory-storage.instances.item.get",
+            "inventory-storage.instances.item.post",
+            "inventory-storage.instances.item.delete",
+            "source-storage.record.update",
+            "inventory-storage.preceding-succeeding-titles.collection.get",
+            "inventory-storage.preceding-succeeding-titles.item.post",
+            "inventory-storage.preceding-succeeding-titles.item.put",
+            "inventory-storage.preceding-succeeding-titles.item.delete"]
         }, {
           "methods": ["DELETE"],
           "pathPattern": "/inventory/instances/{id}",
@@ -137,7 +147,7 @@
     },
     {
       "id": "inventory-batch",
-      "version": "0.3",
+      "version": "0.5",
       "handlers": [
         {
           "methods": ["POST"],
@@ -148,7 +158,11 @@
             "inventory-storage.instances.item.get",
             "inventory-storage.instances.item.put",
             "inventory-storage.instances.item.delete",
-            "inventory-storage.instances.batch.post"
+            "inventory-storage.instances.batch.post",
+            "inventory-storage.preceding-succeeding-titles.collection.get",
+            "inventory-storage.preceding-succeeding-titles.item.post",
+            "inventory-storage.preceding-succeeding-titles.item.put",
+            "inventory-storage.preceding-succeeding-titles.item.delete"
           ]
         }
       ]

--- a/ramls/examples/instance_post.json
+++ b/ramls/examples/instance_post.json
@@ -18,5 +18,33 @@
     "tagList" : [
       "important"
     ]
-  }
+  },
+  "precedingTitles": [
+    {
+      "id": "cb4f8537-7643-4ef4-8cc4-6dbf7bbe8a6b",
+      "precedingInstanceId": "1b74ab75-9f41-4837-8662-a1d99118008d",
+      "title": "A semantic web primer",
+      "hrid": "inst000000000022",
+      "identifiers": [
+        {
+          "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422",
+          "value": "0262012103"
+        }
+      ]
+    }
+  ],
+  "succeedingTitles": [
+    {
+      "id": "1b4f8537-7643-4ef4-8cc4-6dbf7bbe8a6b",
+      "succeedingInstanceId": "8be05cf5-fb4f-4752-8094-8e179d08fb99",
+      "title": "A semantic web primer",
+      "hrid": "inst000000000022",
+      "identifiers": [
+        {
+          "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422",
+          "value": "0262012103"
+        }
+      ]
+    }
+  ]
 }

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -400,6 +400,104 @@
       }
     }
   },
+  "precedingTitles": {
+    "description": "Array of preceding titles",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Id of the preceding title",
+          "type": "string"
+        },
+        "precedingInstanceId": {
+          "description": "Id of the preceding instance id",
+          "type": "string"
+        },
+        "title": {
+          "type": "string",
+          "description": "The primary title (or label) associated with the resource"
+        },
+        "hrid": {
+          "type": "string",
+          "description": "The human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"
+        },
+        "identifiers": {
+          "type": "array",
+          "description": "An extensible set of name-value pairs of identifiers associated with the resource",
+          "minItems": 0,
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string",
+                "description": "Resource identifier value"
+              },
+              "identifierTypeId": {
+                "type": "string",
+                "description": "Resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers)"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "value",
+              "identifierTypeId"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "succeedingTitles": {
+    "description": "Array of succeeding titles",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Id of the succeeding title",
+          "type": "string"
+        },
+        "succeedingInstanceId": {
+          "description": "Id of the succeeding instance id",
+          "type": "string"
+        },
+        "title": {
+          "type": "string",
+          "description": "The primary title (or label) associated with the resource"
+        },
+        "hrid": {
+          "type": "string",
+          "description": "The human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"
+        },
+        "identifiers": {
+          "type": "array",
+          "description": "An extensible set of name-value pairs of identifiers associated with the resource",
+          "minItems": 0,
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string",
+                "description": "Resource identifier value"
+              },
+              "identifierTypeId": {
+                "type": "string",
+                "description": "Resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers)"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "value",
+              "identifierTypeId"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
   "additionalProperties": false,
   "required": [
     "source",

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -408,11 +408,13 @@
       "properties": {
         "id": {
           "description": "Id of the preceding title",
-          "type": "string"
+          "type": "string",
+          "$ref": "uuid.json"
         },
         "precedingInstanceId": {
           "description": "Id of the preceding instance id",
-          "type": "string"
+          "type": "string",
+          "$ref": "uuid.json"
         },
         "title": {
           "type": "string",
@@ -457,11 +459,13 @@
       "properties": {
         "id": {
           "description": "Id of the succeeding title",
-          "type": "string"
+          "type": "string",
+          "$ref": "uuid.json"
         },
         "succeedingInstanceId": {
           "description": "Id of the succeeding instance id",
-          "type": "string"
+          "type": "string",
+          "$ref": "uuid.json"
         },
         "title": {
           "type": "string",

--- a/ramls/inventory-batch.raml
+++ b/ramls/inventory-batch.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory API
-version: v0.4
+version: v0.5
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/inventory.raml
+++ b/ramls/inventory.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory API
-version: v10.1
+version: v10.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/src/main/java/org/folio/inventory/domain/instances/Instance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/Instance.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.inventory.domain.Metadata;
+import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
 import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
 
 public class Instance {
@@ -14,6 +15,8 @@ public class Instance {
   public static final String SOURCE_KEY = "source";
   public static final String PARENT_INSTANCES_KEY = "parentInstances";
   public static final String CHILD_INSTANCES_KEY = "childInstances";
+  public static final String PRECEDING_TITLES_KEY = "precedingTitles";
+  public static final String SUCCEEDING_TITLES_KEY = "succeedingTitles";
   public static final String TITLE_KEY = "title";
   public static final String INDEX_TITLE_KEY = "indexTitle";
   public static final String ALTERNATIVE_TITLES_KEY = "alternativeTitles";
@@ -51,6 +54,8 @@ public class Instance {
   private final String source;
   private List<InstanceRelationshipToParent> parentInstances = new ArrayList();
   private List<InstanceRelationshipToChild> childInstances = new ArrayList();
+  private List<PrecedingSucceedingTitle> precedingTitles = new ArrayList();
+  private List<PrecedingSucceedingTitle> succeedingTitles = new ArrayList();
   private final String title;
   private String indexTitle;
   private List<AlternativeTitle> alternativeTitles = new ArrayList();
@@ -108,6 +113,16 @@ public class Instance {
 
   public Instance setChildInstances(List<InstanceRelationshipToChild> childInstances) {
     this.childInstances = childInstances;
+    return this;
+  }
+
+  public Instance setPrecedingTitles(List<PrecedingSucceedingTitle> precedingTitles) {
+    this.precedingTitles = precedingTitles;
+    return this;
+  }
+
+  public Instance setSucceedingTitles(List<PrecedingSucceedingTitle> succeedingTitles) {
+    this.succeedingTitles = succeedingTitles;
     return this;
   }
 
@@ -268,6 +283,14 @@ public class Instance {
 
   public List<InstanceRelationshipToChild> getChildInstances() {
     return childInstances;
+  }
+
+  public List<PrecedingSucceedingTitle> getPrecedingTitles() {
+    return precedingTitles;
+  }
+
+  public List<PrecedingSucceedingTitle> getSucceedingTitles() {
+    return succeedingTitles;
   }
 
   public String getTitle() {

--- a/src/main/java/org/folio/inventory/domain/instances/Instance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/Instance.java
@@ -1,6 +1,7 @@
 package org.folio.inventory.domain.instances;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -54,8 +55,8 @@ public class Instance {
   private final String source;
   private List<InstanceRelationshipToParent> parentInstances = new ArrayList();
   private List<InstanceRelationshipToChild> childInstances = new ArrayList();
-  private List<PrecedingSucceedingTitle> precedingTitles = new ArrayList();
-  private List<PrecedingSucceedingTitle> succeedingTitles = new ArrayList();
+  private List<PrecedingSucceedingTitle> precedingTitles = new ArrayList<>();
+  private List<PrecedingSucceedingTitle> succeedingTitles = new ArrayList<>();
   private final String title;
   private String indexTitle;
   private List<AlternativeTitle> alternativeTitles = new ArrayList();
@@ -117,12 +118,12 @@ public class Instance {
   }
 
   public Instance setPrecedingTitles(List<PrecedingSucceedingTitle> precedingTitles) {
-    this.precedingTitles = precedingTitles;
+    this.precedingTitles = new ArrayList<>(precedingTitles);
     return this;
   }
 
   public Instance setSucceedingTitles(List<PrecedingSucceedingTitle> succeedingTitles) {
-    this.succeedingTitles = succeedingTitles;
+    this.succeedingTitles = new ArrayList<>(succeedingTitles);
     return this;
   }
 
@@ -166,12 +167,12 @@ public class Instance {
     return this;
   }
 
-  public Instance setPublicationFrequency (List<String> publicationFrequency) {
+  public Instance setPublicationFrequency(List<String> publicationFrequency) {
     this.publicationFrequency = publicationFrequency;
     return this;
   }
 
-  public Instance setPublicationRange (List<String> publicationRange) {
+  public Instance setPublicationRange(List<String> publicationRange) {
     this.publicationRange = publicationRange;
     return this;
   }
@@ -246,7 +247,7 @@ public class Instance {
     return this;
   }
 
-  public Instance setMetadata (Metadata metadata) {
+  public Instance setMetadata(Metadata metadata) {
     this.metadata = metadata;
     return this;
   }
@@ -286,11 +287,11 @@ public class Instance {
   }
 
   public List<PrecedingSucceedingTitle> getPrecedingTitles() {
-    return precedingTitles;
+    return Collections.unmodifiableList(precedingTitles);
   }
 
   public List<PrecedingSucceedingTitle> getSucceedingTitles() {
-    return succeedingTitles;
+    return Collections.unmodifiableList(succeedingTitles);
   }
 
   public String getTitle() {

--- a/src/main/java/org/folio/inventory/domain/instances/titles/PrecedingSucceedingTitle.java
+++ b/src/main/java/org/folio/inventory/domain/instances/titles/PrecedingSucceedingTitle.java
@@ -4,7 +4,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class PrecedingSucceedingTitle {
-  public static final String PRECEDING_INSTANCE_INSTANCE_ID_KEY = "precedingInstanceId";
+  public static final String PRECEDING_INSTANCE_ID_KEY = "precedingInstanceId";
   public static final String SUCCEEDING_INSTANCE_ID_KEY = "succeedingInstanceId";
   public static final String TITLE_KEY = "title";
   public static final String HRID_KEY = "hrid";
@@ -19,6 +19,7 @@ public class PrecedingSucceedingTitle {
 
   public PrecedingSucceedingTitle(String id, String precedingInstanceId,
     String succeedingInstanceId, String title, String hrid, JsonArray identifiers) {
+
     this.id = id;
     this.precedingInstanceId = precedingInstanceId;
     this.succeedingInstanceId = succeedingInstanceId;
@@ -27,19 +28,20 @@ public class PrecedingSucceedingTitle {
     this.identifiers = identifiers;
   }
 
-  public PrecedingSucceedingTitle(JsonObject rel) {
-    this(rel.getString("id"),
-         rel.getString(PRECEDING_INSTANCE_INSTANCE_ID_KEY),
+  public static PrecedingSucceedingTitle from(JsonObject rel) {
+    return new PrecedingSucceedingTitle(rel.getString("id"),
+         rel.getString(PRECEDING_INSTANCE_ID_KEY),
          rel.getString(SUCCEEDING_INSTANCE_ID_KEY),
          rel.getString(TITLE_KEY),
          rel.getString(HRID_KEY),
-         rel.getJsonArray(IDENTIFIERS_KEY)
-      );
+         rel.getJsonArray(IDENTIFIERS_KEY));
   }
 
-  public PrecedingSucceedingTitle(JsonObject rel, String title, String hrid,
+  public static PrecedingSucceedingTitle from(JsonObject rel, String title, String hrid,
     JsonArray identifiers) {
-    this(rel.getString("id"), rel.getString(PRECEDING_INSTANCE_INSTANCE_ID_KEY),
-      rel.getString(SUCCEEDING_INSTANCE_ID_KEY), title, hrid, identifiers);
+    return new PrecedingSucceedingTitle(rel.getString("id"),
+      rel.getString(PRECEDING_INSTANCE_ID_KEY),
+      rel.getString(SUCCEEDING_INSTANCE_ID_KEY),
+      title, hrid, identifiers);
   }
 }

--- a/src/main/java/org/folio/inventory/domain/instances/titles/PrecedingSucceedingTitle.java
+++ b/src/main/java/org/folio/inventory/domain/instances/titles/PrecedingSucceedingTitle.java
@@ -1,0 +1,45 @@
+package org.folio.inventory.domain.instances.titles;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class PrecedingSucceedingTitle {
+  public static final String PRECEDING_INSTANCE_INSTANCE_ID_KEY = "precedingInstanceId";
+  public static final String SUCCEEDING_INSTANCE_ID_KEY = "succeedingInstanceId";
+  public static final String TITLE_KEY = "title";
+  public static final String HRID_KEY = "hrid";
+  public static final String IDENTIFIERS_KEY = "identifiers";
+
+  public final String id;
+  public final String precedingInstanceId;
+  public final String succeedingInstanceId;
+  public final String title;
+  public final String hrid;
+  public final JsonArray identifiers;
+
+  public PrecedingSucceedingTitle(String id, String precedingInstanceId,
+    String succeedingInstanceId, String title, String hrid, JsonArray identifiers) {
+    this.id = id;
+    this.precedingInstanceId = precedingInstanceId;
+    this.succeedingInstanceId = succeedingInstanceId;
+    this.title = title;
+    this.hrid = hrid;
+    this.identifiers = identifiers;
+  }
+
+  public PrecedingSucceedingTitle(JsonObject rel) {
+    this(rel.getString("id"),
+         rel.getString(PRECEDING_INSTANCE_INSTANCE_ID_KEY),
+         rel.getString(SUCCEEDING_INSTANCE_ID_KEY),
+         rel.getString(TITLE_KEY),
+         rel.getString(HRID_KEY),
+         rel.getJsonArray(IDENTIFIERS_KEY)
+      );
+  }
+
+  public PrecedingSucceedingTitle(JsonObject rel, String title, String hrid,
+    JsonArray identifiers) {
+    this(rel.getString("id"), rel.getString(PRECEDING_INSTANCE_INSTANCE_ID_KEY),
+      rel.getString(SUCCEEDING_INSTANCE_ID_KEY), title, hrid, identifiers);
+  }
+}

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -2,6 +2,7 @@ package org.folio.inventory.resources;
 
 import static io.netty.util.internal.StringUtil.COMMA;
 import static java.lang.String.format;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.inventory.support.http.server.SuccessResponse.noContent;
 
 import java.io.UnsupportedEncodingException;
@@ -14,6 +15,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -28,6 +31,7 @@ import org.folio.inventory.domain.instances.InstanceCollection;
 import org.folio.inventory.domain.instances.InstanceRelationship;
 import org.folio.inventory.domain.instances.InstanceRelationshipToChild;
 import org.folio.inventory.domain.instances.InstanceRelationshipToParent;
+import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
 import org.folio.inventory.storage.Storage;
 import org.folio.inventory.storage.external.CollectionResourceClient;
 import org.folio.inventory.support.JsonArrayHelper;
@@ -126,6 +130,17 @@ public class Instances extends AbstractInstances {
     }
   }
 
+  private void makeInstancesResponse(Success<MultipleRecords<Instance>> success,
+    RoutingContext routingContext, WebContext context) {
+    InstancesResponseWrapper instancesResponseWrapper = new InstancesResponseWrapper();
+    instancesResponseWrapper.setSuccess(success);
+    completedFuture(instancesResponseWrapper)
+      .thenCompose(response -> fetchBatchRelationships(response, routingContext, context))
+      .thenCompose(response -> fetchBatchPrecedingSucceedingTitles(response, routingContext, context))
+      .thenAccept(response -> JsonResponse.success(routingContext.response(),
+        toRepresentation(response, context)));
+  }
+
   private void create(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
 
@@ -144,18 +159,19 @@ public class Instances extends AbstractInstances {
         Instance response = success.getResult();
         response.setParentInstances(newInstance.getParentInstances());
         response.setChildInstances(newInstance.getChildInstances());
-        updateInstanceRelationships(response, routingContext, context,
-          x -> {
-            try {
-              URL url = context.absoluteUrl(format("%s/%s",
-                INSTANCES_PATH, success.getResult().getId()));
-              RedirectResponse.created(routingContext.response(), url.toString());
-            } catch (MalformedURLException e) {
-              log.warn(
-                format("Failed to create self link for instance: %s", e.toString()));
-            }
+        response.setPrecedingTitles(newInstance.getPrecedingTitles());
+        response.setSucceedingTitles(newInstance.getSucceedingTitles());
+
+        updateRelatedRecords(routingContext, context, response, r -> {
+          try {
+            URL url = context.absoluteUrl(format("%s/%s",
+              INSTANCES_PATH, response.getId()));
+            RedirectResponse.created(routingContext.response(), url.toString());
+          } catch (MalformedURLException e) {
+            log.warn(
+              format("Failed to create self link for instance: %s", e.toString()));
           }
-        );
+        });
       }, FailureResponseConsumer.serverError(routingContext.response()));
   }
 
@@ -239,7 +255,7 @@ public class Instances extends AbstractInstances {
     instanceCollection.update(
       instance,
       v -> {
-        updateInstanceRelationships(instance, rContext, wContext, (x) -> noContent(rContext.response()));
+        updateRelatedRecords(rContext, wContext, instance, x -> noContent(rContext.response()));
         if (isInstanceControlledByRecord(instance)) {
           updateSuppressFromDiscoveryFlag(wContext, instance);
         }
@@ -290,8 +306,12 @@ public class Instances extends AbstractInstances {
     storage.getInstanceCollection(context).findById(
       routingContext.request().getParam("id"),
       it -> {
-        if (it.getResult() != null) {
-          makeInstanceResponse(it, routingContext, context);
+        Instance instance = it.getResult();
+        if (instance != null) {
+          completedFuture(instance)
+            .thenCompose(response -> fetchInstanceRelationships(it, routingContext, context))
+            .thenCompose(response -> fetchPrecedingSucceedingTitles(it, routingContext, context))
+            .thenAccept(response -> successResponse(routingContext, context, response));
         } else {
           ClientErrorResponse.notFound(routingContext.response());
         }
@@ -302,16 +322,16 @@ public class Instances extends AbstractInstances {
   /**
    * Fetches instance relationships for multiple Instance records, populates, responds
    *
-   * @param success        Multi record Instances result
+   * @param instancesResponseWrapper Multi record Instances result
    * @param routingContext
    * @param context
    */
-  private void makeInstancesResponse(
-    Success<MultipleRecords<Instance>> success,
+  private CompletableFuture<InstancesResponseWrapper> fetchBatchRelationships(
+    InstancesResponseWrapper instancesResponseWrapper,
     RoutingContext routingContext,
     WebContext context) {
 
-    List<String> instanceIds = getInstanceIdsFromInstanceResult(success);
+    List<String> instanceIds = getInstanceIdsFromInstanceResult(instancesResponseWrapper.getSuccess());
     String query = createQueryForRelatedInstances(instanceIds);
 
     try {
@@ -322,23 +342,37 @@ public class Instances extends AbstractInstances {
     CollectionResourceClient relatedInstancesClient = createInstanceRelationshipsClient(routingContext, context);
 
     if (relatedInstancesClient != null) {
-      relatedInstancesClient.getMany(query, (Response result) -> {
-        Map<String, List<InstanceRelationshipToParent>> parentInstanceMap = new HashMap();
-        Map<String, List<InstanceRelationshipToChild>> childInstanceMap = new HashMap();
-        if (result.getStatusCode() == 200) {
-          JsonObject json = result.getJson();
-          List<JsonObject> relationsList = JsonArrayHelper.toList(json.getJsonArray("instanceRelationships"));
-          relationsList.stream().map(rel -> {
-            addToList(childInstanceMap, rel.getString("superInstanceId"), new InstanceRelationshipToChild(rel));
-            return rel;
-          }).forEachOrdered(rel -> {
-            addToList(parentInstanceMap, rel.getString("subInstanceId"), new InstanceRelationshipToParent(rel));
-          });
-        }
-        JsonResponse.success(routingContext.response(),
-          toRepresentation(success.getResult(), parentInstanceMap, childInstanceMap, context));
-      });
+      CompletableFuture<Response> relatedInstancesFetched = new CompletableFuture<>();
+
+      relatedInstancesClient.getMany(query, relatedInstancesFetched::complete);
+
+      return relatedInstancesFetched
+        .thenCompose(response -> withInstancesRelationships(instancesResponseWrapper, response));
+
     }
+    return completedFuture(null);
+  }
+
+  private CompletableFuture<InstancesResponseWrapper> fetchBatchPrecedingSucceedingTitles(
+    InstancesResponseWrapper instancesResponseWrapper, RoutingContext routingContext, WebContext context) {
+
+    List<String> instanceIds = getInstanceIdsFromInstanceResult(instancesResponseWrapper.getSuccess());
+    String query = createQueryForPrecedingSucceedingInstances(instanceIds);
+
+    try {
+      query = URLEncoder.encode(query, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      log.error(format("Cannot encode query %s", query));
+    }
+
+    CollectionResourceClient precedingSucceedingTitlesClient = createPrecedingSucceedingTitlesClient(routingContext, context);
+    CompletableFuture<Response> precedingSucceedingTitlesFetched = new CompletableFuture<>();
+
+    precedingSucceedingTitlesClient.getMany(query, precedingSucceedingTitlesFetched::complete);
+
+    return precedingSucceedingTitlesFetched
+      .thenCompose(response ->
+        withPrecedingSucceedingTitlesMany(routingContext, context, instancesResponseWrapper, response));
   }
 
   /**
@@ -348,7 +382,7 @@ public class Instances extends AbstractInstances {
    * @param routingContext
    * @param context
    */
-  private void makeInstanceResponse(
+  private CompletableFuture<Instance> fetchInstanceRelationships(
     Success<Instance> success,
     RoutingContext routingContext,
     WebContext context) {
@@ -359,29 +393,82 @@ public class Instances extends AbstractInstances {
     CollectionResourceClient relatedInstancesClient = createInstanceRelationshipsClient(routingContext, context);
 
     if (relatedInstancesClient != null) {
-      relatedInstancesClient.getMany(query, (Response result) -> {
-        List<InstanceRelationshipToParent> parentInstanceList = new ArrayList();
-        List<InstanceRelationshipToChild> childInstanceList = new ArrayList();
-        if (result.getStatusCode() == 200) {
-          JsonObject json = result.getJson();
-          List<JsonObject> relationsList = JsonArrayHelper.toList(json.getJsonArray("instanceRelationships"));
-          relationsList.forEach(rel -> {
-            if (rel.getString(InstanceRelationship.SUPER_INSTANCE_ID_KEY).equals(instance.getId())) {
-              childInstanceList.add(new InstanceRelationshipToChild(rel));
-            } else if (rel.getString(InstanceRelationship.SUB_INSTANCE_ID_KEY).equals(instance.getId())) {
-              parentInstanceList.add(new InstanceRelationshipToParent(rel));
-            }
-          });
-        }
-        JsonResponse.success(
-          routingContext.response(),
-          toRepresentation(
-            success.getResult(),
-            parentInstanceList,
-            childInstanceList,
-            context));
-      });
+      CompletableFuture<Response> relatedInstancesFetched = new CompletableFuture<>();
+
+      relatedInstancesClient.getMany(query, relatedInstancesFetched::complete);
+
+      return relatedInstancesFetched
+        .thenCompose(response -> withInstanceRelationships(instance, response));
     }
+    return completedFuture(null);
+  }
+
+  private void successResponse(RoutingContext routingContext, WebContext context,
+                               Instance instance) {
+
+    JsonResponse.success(routingContext.response(), toRepresentation(instance,
+      new ArrayList<>(), new ArrayList<>(),
+      instance.getPrecedingTitles(), instance.getSucceedingTitles(), context));
+  }
+
+  private CompletableFuture<InstancesResponseWrapper> withInstancesRelationships(InstancesResponseWrapper instancesResponseWrapper,
+                                                                                 Response result) {
+    if (result.getStatusCode() == 200) {
+      Map<String, List<InstanceRelationshipToParent>> parentInstanceMap = new HashMap();
+      Map<String, List<InstanceRelationshipToChild>> childInstanceMap = new HashMap();
+
+      JsonObject json = result.getJson();
+      List<JsonObject> relationsList = JsonArrayHelper.toList(json.getJsonArray("instanceRelationships"));
+      relationsList.stream().map(rel -> {
+        addToList(childInstanceMap, rel.getString("superInstanceId"), new InstanceRelationshipToChild(rel));
+        return rel;
+      }).forEachOrdered(rel -> {
+        addToList(parentInstanceMap, rel.getString("subInstanceId"), new InstanceRelationshipToParent(rel));
+      });
+
+      instancesResponseWrapper.setChildInstanceMap(childInstanceMap);
+      instancesResponseWrapper.setParentInstanceMap(parentInstanceMap);
+      return completedFuture(instancesResponseWrapper);
+    }
+    return completedFuture(null);
+  }
+
+  private CompletableFuture<Instance> withInstanceRelationships(Instance instance,
+                                                                Response result) {
+    List<InstanceRelationshipToParent> parentInstanceList = new ArrayList();
+    List<InstanceRelationshipToChild> childInstanceList = new ArrayList();
+    if (result.getStatusCode() == 200) {
+      JsonObject json = result.getJson();
+      List<JsonObject> relationsList = JsonArrayHelper.toList(json.getJsonArray("instanceRelationships"));
+      relationsList.forEach(rel -> {
+        if (rel.getString(InstanceRelationship.SUPER_INSTANCE_ID_KEY).equals(instance.getId())) {
+          childInstanceList.add(new InstanceRelationshipToChild(rel));
+        } else if (rel.getString(InstanceRelationship.SUB_INSTANCE_ID_KEY).equals(instance.getId())) {
+          parentInstanceList.add(new InstanceRelationshipToParent(rel));
+        }
+      });
+      instance.getParentInstances().addAll(parentInstanceList);
+      instance.getChildInstances().addAll(childInstanceList);
+    }
+    return completedFuture(instance);
+  }
+
+
+  private CompletableFuture<Instance> fetchPrecedingSucceedingTitles(
+    Success<Instance> success, RoutingContext routingContext, WebContext context) {
+
+    Instance instance = success.getResult();
+    List<String> instanceIds = getInstanceIdsFromInstanceResult(success);
+    String queryForPrecedingSucceedingInstances = createQueryForPrecedingSucceedingInstances(instanceIds);
+    CollectionResourceClient precedingSucceedingTitlesClient = createPrecedingSucceedingTitlesClient(routingContext, context);
+
+    CompletableFuture<Response> precedingSucceedingTitlesFetched = new CompletableFuture<>();
+
+    precedingSucceedingTitlesClient.getMany(queryForPrecedingSucceedingInstances, precedingSucceedingTitlesFetched::complete);
+
+    return precedingSucceedingTitlesFetched
+      .thenCompose(response ->
+        withPrecedingSucceedingTitles(routingContext, context, instance, response));
   }
 
   // Utilities
@@ -400,8 +487,9 @@ public class Instances extends AbstractInstances {
     return instanceIds;
   }
 
-  private synchronized void addToList(Map<String, List<InstanceRelationshipToChild>> items, String mapKey, InstanceRelationshipToChild myItem) {
-    List<InstanceRelationshipToChild> itemsList = items.get(mapKey);
+  private synchronized <T> void addToList(Map<String, List<T>> items,
+                                          String mapKey, T myItem) {
+    List<T> itemsList = items.get(mapKey);
 
     // if list does not exist create it
     if (itemsList == null) {
@@ -416,20 +504,98 @@ public class Instances extends AbstractInstances {
     }
   }
 
-  private synchronized void addToList(Map<String, List<InstanceRelationshipToParent>> items, String mapKey, InstanceRelationshipToParent myItem) {
-    List<InstanceRelationshipToParent> itemsList = items.get(mapKey);
-
-    // if list does not exist create it
-    if (itemsList == null) {
-      itemsList = new ArrayList();
-      itemsList.add(myItem);
-      items.put(mapKey, itemsList);
-    } else {
-      // add if item is not already in list
-      if (!itemsList.contains(myItem)) {
-        itemsList.add(myItem);
-      }
+  private CompletableFuture<InstancesResponseWrapper> withPrecedingSucceedingTitlesMany(
+    RoutingContext routingContext, WebContext context, InstancesResponseWrapper instancesResponseWrapper, Response result) {
+    if (result.getStatusCode() == 200) {
+      Map<String, List<PrecedingSucceedingTitle>> precedingTitlesMap = new HashMap();
+      Map<String, List<PrecedingSucceedingTitle>> succeedingTitlesMap = new HashMap();
+      JsonObject json = result.getJson();
+      List<JsonObject> relationsList = JsonArrayHelper.toList(json.getJsonArray("precedingSucceedingTitles"));
+      relationsList.stream().map(rel -> {
+        final String precedingInstanceId = rel.getString("precedingInstanceId");
+        if (StringUtils.isNotBlank(precedingInstanceId)) {
+          addToList(precedingTitlesMap, precedingInstanceId, new PrecedingSucceedingTitle(rel));
+        }
+        return rel;
+      }).forEachOrdered(rel -> {
+          final String succeedingInstanceId = rel.getString("succeedingInstanceId");
+          if (StringUtils.isNotBlank(succeedingInstanceId)) {
+            addToList(succeedingTitlesMap, succeedingInstanceId, new PrecedingSucceedingTitle(rel));
+          }
+        }
+      );
+      instancesResponseWrapper.setPrecedingTitlesMap(precedingTitlesMap);
+      instancesResponseWrapper.setSucceedingTitlesMap(succeedingTitlesMap);
+      return completedFuture(instancesResponseWrapper);
     }
+    return completedFuture(null);
   }
 
+  private CompletableFuture<Instance> withPrecedingSucceedingTitles(
+    RoutingContext routingContext, WebContext context, Instance instance, Response result) {
+    if (result.getStatusCode() == 200) {
+      JsonObject json = result.getJson();
+      List<JsonObject> relationsList = JsonArrayHelper.toList(json.getJsonArray("precedingSucceedingTitles"));
+
+      List<CompletableFuture<PrecedingSucceedingTitle>> precedingTitleCompletableFutures =
+        relationsList.stream().filter(rel -> isPrecedingTitle(instance, rel))
+          .map(rel -> getPrecedingSucceedingTitle(routingContext, context, rel,
+            PrecedingSucceedingTitle.PRECEDING_INSTANCE_INSTANCE_ID_KEY)).collect(Collectors.toList());
+
+      List<CompletableFuture<PrecedingSucceedingTitle>> succeedingTitleCompletableFutures =
+        relationsList.stream().filter(rel -> isSucceedingTitle(instance, rel))
+          .map(rel -> getPrecedingSucceedingTitle(routingContext, context, rel,
+            PrecedingSucceedingTitle.SUCCEEDING_INSTANCE_ID_KEY)).collect(Collectors.toList());
+
+      return completedFuture(instance)
+        .thenCompose(r -> withPrecedingTitles(instance, precedingTitleCompletableFutures))
+        .thenCompose(r -> withSucceedingTitles(instance, succeedingTitleCompletableFutures));
+    }
+    return completedFuture(null);
+  }
+
+  private boolean isPrecedingTitle(Instance instance, JsonObject rel) {
+    return instance.getId().equals(rel.getString(PrecedingSucceedingTitle.SUCCEEDING_INSTANCE_ID_KEY));
+  }
+
+  private boolean isSucceedingTitle(Instance instance, JsonObject rel) {
+    return instance.getId().equals(rel.getString(PrecedingSucceedingTitle.PRECEDING_INSTANCE_INSTANCE_ID_KEY));
+  }
+
+  private CompletionStage<Instance> withSucceedingTitles(Instance instance,
+    List<CompletableFuture<PrecedingSucceedingTitle>> succeedingTitleCompletableFutures) {
+    return allResultsOf(succeedingTitleCompletableFutures)
+      .thenApply(resultItem -> instance.setSucceedingTitles(resultItem));
+  }
+
+  private CompletableFuture<Instance> withPrecedingTitles(Instance instance,
+    List<CompletableFuture<PrecedingSucceedingTitle>> precedingTitleCompletableFutures) {
+    return allResultsOf(precedingTitleCompletableFutures)
+      .thenApply(resultItem -> instance.setPrecedingTitles(resultItem));
+  }
+
+  private CompletableFuture<PrecedingSucceedingTitle> getPrecedingSucceedingTitle(
+    RoutingContext routingContext, WebContext context, JsonObject rel, String precedingSucceedingKey) {
+    if (!StringUtils.isBlank(rel.getString(precedingSucceedingKey))) {
+      String precedingInstanceId = rel.getString(precedingSucceedingKey);
+      CompletableFuture<Success<Instance>> getInstanceFuture = new CompletableFuture<>();
+      storage
+        .getInstanceCollection(context).findById(precedingInstanceId, getInstanceFuture::complete,
+        FailureResponseConsumer.serverError(routingContext.response()));
+
+      return getInstanceFuture.thenApply(response -> {
+        Instance precedingInstance = response.getResult();
+        if (precedingInstance != null) {
+          return new PrecedingSucceedingTitle(rel,
+            precedingInstance.getTitle(),
+            precedingInstance.getHrid(),
+            new JsonArray(precedingInstance.getIdentifiers()));
+        } else {
+          return null;
+        }
+      });
+    } else {
+      return completedFuture(new PrecedingSucceedingTitle(rel));
+    }
+  }
 }

--- a/src/main/java/org/folio/inventory/resources/InstancesBatch.java
+++ b/src/main/java/org/folio/inventory/resources/InstancesBatch.java
@@ -76,7 +76,7 @@ public class InstancesBatch extends AbstractInstances {
             requestBody.getInteger(BATCH_RESPONSE_FIELD_TOTAL_RECORDS)));
 
           if (!createdInstances.isEmpty()) {
-            updateReletedRecords(validInstances, createdInstances, routingContext, webContext).
+            updateRelatedRecords(validInstances, createdInstances, routingContext, webContext).
               setHandler(ar -> {
                 JsonObject responseBody = getBatchResponse(createdInstances, errorMessages, webContext);
                 RedirectResponse.created(routingContext.response(), Buffer.buffer(responseBody.encodePrettily()));
@@ -177,8 +177,9 @@ public class InstancesBatch extends AbstractInstances {
    * @param routingContext routingContext
    * @param webContext webContext
    */
-  private Future<CompositeFuture> updateReletedRecords(List<JsonObject> newInstances, List<Instance> createdInstances,
-                                                               RoutingContext routingContext, WebContext webContext) {
+  private Future<CompositeFuture> updateRelatedRecords(List<JsonObject> newInstances, List<Instance> createdInstances,
+    RoutingContext routingContext, WebContext webContext) {
+
     Future<CompositeFuture> resultFuture = Future.future();
     try {
       Map<String, Instance> mapInstanceById = newInstances.stream()

--- a/src/main/java/org/folio/inventory/resources/InstancesResponse.java
+++ b/src/main/java/org/folio/inventory/resources/InstancesResponse.java
@@ -7,11 +7,12 @@ import org.folio.inventory.domain.instances.InstanceRelationshipToChild;
 import org.folio.inventory.domain.instances.InstanceRelationshipToParent;
 import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class InstancesResponseWrapper {
+public class InstancesResponse {
   private Success<MultipleRecords<Instance>> success;
   private Map<String, List<InstanceRelationshipToParent>> parentInstanceMap = new HashMap();
   private Map<String, List<InstanceRelationshipToChild>> childInstanceMap = new HashMap();
@@ -22,39 +23,52 @@ public class InstancesResponseWrapper {
     return success;
   }
 
-  public void setSuccess(Success<MultipleRecords<Instance>> success) {
+  public InstancesResponse setSuccess(Success<MultipleRecords<Instance>> success) {
     this.success = success;
+    return this;
   }
 
   public Map<String, List<InstanceRelationshipToParent>> getParentInstanceMap() {
-    return parentInstanceMap;
+    return Collections.unmodifiableMap(parentInstanceMap);
   }
 
-  public void setParentInstanceMap(Map<String, List<InstanceRelationshipToParent>> parentInstanceMap) {
+  public InstancesResponse setParentInstanceMap(
+    Map<String, List<InstanceRelationshipToParent>> parentInstanceMap) {
+
     this.parentInstanceMap = parentInstanceMap;
+    return this;
   }
 
   public Map<String, List<InstanceRelationshipToChild>> getChildInstanceMap() {
-    return childInstanceMap;
+    return Collections.unmodifiableMap(childInstanceMap);
   }
 
-  public void setChildInstanceMap(Map<String, List<InstanceRelationshipToChild>> childInstanceMap) {
+  public InstancesResponse setChildInstanceMap(
+    Map<String, List<InstanceRelationshipToChild>> childInstanceMap) {
+
     this.childInstanceMap = childInstanceMap;
+    return this;
   }
 
   public Map<String, List<PrecedingSucceedingTitle>> getPrecedingTitlesMap() {
-    return precedingTitlesMap;
+    return Collections.unmodifiableMap(precedingTitlesMap);
   }
 
-  public void setPrecedingTitlesMap(Map<String, List<PrecedingSucceedingTitle>> precedingTitlesMap) {
+  public InstancesResponse setPrecedingTitlesMap(
+    Map<String, List<PrecedingSucceedingTitle>> precedingTitlesMap) {
+
     this.precedingTitlesMap = precedingTitlesMap;
+    return this;
   }
 
   public Map<String, List<PrecedingSucceedingTitle>> getSucceedingTitlesMap() {
-    return succeedingTitlesMap;
+    return Collections.unmodifiableMap(succeedingTitlesMap);
   }
 
-  public void setSucceedingTitlesMap(Map<String, List<PrecedingSucceedingTitle>> succeedingTitlesMap) {
+  public InstancesResponse setSucceedingTitlesMap(
+    Map<String, List<PrecedingSucceedingTitle>> succeedingTitlesMap) {
+
     this.succeedingTitlesMap = succeedingTitlesMap;
+    return this;
   }
 }

--- a/src/main/java/org/folio/inventory/resources/InstancesResponseWrapper.java
+++ b/src/main/java/org/folio/inventory/resources/InstancesResponseWrapper.java
@@ -1,0 +1,60 @@
+package org.folio.inventory.resources;
+
+import org.folio.inventory.common.domain.MultipleRecords;
+import org.folio.inventory.common.domain.Success;
+import org.folio.inventory.domain.instances.Instance;
+import org.folio.inventory.domain.instances.InstanceRelationshipToChild;
+import org.folio.inventory.domain.instances.InstanceRelationshipToParent;
+import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class InstancesResponseWrapper {
+  private Success<MultipleRecords<Instance>> success;
+  private Map<String, List<InstanceRelationshipToParent>> parentInstanceMap = new HashMap();
+  private Map<String, List<InstanceRelationshipToChild>> childInstanceMap = new HashMap();
+  private Map<String, List<PrecedingSucceedingTitle>> precedingTitlesMap = new HashMap();
+  private Map<String, List<PrecedingSucceedingTitle>> succeedingTitlesMap = new HashMap();
+
+  public Success<MultipleRecords<Instance>> getSuccess() {
+    return success;
+  }
+
+  public void setSuccess(Success<MultipleRecords<Instance>> success) {
+    this.success = success;
+  }
+
+  public Map<String, List<InstanceRelationshipToParent>> getParentInstanceMap() {
+    return parentInstanceMap;
+  }
+
+  public void setParentInstanceMap(Map<String, List<InstanceRelationshipToParent>> parentInstanceMap) {
+    this.parentInstanceMap = parentInstanceMap;
+  }
+
+  public Map<String, List<InstanceRelationshipToChild>> getChildInstanceMap() {
+    return childInstanceMap;
+  }
+
+  public void setChildInstanceMap(Map<String, List<InstanceRelationshipToChild>> childInstanceMap) {
+    this.childInstanceMap = childInstanceMap;
+  }
+
+  public Map<String, List<PrecedingSucceedingTitle>> getPrecedingTitlesMap() {
+    return precedingTitlesMap;
+  }
+
+  public void setPrecedingTitlesMap(Map<String, List<PrecedingSucceedingTitle>> precedingTitlesMap) {
+    this.precedingTitlesMap = precedingTitlesMap;
+  }
+
+  public Map<String, List<PrecedingSucceedingTitle>> getSucceedingTitlesMap() {
+    return succeedingTitlesMap;
+  }
+
+  public void setSucceedingTitlesMap(Map<String, List<PrecedingSucceedingTitle>> succeedingTitlesMap) {
+    this.succeedingTitlesMap = succeedingTitlesMap;
+  }
+}

--- a/src/test/java/api/ApiTestSuite.java
+++ b/src/test/java/api/ApiTestSuite.java
@@ -39,7 +39,8 @@ import support.fakes.FakeOkapi;
   ModsIngestExamples.class,
   IsbnUtilsApiExamples.class,
   ItemAllowedStatusesSchemaTest.class,
-  TenantApiExamples.class
+  TenantApiExamples.class,
+  PrecedingSucceedingTitlesApiExamples.class
 })
 public class ApiTestSuite {
   public static final int INVENTORY_VERTICLE_TEST_PORT = 9603;

--- a/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
+++ b/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
@@ -16,9 +16,11 @@ import org.folio.inventory.support.http.client.Response;
 import org.junit.Test;
 
 import java.net.MalformedURLException;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
 
 public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
 
@@ -414,7 +416,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   private void verifyRelatedInstancePrecedingTitle(IndividualResource relatedInstance,
-                                                   IndividualResource createdInstance) throws MalformedURLException,
+    IndividualResource createdInstance) throws MalformedURLException,
     InterruptedException, ExecutionException, TimeoutException {
 
     Response response = instancesClient.getById(relatedInstance.getId());
@@ -424,7 +426,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   private void verifyRelatedInstanceSucceedingTitle(IndividualResource relatedInstance,
-                                                    IndividualResource createdInstance) throws MalformedURLException,
+    IndividualResource createdInstance) throws MalformedURLException,
     InterruptedException, ExecutionException, TimeoutException {
 
     Response response = instancesClient.getById(relatedInstance.getId());
@@ -452,8 +454,9 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
       .findFirst().get();
   }
 
-  private JsonArray getUnconnectedPrecedingSucceedingTitle(String id1,
-                                                           String id2) {
+  private JsonArray getUnconnectedPrecedingSucceedingTitle(
+    String id1, String id2) {
+
     JsonObject precedingSucceedingTitle1 = createSemanticWebUnconnectedTitle(id1);
     JsonObject precedingSucceedingTitle2 = createOpenBibliographyUnconnectedTitle(id2);
 
@@ -485,8 +488,9 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
           .put("value", "0262012103")));
   }
 
-  private void assertPrecedingSucceedingTitles(JsonObject actualPrecedingTitle, JsonObject expected, String precedingInstanceId,
-                                               String succeedingInstanceId) {
+  private void assertPrecedingSucceedingTitles(JsonObject actualPrecedingTitle,
+    JsonObject expected, String precedingInstanceId, String succeedingInstanceId) {
+
     assertThat(actualPrecedingTitle.getString("title"), is(expected.getString("title")));
     assertThat(actualPrecedingTitle.getString("hrid"), is(expected.getString("hrid")));
     assertThat(actualPrecedingTitle.getJsonArray("identifiers"), is(expected.getJsonArray("identifiers")));

--- a/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
+++ b/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
@@ -1,0 +1,496 @@
+package api;
+
+import static api.support.InstanceSamples.nod;
+import static api.support.InstanceSamples.smallAngryPlanet;
+import static api.support.InstanceSamples.taoOfPooh;
+import static api.support.InstanceSamples.uprooted;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import api.support.ApiTests;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.inventory.support.http.client.IndividualResource;
+import org.folio.inventory.support.http.client.Response;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
+
+  @Test
+  public void canCreateAnInstanceWithUnconnectedPrecedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    String precedingSucceedingTitleId1 = UUID.randomUUID().toString();
+    String precedingSucceedingTitleId2 = UUID.randomUUID().toString();
+    JsonArray precedingTitles = getUnconnectedPrecedingSucceedingTitle(
+      precedingSucceedingTitleId1, precedingSucceedingTitleId2);
+
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("precedingTitles", precedingTitles);
+
+    IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    JsonArray actualPrecedingTitles = createdInstance.getJson().getJsonArray("precedingTitles");
+    JsonObject actualPrecedingTitle1 = getRecordById(actualPrecedingTitles, precedingSucceedingTitleId1);
+    JsonObject actualPrecedingTitle2 = getRecordById(actualPrecedingTitles, precedingSucceedingTitleId2);
+
+    assertPrecedingSucceedingTitles(actualPrecedingTitle1, precedingTitles.getJsonObject(0), null,
+      createdInstance.getId().toString());
+    assertPrecedingSucceedingTitles(actualPrecedingTitle2, precedingTitles.getJsonObject(1), null,
+      createdInstance.getId().toString());
+  }
+
+  @Test
+  public void canCreateAnInstanceWithUnconnectedSucceedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    String precedingSucceedingTitleId1 = UUID.randomUUID().toString();
+    String precedingSucceedingTitleId2 = UUID.randomUUID().toString();
+    JsonArray succeedingTitles = getUnconnectedPrecedingSucceedingTitle(
+      precedingSucceedingTitleId1, precedingSucceedingTitleId2);
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("succeedingTitles", succeedingTitles);
+
+    IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    JsonArray actualSucceedingTitles = createdInstance.getJson().getJsonArray("succeedingTitles");
+    JsonObject actualSucceedingTitle1 = getRecordById(actualSucceedingTitles, precedingSucceedingTitleId1);
+    JsonObject actualSucceedingTitle2 = getRecordById(actualSucceedingTitles, precedingSucceedingTitleId2);
+
+    assertPrecedingSucceedingTitles(actualSucceedingTitle1, succeedingTitles.getJsonObject(0),
+      createdInstance.getId().toString(), null);
+    assertPrecedingSucceedingTitles(actualSucceedingTitle2, succeedingTitles.getJsonObject(1),
+      createdInstance.getId().toString(), null);
+  }
+
+  @Test
+  public void canUpdateAnInstanceWithUnconnectedPrecedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    JsonObject precedingTitle = createSemanticWebUnconnectedTitle(UUID.randomUUID().toString());
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("precedingTitles", new JsonArray().add(precedingTitle));
+
+    IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    JsonObject newPrecedingTitle = new JsonObject()
+      .put("title", "New title")
+      .put("hrid", "inst000000000101")
+      .put("identifiers", new JsonArray().add(
+        new JsonObject()
+          .put("identifierTypeId", "1231054f-be78-422d-bd51-4ed9f33c3422")
+          .put("value", "000012104")));
+
+    JsonObject newInstance = createdInstance.getJson().copy();
+    newInstance.put("precedingTitles", new JsonArray().add(newPrecedingTitle));
+
+    instancesClient.replace(createdInstance.getId(), newInstance);
+
+    Response instanceResponse = instancesClient.getById(createdInstance.getId());
+    assertPrecedingSucceedingTitles(instanceResponse.getJson().getJsonArray("precedingTitles")
+        .getJsonObject(0), newPrecedingTitle, null,
+      createdInstance.getId().toString());
+  }
+
+  @Test
+  public void canUpdateAnInstanceWithUnconnectedSucceedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    JsonObject succeedingTitle = createSemanticWebUnconnectedTitle(UUID.randomUUID().toString());
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("succeedingTitles", new JsonArray().add(succeedingTitle));
+
+    IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    JsonObject newSucceedingTitle = new JsonObject()
+      .put("title", "New title")
+      .put("hrid", "inst000000000022")
+      .put("identifiers", new JsonArray().add(
+        new JsonObject()
+          .put("identifierTypeId", "8261054f-be78-422d-bd51-4ed9f33c3422")
+          .put("value", "0262012103")));
+
+    JsonObject newInstance = createdInstance.getJson().copy();
+    newInstance.put("succeedingTitles", new JsonArray().add(newSucceedingTitle));
+
+    instancesClient.replace(createdInstance.getId(), newInstance);
+
+    Response instanceResponse = instancesClient.getById(createdInstance.getId());
+    assertPrecedingSucceedingTitles(instanceResponse.getJson().getJsonArray("succeedingTitles")
+        .getJsonObject(0), newSucceedingTitle, createdInstance.getId().toString(),
+      null);
+  }
+
+  @Test
+  public void canDeleteAnInstanceWithUnconnectedPrecedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    JsonObject precedingTitle = createSemanticWebUnconnectedTitle(UUID.randomUUID().toString());
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("precedingTitles", new JsonArray().add(precedingTitle));
+
+    IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    JsonObject newInstance = createdInstance.getJson().copy();
+    newInstance.put("precedingTitles", new JsonArray());
+
+    instancesClient.replace(createdInstance.getId(), newInstance);
+
+    Response instanceResponse = instancesClient.getById(createdInstance.getId());
+    assertThat(instanceResponse.getJson().getJsonArray("precedingTitles"), is(new JsonArray()));
+  }
+
+  @Test
+  public void canDeleteAnInstanceWithUnconnectedSucceedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    JsonObject succeedingTitles = createSemanticWebUnconnectedTitle(UUID.randomUUID().toString());
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("succeedingTitles", new JsonArray().add(succeedingTitles));
+
+    IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    JsonObject newInstance = createdInstance.getJson().copy();
+    newInstance.put("succeedingTitles", new JsonArray());
+
+    instancesClient.replace(createdInstance.getId(), newInstance);
+
+    Response instanceResponse = instancesClient.getById(createdInstance.getId());
+    assertThat(instanceResponse.getJson().getJsonArray("succeedingTitles"), is(new JsonArray()));
+  }
+
+  @Test
+  public void canCreateAnInstanceWithConnectedPrecedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    UUID nodId = UUID.randomUUID();
+    UUID uprootedId = UUID.randomUUID();
+    String nodPrecedingTitleId = UUID.randomUUID().toString();
+    String uprootedPrecedingTitleId = UUID.randomUUID().toString();
+    IndividualResource nod = instancesClient.create(nod(nodId));
+    IndividualResource uprooted = instancesClient.create(uprooted(uprootedId));
+
+    JsonObject nodPrecedingTitle = createConnectedPrecedingTitle(nodPrecedingTitleId, nodId.toString());
+    JsonObject uprootedPrecedingTitle = createConnectedPrecedingTitle(uprootedPrecedingTitleId, uprootedId.toString());
+
+    JsonArray precedingTitles = new JsonArray()
+      .add(nodPrecedingTitle).add(uprootedPrecedingTitle);
+
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("precedingTitles", precedingTitles);
+
+    IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    JsonArray actualPrecedingTitles = createdInstance.getJson().getJsonArray("precedingTitles");
+    JsonObject actualPrecedingTitle1 = getRecordById(actualPrecedingTitles, nodPrecedingTitleId);
+    JsonObject actualPrecedingTitle2 = getRecordById(actualPrecedingTitles, uprootedPrecedingTitleId);
+
+    assertPrecedingSucceedingTitles(actualPrecedingTitle1, nod.getJson(), nod.getId().toString(),
+      createdInstance.getId().toString());
+    assertPrecedingSucceedingTitles(actualPrecedingTitle2, uprooted.getJson(), uprooted.getId().toString(),
+      createdInstance.getId().toString());
+
+    verifyRelatedInstanceSucceedingTitle(nod, createdInstance);
+    verifyRelatedInstanceSucceedingTitle(uprooted, createdInstance);
+  }
+
+  @Test
+  public void canCreateAnInstanceWithConnectedSucceedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    UUID nodId = UUID.randomUUID();
+    UUID uprootedId = UUID.randomUUID();
+    String nodPrecedingTitleId = UUID.randomUUID().toString();
+    String uprootedPrecedingTitleId = UUID.randomUUID().toString();
+    IndividualResource nod = instancesClient.create(nod(nodId));
+    IndividualResource uprooted = instancesClient.create(uprooted(uprootedId));
+
+    JsonObject nodSucceedingTitle = createConnectedSucceedingTitle(nodPrecedingTitleId, nodId.toString());
+    JsonObject uprootedSucceedingTitle = createConnectedSucceedingTitle(uprootedPrecedingTitleId, uprootedId.toString());
+
+    JsonArray succeedingTitles = new JsonArray()
+      .add(nodSucceedingTitle).add(uprootedSucceedingTitle);
+
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("succeedingTitles", succeedingTitles);
+
+    IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    JsonArray actualSucceedingTitles = createdInstance.getJson().getJsonArray("succeedingTitles");
+    JsonObject actualSucceedingTitle1 = getRecordById(actualSucceedingTitles, nodPrecedingTitleId);
+    JsonObject actualSucceedingTitle2 = getRecordById(actualSucceedingTitles, uprootedPrecedingTitleId);
+
+    assertPrecedingSucceedingTitles(actualSucceedingTitle1, nod.getJson(),
+      createdInstance.getId().toString(), nod.getId().toString());
+    assertPrecedingSucceedingTitles(actualSucceedingTitle2, uprooted.getJson(),
+      createdInstance.getId().toString(), uprooted.getId().toString());
+
+    verifyRelatedInstancePrecedingTitle(nod, createdInstance);
+    verifyRelatedInstancePrecedingTitle(uprooted, createdInstance);
+  }
+
+  @Test
+  public void canUpdateAnInstanceWithConnectedPrecedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    UUID nodId = UUID.randomUUID();
+    UUID uprootedId = UUID.randomUUID();
+    String nodPrecedingTitleId = UUID.randomUUID().toString();
+    String uprootedPrecedingTitleId = UUID.randomUUID().toString();
+    IndividualResource nod = instancesClient.create(nod(nodId));
+    IndividualResource uprooted = instancesClient.create(uprooted(uprootedId));
+
+    JsonObject nodPrecedingTitle = createConnectedPrecedingTitle(nodPrecedingTitleId, nodId.toString());
+    JsonObject uprootedPrecedingTitle = createConnectedPrecedingTitle(uprootedPrecedingTitleId, uprootedId.toString());
+
+    JsonArray precedingTitles = new JsonArray()
+      .add(nodPrecedingTitle).add(uprootedPrecedingTitle);
+
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("precedingTitles", precedingTitles);
+
+    IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    IndividualResource taoOfPooh = instancesClient.create(taoOfPooh(uprootedId));
+    JsonObject newInstance = createdInstance.getJson().copy();
+    JsonObject taoOfPoohPrecedingTitle = createConnectedPrecedingTitle(UUID.randomUUID().toString(), taoOfPooh
+      .getId().toString());
+    newInstance.put("precedingTitles", new JsonArray()
+      .add(taoOfPoohPrecedingTitle));
+
+    instancesClient.replace(createdInstance.getId(), newInstance);
+
+    verifyRelatedInstancePrecedingTitle(createdInstance, taoOfPooh);
+    verifyRelatedInstanceSucceedingTitle(taoOfPooh, createdInstance);
+  }
+
+  @Test
+  public void canUpdateAnInstanceWithConnectedSucceedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    UUID nodId = UUID.randomUUID();
+    UUID uprootedId = UUID.randomUUID();
+    String nodPrecedingTitleId = UUID.randomUUID().toString();
+    String uprootedPrecedingTitleId = UUID.randomUUID().toString();
+    IndividualResource nod = instancesClient.create(nod(nodId));
+    IndividualResource uprooted = instancesClient.create(uprooted(uprootedId));
+
+    JsonObject nodSucceedingTitle = createConnectedSucceedingTitle(nodPrecedingTitleId, nodId.toString());
+    JsonObject uprootedSucceedingTitle = createConnectedSucceedingTitle(uprootedPrecedingTitleId, uprootedId.toString());
+
+    JsonArray succeedingTitles = new JsonArray()
+      .add(nodSucceedingTitle).add(uprootedSucceedingTitle);
+
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("succeedingTitles", succeedingTitles);
+
+    IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    IndividualResource taoOfPooh = instancesClient.create(taoOfPooh(uprootedId));
+    JsonObject newInstance = createdInstance.getJson().copy();
+    JsonObject taoOfPoohPrecedingTitle = createConnectedSucceedingTitle(UUID.randomUUID().toString(), taoOfPooh
+      .getId().toString());
+    newInstance.put("succeedingTitles", new JsonArray()
+      .add(taoOfPoohPrecedingTitle));
+
+    instancesClient.replace(createdInstance.getId(), newInstance);
+
+    verifyRelatedInstanceSucceedingTitle(createdInstance, taoOfPooh);
+    verifyRelatedInstancePrecedingTitle(taoOfPooh, createdInstance);
+  }
+
+  @Test
+  public void canCreateAnInstanceWithConnectedSucceedingAndPrecedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    UUID nodId = UUID.randomUUID();
+    UUID uprootedId = UUID.randomUUID();
+    String nodPrecedingTitleId = UUID.randomUUID().toString();
+    String uprootedSucceedingTitleId = UUID.randomUUID().toString();
+    IndividualResource nod = instancesClient.create(nod(nodId));
+    IndividualResource uprooted = instancesClient.create(uprooted(uprootedId));
+
+    JsonObject nodPrecedingTitle = createConnectedPrecedingTitle(nodPrecedingTitleId, nodId.toString());
+    JsonObject uprootedSucceedingTitle = createConnectedSucceedingTitle(uprootedSucceedingTitleId, uprootedId.toString());
+
+    String unconnectedSucceedingTitleId = UUID.randomUUID().toString();
+    String unconnectedPrecedingTitleId = UUID.randomUUID().toString();
+
+    JsonObject unconnectedSucceedingTitle = createSemanticWebUnconnectedTitle(unconnectedSucceedingTitleId);
+    JsonObject unconnectedPrecedingTitle = createOpenBibliographyUnconnectedTitle(unconnectedPrecedingTitleId);
+
+    JsonArray precedingTitles = new JsonArray()
+      .add(nodPrecedingTitle).add(unconnectedPrecedingTitle);
+    JsonArray succeedingTitles = new JsonArray()
+      .add(uprootedSucceedingTitle).add(unconnectedSucceedingTitle);
+
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("precedingTitles", precedingTitles);
+    smallAngryPlanetJson.put("succeedingTitles", succeedingTitles);
+
+    IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    JsonArray actualPrecedingTitles = createdInstance.getJson().getJsonArray("precedingTitles");
+    JsonObject actualPrecedingTitle1 = getRecordById(actualPrecedingTitles, nodPrecedingTitleId);
+    JsonObject actualPrecedingTitle2 = getRecordById(actualPrecedingTitles, unconnectedPrecedingTitleId);
+
+    assertPrecedingSucceedingTitles(actualPrecedingTitle1, nod.getJson(), nod.getId().toString(),
+      createdInstance.getId().toString());
+    assertPrecedingSucceedingTitles(actualPrecedingTitle2, unconnectedPrecedingTitle,
+      null, createdInstance.getId().toString());
+
+    JsonArray actualSucceedingTitles = createdInstance.getJson().getJsonArray("succeedingTitles");
+    JsonObject actualSucceedingTitle1 = getRecordById(actualSucceedingTitles, uprootedSucceedingTitleId);
+    JsonObject actualSucceedingTitle2 = getRecordById(actualSucceedingTitles, unconnectedSucceedingTitleId);
+
+    assertPrecedingSucceedingTitles(actualSucceedingTitle1, uprooted.getJson(),
+      createdInstance.getId().toString(), uprooted.getId().toString());
+    assertPrecedingSucceedingTitles(actualSucceedingTitle2, unconnectedSucceedingTitle,
+      createdInstance.getId().toString(), null);
+
+    verifyRelatedInstancePrecedingTitle(uprooted, createdInstance);
+    verifyRelatedInstanceSucceedingTitle(nod, createdInstance);
+  }
+
+  @Test
+  public void canCreateBatchOfInstancesWithPrecedingSucceedingTitles()
+    throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+    String precedingSucceedingTitleId1 = UUID.randomUUID().toString();
+    String precedingSucceedingTitleId2 = UUID.randomUUID().toString();
+    JsonArray precedingTitles = getUnconnectedPrecedingSucceedingTitle(
+      precedingSucceedingTitleId1, precedingSucceedingTitleId2);
+
+    UUID angryPlanetId = UUID.randomUUID();
+    JsonObject angryPlanet = smallAngryPlanet(angryPlanetId)
+      .put("precedingTitles", precedingTitles);
+
+    String succeedingConnectedTitleId = UUID.randomUUID().toString();
+    JsonObject succeedingConnectedTitle = createConnectedSucceedingTitle(
+      succeedingConnectedTitleId, angryPlanetId.toString());
+    UUID uprootedId = UUID.randomUUID();
+    JsonObject uprooted = uprooted(uprootedId)
+      .put("succeedingTitles", new JsonArray().add(succeedingConnectedTitle));
+    JsonObject request = new JsonObject();
+    request.put("instances", new JsonArray().add(angryPlanet).add(uprooted));
+    request.put("totalRecords", 2);
+
+    instancesBatchClient.create(request);
+
+    Response createdAngryPlanet = instancesClient.getById(angryPlanetId);
+    Response createdUprooted = instancesClient.getById(uprootedId);
+
+    JsonArray actualPrecedingTitles = createdAngryPlanet.getJson().getJsonArray("precedingTitles");
+    JsonObject actualPrecedingTitle1 = getRecordById(actualPrecedingTitles, precedingSucceedingTitleId1);
+    JsonObject actualPrecedingTitle2 = getRecordById(actualPrecedingTitles, precedingSucceedingTitleId2);
+    JsonObject actualPrecedingTitle3 = getRecordById(actualPrecedingTitles, succeedingConnectedTitleId);
+
+    assertPrecedingSucceedingTitles(actualPrecedingTitle1, precedingTitles.getJsonObject(0), null,
+      angryPlanetId.toString());
+    assertPrecedingSucceedingTitles(actualPrecedingTitle2, precedingTitles.getJsonObject(1), null,
+      angryPlanetId.toString());
+    assertPrecedingSucceedingTitles(actualPrecedingTitle3, createdUprooted.getJson(), uprootedId.toString(),
+      angryPlanetId.toString());
+
+    JsonArray succeedingTitles = createdUprooted.getJson().getJsonArray("succeedingTitles");
+    assertPrecedingSucceedingTitles(succeedingTitles.getJsonObject(0), createdAngryPlanet.getJson(),
+      uprootedId.toString(), angryPlanetId.toString());
+  }
+
+  private void verifyRelatedInstancePrecedingTitle(IndividualResource relatedInstance,
+                                                   IndividualResource createdInstance) throws MalformedURLException,
+    InterruptedException, ExecutionException, TimeoutException {
+
+    Response response = instancesClient.getById(relatedInstance.getId());
+    JsonArray succeedingTitles = response.getJson().getJsonArray("precedingTitles");
+    assertPrecedingSucceedingTitles(succeedingTitles.getJsonObject(0), createdInstance.getJson(),
+      createdInstance.getId().toString(), relatedInstance.getId().toString());
+  }
+
+  private void verifyRelatedInstanceSucceedingTitle(IndividualResource relatedInstance,
+                                                    IndividualResource createdInstance) throws MalformedURLException,
+    InterruptedException, ExecutionException, TimeoutException {
+
+    Response response = instancesClient.getById(relatedInstance.getId());
+    JsonArray succeedingTitles = response.getJson().getJsonArray("succeedingTitles");
+    assertPrecedingSucceedingTitles(succeedingTitles.getJsonObject(0), createdInstance.getJson(),
+      relatedInstance.getId().toString(), createdInstance.getId().toString());
+  }
+
+  private JsonObject createConnectedPrecedingTitle(String id, String precedingInstanceId) {
+    return new JsonObject()
+      .put("id", id)
+      .put("precedingInstanceId", precedingInstanceId);
+  }
+
+  private JsonObject createConnectedSucceedingTitle(String id, String succeedingInstanceId) {
+    return new JsonObject()
+      .put("id", id)
+      .put("succeedingInstanceId", succeedingInstanceId);
+  }
+
+  private JsonObject getRecordById(JsonArray collection, String id) {
+    return collection.stream()
+      .map(index -> (JsonObject) index)
+      .filter(request -> StringUtils.equals(request.getString("id"), id))
+      .findFirst().get();
+  }
+
+  private JsonArray getUnconnectedPrecedingSucceedingTitle(String id1,
+                                                           String id2) {
+    JsonObject precedingSucceedingTitle1 = createSemanticWebUnconnectedTitle(id1);
+    JsonObject precedingSucceedingTitle2 = createOpenBibliographyUnconnectedTitle(id2);
+
+    JsonArray precedingSucceedingTitles = new JsonArray();
+    precedingSucceedingTitles.add(precedingSucceedingTitle1);
+    precedingSucceedingTitles.add(precedingSucceedingTitle2);
+    return precedingSucceedingTitles;
+  }
+
+  private JsonObject createOpenBibliographyUnconnectedTitle(String precedingSucceedingTitleId2) {
+    return new JsonObject()
+      .put("id", precedingSucceedingTitleId2)
+      .put("title", "Open Bibliography for Science, Technology and Medicine")
+      .put("hrid", "inst000000000555")
+      .put("identifiers", new JsonArray().add(
+        new JsonObject()
+          .put("identifierTypeId", "8261054f-be78-422d-bd51-4ed9f33c8012")
+          .put("value", "0662012103")));
+  }
+
+  private JsonObject createSemanticWebUnconnectedTitle(String precedingSucceedingTitleId1) {
+    return new JsonObject()
+      .put("id", precedingSucceedingTitleId1)
+      .put("title", "A semantic web prime")
+      .put("hrid", "inst000000000022")
+      .put("identifiers", new JsonArray().add(
+        new JsonObject()
+          .put("identifierTypeId", "8261054f-be78-422d-bd51-4ed9f33c3422")
+          .put("value", "0262012103")));
+  }
+
+  private void assertPrecedingSucceedingTitles(JsonObject actualPrecedingTitle, JsonObject expected, String precedingInstanceId,
+                                               String succeedingInstanceId) {
+    assertThat(actualPrecedingTitle.getString("title"), is(expected.getString("title")));
+    assertThat(actualPrecedingTitle.getString("hrid"), is(expected.getString("hrid")));
+    assertThat(actualPrecedingTitle.getJsonArray("identifiers"), is(expected.getJsonArray("identifiers")));
+    assertThat(actualPrecedingTitle.getString("precedingInstanceId"), is(precedingInstanceId));
+    assertThat(actualPrecedingTitle.getString("succeedingInstanceId"), is(succeedingInstanceId));
+  }
+}

--- a/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
+++ b/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
@@ -134,7 +134,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   @Test
-  public void canDeleteAnInstanceWithUnconnectedPrecedingTitles()
+  public void canDeleteUnconnectedPrecedingTitle()
     throws InterruptedException, MalformedURLException, TimeoutException,
     ExecutionException {
 
@@ -154,7 +154,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   @Test
-  public void canDeleteAnInstanceWithUnconnectedSucceedingTitles()
+  public void canDeleteUnconnectedSucceedingTitle()
     throws InterruptedException, MalformedURLException, TimeoutException,
     ExecutionException {
 

--- a/src/test/java/api/support/ApiTests.java
+++ b/src/test/java/api/support/ApiTests.java
@@ -21,6 +21,7 @@ public abstract class ApiTests {
   protected final ResourceClient instancesClient;
   protected final ResourceClient isbnClient;
   protected final ResourceClient usersClient;
+  protected final ResourceClient instancesBatchClient;
 
   public ApiTests() {
     holdingsStorageClient = ResourceClient.forHoldingsStorage(okapiClient);
@@ -29,6 +30,7 @@ public abstract class ApiTests {
     instancesClient = ResourceClient.forInstances(okapiClient);
     isbnClient = ResourceClient.forIsbns(okapiClient);
     usersClient = ResourceClient.forUsers(okapiClient);
+    instancesBatchClient = ResourceClient.forInstancesBatch(okapiClient);
   }
 
   @BeforeClass

--- a/src/test/java/api/support/http/BusinessLogicInterfaceUrls.java
+++ b/src/test/java/api/support/http/BusinessLogicInterfaceUrls.java
@@ -14,6 +14,10 @@ public class BusinessLogicInterfaceUrls {
     return getUrl("/inventory/instances", subPath);
   }
 
+  public static URL instancesBatch(String subPath) {
+    return getUrl("/inventory/instances/batch", subPath);
+  }
+
   public static URL isbns(String subPath) {
     return getUrl("/isbn", subPath);
   }

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -55,6 +55,11 @@ public class ResourceClient {
       "instances");
   }
 
+  public static ResourceClient forInstancesBatch(OkapiHttpClient client) {
+    return new ResourceClient(client, BusinessLogicInterfaceUrls::instancesBatch,
+      "instances");
+  }
+
   public static ResourceClient forInstitutions(OkapiHttpClient client) {
     return new ResourceClient(client, StorageInterfaceUrls::institutionsStorageUrl,
       "institutions", "locinsts");

--- a/src/test/java/support/fakes/FakeOkapi.java
+++ b/src/test/java/support/fakes/FakeOkapi.java
@@ -3,7 +3,6 @@ package support.fakes;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServer;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import support.fakes.processors.StorageRecordPreProcessors;
 
@@ -83,6 +82,12 @@ public class FakeOkapi extends AbstractVerticle {
       .withRootPath("/instance-storage/instance-relationships")
       .withCollectionPropertyName("instanceRelationships")
       .withRequiredProperties("superInstanceId", "subInstanceId", "instanceRelationshipTypeId")
+      .create().register(router);
+
+    new FakeStorageModuleBuilder()
+      .withRecordName("preceding succeeding titles")
+      .withRootPath("/preceding-succeeding-titles")
+      .withCollectionPropertyName("precedingSucceedingTitles")
       .create().register(router);
   }
 


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-198

- create new fields: precedingTitles and succeedingTitles in instance endpoints
- get, add, edit and delete preceding/succeeding titles using /inventory-storage/preceding-succeeding-titles endpoints