### PR TITLE
MODINVSTOR-456 Add the missing permission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -83,6 +83,7 @@
           "permissionsRequired": ["inventory.instances.collection.get"],
           "modulePermissions": [
             "inventory-storage.instances.collection.get",
+            "inventory-storage.instances.item.get",
             "inventory-storage.preceding-succeeding-titles.collection.get"]
         }, {
           "methods": ["GET"],


### PR DESCRIPTION
Need to add the missing permission "inventory-storage.instances.item.get" to 
GET /inventory/instances

https://issues.folio.org/browse/MODINVSTOR-456
