### PR TITLE
MODINV-215 Exception handling for /inventory/instances endpoints

### DIFF
--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -6,14 +6,12 @@ import static org.folio.inventory.common.FutureAssistance.allOf;
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.folio.inventory.common.WebContext;
@@ -183,8 +181,9 @@ public abstract class AbstractInstances {
    Map<String, T> existingObjects, Map<String, T> updatingObjects) {
 
     return existingObjects.keySet().stream()
-      .filter(key -> !updatingObjects.containsKey(key)).map(existingKey ->
-        resourceClient.delete(existingKey)).collect(Collectors.toList());
+      .filter(key -> !updatingObjects.containsKey(key))
+      .map(resourceClient::delete)
+      .collect(Collectors.toList());
   }
 
   private <T> List<CompletableFuture<Response>> createOrEdit(

--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -520,7 +520,7 @@ public abstract class AbstractInstances {
 
   protected String createQueryForRelatedInstances(List<String> instanceIds) {
     String idList = instanceIds.stream().distinct().collect(Collectors.joining(" or "));
-    String query = format("query=(subInstanceId==(%s)+or+superInstanceId==(%s))", idList, idList);
+    String query = format("query=subInstanceId==(%s)+or+superInstanceId==(%s)", idList, idList);
     return query;
   }
 

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -173,16 +173,22 @@ public class Instances extends AbstractInstances {
         response.setPrecedingTitles(newInstance.getPrecedingTitles());
         response.setSucceedingTitles(newInstance.getSucceedingTitles());
 
-        updateRelatedRecords(routingContext, context, response, r -> {
-          try {
-            URL url = context.absoluteUrl(format("%s/%s",
-              INSTANCES_PATH, response.getId()));
-            RedirectResponse.created(routingContext.response(), url.toString());
-          } catch (MalformedURLException e) {
-            log.warn(
-              format("Failed to create self link for instance: %s", e.toString()));
-          }
-        });
+        updateRelatedRecords(routingContext, context, response)
+          .whenComplete((r, ex) -> {
+            if (ex != null) {
+              log.warn("Exception occurred", ex);
+              handleFailure(getKnownException(ex), routingContext);
+            } else {
+              try {
+                URL url = context.absoluteUrl(format("%s/%s",
+                  INSTANCES_PATH, response.getId()));
+                RedirectResponse.created(routingContext.response(), url.toString());
+              } catch (MalformedURLException e) {
+                log.warn(
+                  format("Failed to create self link for instance: %s", e.toString()));
+              }
+            }
+          });
       }, FailureResponseConsumer.serverError(routingContext.response()));
   }
 
@@ -267,7 +273,15 @@ public class Instances extends AbstractInstances {
     instanceCollection.update(
       instance,
       v -> {
-        updateRelatedRecords(rContext, wContext, instance, x -> noContent(rContext.response()));
+        updateRelatedRecords(rContext, wContext, instance)
+          .whenComplete((result, ex) -> {
+            if (ex != null) {
+              log.warn("Exception occurred", ex);
+              handleFailure(getKnownException(ex), rContext);
+            } else {
+              noContent(rContext.response());
+            }
+          });
         if (isInstanceControlledByRecord(instance)) {
           updateSuppressFromDiscoveryFlag(wContext, instance);
         }

--- a/src/main/java/org/folio/inventory/resources/InstancesBatch.java
+++ b/src/main/java/org/folio/inventory/resources/InstancesBatch.java
@@ -209,7 +209,7 @@ public class InstancesBatch extends AbstractInstances {
             });
         }
       }
-      resultFuture.handle(CompositeFuture.join(updateRelationshipsFutures));
+      CompositeFuture.join(updateRelationshipsFutures).setHandler(resultFuture);
     } catch (IllegalStateException e) {
       log.error("Can not update instances relationships cause: " + e);
       resultFuture.fail(e);

--- a/src/main/java/org/folio/inventory/storage/external/CollectionResourceRepository.java
+++ b/src/main/java/org/folio/inventory/storage/external/CollectionResourceRepository.java
@@ -1,29 +1,28 @@
 package org.folio.inventory.storage.external;
 
 import org.folio.inventory.storage.external.exceptions.ExternalResourceFetchException;
-import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.inventory.support.http.client.Response;
 
-import java.net.URL;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
-public class CollectionResourceRepository extends CollectionResourceClient{
+public class CollectionResourceRepository {
 
-  public CollectionResourceRepository(OkapiHttpClient client, URL collectionRoot) {
-    super(client, collectionRoot);
+  private CollectionResourceClient resourceClient;
+
+  public CollectionResourceRepository(CollectionResourceClient resourceClient) {
+    this.resourceClient = resourceClient;
   }
 
   public CompletableFuture<Response> post(Object resourceRepresentation) {
     CompletableFuture<Response> future = new CompletableFuture<>();
-    post(resourceRepresentation, future::complete);
+    resourceClient.post(resourceRepresentation, future::complete);
 
     return future.thenCompose(response ->  handleResponse(response, 201));
   }
 
   public CompletableFuture<Response> put(String id, Object resourceRepresentation) {
     CompletableFuture<Response> future = new CompletableFuture<>();
-    put(id, resourceRepresentation, future::complete);
+    resourceClient.put(id, resourceRepresentation, future::complete);
 
     return future.thenCompose(response ->  handleResponse(response, 204));
   }
@@ -31,12 +30,12 @@ public class CollectionResourceRepository extends CollectionResourceClient{
   public CompletableFuture<Response> delete(String id) {
     CompletableFuture<Response> future = new CompletableFuture<>();
 
-    delete(id, future::complete);
+    resourceClient.delete(id, future::complete);
 
     return future.thenCompose(response -> handleResponse(response, 204));
   }
 
-  private CompletionStage<Response> handleResponse(Response response,
+  private CompletableFuture<Response> handleResponse(Response response,
     int expectedStatusCode) {
 
     if (response.getStatusCode() != expectedStatusCode) {

--- a/src/main/java/org/folio/inventory/storage/external/CollectionResourceRepository.java
+++ b/src/main/java/org/folio/inventory/storage/external/CollectionResourceRepository.java
@@ -1,0 +1,51 @@
+package org.folio.inventory.storage.external;
+
+import org.folio.inventory.storage.external.exceptions.ExternalResourceFetchException;
+import org.folio.inventory.support.http.client.OkapiHttpClient;
+import org.folio.inventory.support.http.client.Response;
+
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class CollectionResourceRepository extends CollectionResourceClient{
+
+  public CollectionResourceRepository(OkapiHttpClient client, URL collectionRoot) {
+    super(client, collectionRoot);
+  }
+
+  public CompletableFuture<Response> post(Object resourceRepresentation) {
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    post(resourceRepresentation, future::complete);
+
+    return future.thenCompose(response ->  handleResponse(response, 201));
+  }
+
+  public CompletableFuture<Response> put(String id, Object resourceRepresentation) {
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    put(id, resourceRepresentation, future::complete);
+
+    return future.thenCompose(response ->  handleResponse(response, 204));
+  }
+
+  public CompletableFuture<Response> delete(String id) {
+    CompletableFuture<Response> future = new CompletableFuture<>();
+
+    delete(id, future::complete);
+
+    return future.thenCompose(response -> handleResponse(response, 204));
+  }
+
+  private CompletionStage<Response> handleResponse(Response response,
+    int expectedStatusCode) {
+
+    if (response.getStatusCode() != expectedStatusCode) {
+      final CompletableFuture<Response> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new ExternalResourceFetchException(response));
+
+      return failed;
+    }
+
+    return CompletableFuture.completedFuture(response);
+  }
+}

--- a/src/main/java/org/folio/inventory/validation/exceptions/UnprocessableEntityException.java
+++ b/src/main/java/org/folio/inventory/validation/exceptions/UnprocessableEntityException.java
@@ -1,11 +1,13 @@
 package org.folio.inventory.validation.exceptions;
 
+import org.folio.inventory.exceptions.AbstractInventoryException;
 import org.folio.inventory.support.http.server.ValidationError;
 
-public class UnprocessableEntityException extends Exception {
+public class UnprocessableEntityException extends AbstractInventoryException {
   private final ValidationError validationError;
 
   public UnprocessableEntityException(ValidationError validationError) {
+    super(validationError.message);
     this.validationError = validationError;
   }
 

--- a/src/test/java/api/InstanceRelationshipsTest.java
+++ b/src/test/java/api/InstanceRelationshipsTest.java
@@ -5,6 +5,7 @@ import static api.support.InstanceSamples.smallAngryPlanet;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static support.matchers.ResponseMatchers.hasValidationError;
 
 import java.net.MalformedURLException;
 import java.util.HashMap;
@@ -16,7 +17,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import io.vertx.core.http.HttpMethod;
 import org.folio.inventory.support.http.client.IndividualResource;
 import org.folio.inventory.support.http.client.Response;
 import org.joda.time.DateTime;
@@ -24,6 +24,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import api.support.ApiTests;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import support.fakes.EndpointFailureDescriptor;
@@ -146,18 +147,7 @@ public class InstanceRelationshipsTest extends ApiTests {
     throws InterruptedException, MalformedURLException, TimeoutException,
     ExecutionException {
 
-    String precedingTitleId = UUID.randomUUID().toString();
-    final JsonObject expectedErrorResponse = new JsonObject()
-      .put("message", String.format("Cannot set preceding_succeeding_title.precedinginstanceid = " +
-        "%s because it does not exist in instance.id.", precedingTitleId));
-    precedingSucceedingTitlesClient.emulateFailure(
-      new EndpointFailureDescriptor()
-        .setFailureExpireDate(DateTime.now().plusSeconds(2).toDate())
-        .setStatusCode(422)
-        .setContentType("application/json")
-        .setBody(expectedErrorResponse.toString())
-        .setMethod(HttpMethod.POST));
-
+    final String precedingTitleId = UUID.randomUUID().toString();
     JsonObject precedingTitle = new JsonObject()
       .put("id", UUID.randomUUID().toString())
       .put("precedingInstanceId", precedingTitleId);
@@ -169,9 +159,8 @@ public class InstanceRelationshipsTest extends ApiTests {
 
     Response response = instancesClient.attemptToCreate(smallAngryPlanetJson);
 
-    assertThat(response.getStatusCode(), is(422));
-    assertThat(response.getContentType(), is("application/json"));
-    assertThat(response.getJson(), is(expectedErrorResponse));
+    assertThat(response, hasValidationError("Preceding instance does not exist",
+      "precedingInstanceId", precedingTitleId));
   }
 
   @Test
@@ -179,18 +168,7 @@ public class InstanceRelationshipsTest extends ApiTests {
     throws InterruptedException, MalformedURLException, TimeoutException,
     ExecutionException {
 
-    String succeedingTitleId = UUID.randomUUID().toString();
-    final JsonObject expectedErrorResponse = new JsonObject()
-      .put("message", String.format("Cannot set preceding_succeeding_title.succeedinginstanceid = " +
-        "%s because it does not exist in instance.id.", succeedingTitleId));
-    precedingSucceedingTitlesClient.emulateFailure(
-      new EndpointFailureDescriptor()
-        .setFailureExpireDate(DateTime.now().plusSeconds(2).toDate())
-        .setStatusCode(422)
-        .setContentType("application/json")
-        .setBody(expectedErrorResponse.toString())
-        .setMethod(HttpMethod.POST));
-
+    final String succeedingTitleId = UUID.randomUUID().toString();
     JsonObject succeedingTitle = new JsonObject()
       .put("id", UUID.randomUUID().toString())
       .put("succeedingInstanceId", succeedingTitleId);
@@ -202,9 +180,8 @@ public class InstanceRelationshipsTest extends ApiTests {
 
     Response response = instancesClient.attemptToCreate(smallAngryPlanetJson);
 
-    assertThat(response.getStatusCode(), is(422));
-    assertThat(response.getContentType(), is("application/json"));
-    assertThat(response.getJson(), is(expectedErrorResponse));
+    assertThat(response, hasValidationError("Succeeding instance does not exist",
+      "succeedingInstanceId", succeedingTitleId));
   }
 
   @Test
@@ -212,20 +189,10 @@ public class InstanceRelationshipsTest extends ApiTests {
     throws InterruptedException, MalformedURLException, TimeoutException,
     ExecutionException {
 
-    String superInstanceId = UUID.randomUUID().toString();
-    final JsonObject expectedErrorResponse = new JsonObject()
-      .put("message", String.format("Cannot set instance_relationship.superInstanceId = " +
-        "%s because it does not exist in instance.id.", superInstanceId));
-    instanceRelationshipClient.emulateFailure(
-      new EndpointFailureDescriptor()
-        .setFailureExpireDate(DateTime.now().plusSeconds(2).toDate())
-        .setStatusCode(422)
-        .setContentType("application/json")
-        .setBody(expectedErrorResponse.toString())
-        .setMethod(HttpMethod.POST));
-
+    final String superInstanceId = UUID.randomUUID().toString();
     JsonObject parentInstance = new JsonObject()
       .put("id", UUID.randomUUID().toString())
+      .put("instanceRelationshipTypeId", instanceRelationshipTypeFixture.monographicSeries().getId())
       .put("superInstanceId", superInstanceId);
 
     JsonArray parentInstances = new JsonArray().add(parentInstance);
@@ -235,9 +202,8 @@ public class InstanceRelationshipsTest extends ApiTests {
 
     Response response = instancesClient.attemptToCreate(smallAngryPlanetJson);
 
-    assertThat(response.getStatusCode(), is(422));
-    assertThat(response.getContentType(), is("application/json"));
-    assertThat(response.getJson(), is(expectedErrorResponse));
+    assertThat(response, hasValidationError("Super instance does not exist",
+      "superInstanceId", superInstanceId));
   }
 
   @Test
@@ -245,20 +211,10 @@ public class InstanceRelationshipsTest extends ApiTests {
     throws InterruptedException, MalformedURLException, TimeoutException,
     ExecutionException {
 
-    String subInstanceId = UUID.randomUUID().toString();
-    final JsonObject expectedErrorResponse = new JsonObject()
-      .put("message", String.format("Cannot set instance_relationship.subInstanceId = " +
-        "%s because it does not exist in instance.id.", subInstanceId));
-    instanceRelationshipClient.emulateFailure(
-      new EndpointFailureDescriptor()
-        .setFailureExpireDate(DateTime.now().plusSeconds(2).toDate())
-        .setStatusCode(422)
-        .setContentType("application/json")
-        .setBody(expectedErrorResponse.toString())
-        .setMethod(HttpMethod.POST));
-
+    final String subInstanceId = UUID.randomUUID().toString();
     JsonObject childInstance = new JsonObject()
       .put("id", UUID.randomUUID().toString())
+      .put("instanceRelationshipTypeId", instanceRelationshipTypeFixture.boundWith().getId())
       .put("subInstanceId", subInstanceId);
 
     JsonArray childInstances = new JsonArray().add(childInstance);
@@ -268,9 +224,34 @@ public class InstanceRelationshipsTest extends ApiTests {
 
     Response response = instancesClient.attemptToCreate(smallAngryPlanetJson);
 
-    assertThat(response.getStatusCode(), is(422));
-    assertThat(response.getContentType(), is("application/json"));
-    assertThat(response.getJson(), is(expectedErrorResponse));
+    assertThat(response, hasValidationError("Sub instance does not exist",
+      "subInstanceId", subInstanceId));
+  }
+
+  @Test
+  public void cannotCreateAnInstanceWithNonExistedRelationshipType()
+    throws InterruptedException, MalformedURLException, TimeoutException,
+    ExecutionException {
+
+    final String relationshipTypeId = UUID.randomUUID().toString();
+
+    final IndividualResource subInstance = instancesClient
+      .create(smallAngryPlanet(UUID.randomUUID()));
+
+    JsonObject childInstance = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("instanceRelationshipTypeId", relationshipTypeId)
+      .put("subInstanceId", subInstance.getId().toString());
+
+    JsonArray childInstances = new JsonArray().add(childInstance);
+
+    JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID());
+    smallAngryPlanetJson.put("childInstances", childInstances);
+
+    Response response = instancesClient.attemptToCreate(smallAngryPlanetJson);
+
+    assertThat(response, hasValidationError("Relationship type does not exist",
+      "instanceRelationshipTypeId", relationshipTypeId));
   }
 
   @Test
@@ -356,7 +337,7 @@ public class InstanceRelationshipsTest extends ApiTests {
     ExecutionException {
     UUID nodId = UUID.randomUUID();
     String parentInstanceId = UUID.randomUUID().toString();
-    String boundWithInstanceRelationshipTypeId = "758f13db-ffb4-440e-bb10-8a364aa6cb4a";
+    String boundWithInstanceRelationshipTypeId = instanceRelationshipTypeFixture.boundWith().getId();
 
     IndividualResource smallAngryPlanet = instancesClient.create(smallAngryPlanet(UUID.randomUUID()));
     JsonObject parentInstance = new JsonObject()
@@ -401,7 +382,7 @@ public class InstanceRelationshipsTest extends ApiTests {
     throws InterruptedException, MalformedURLException, TimeoutException,
     ExecutionException {
     UUID nodId = UUID.randomUUID();
-    String boundWithInstanceRelationshipTypeId = "758f13db-ffb4-440e-bb10-8a364aa6cb4a";
+    String boundWithInstanceRelationshipTypeId = instanceRelationshipTypeFixture.boundWith().getId();
 
     IndividualResource smallAngryPlanet = instancesClient.create(smallAngryPlanet(UUID.randomUUID()));
     JsonObject parentInstance = new JsonObject()
@@ -517,7 +498,7 @@ public class InstanceRelationshipsTest extends ApiTests {
   private JsonObject createInstanceRelationships(UUID precedingId, UUID succeedingId) {
     return new JsonObject()
       .put("id", UUID.randomUUID().toString())
-      .put("instanceRelationshipTypeId", UUID.randomUUID().toString())
+      .put("instanceRelationshipTypeId", instanceRelationshipTypeFixture.boundWith().getId())
       .put("superInstanceId", precedingId.toString())
       .put("subInstanceId", succeedingId.toString());
   }

--- a/src/test/java/api/support/ApiTests.java
+++ b/src/test/java/api/support/ApiTests.java
@@ -1,15 +1,17 @@
 package api.support;
 
-import api.ApiTestSuite;
-import api.support.http.ResourceClient;
+import java.net.MalformedURLException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
-import java.net.MalformedURLException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
+import api.ApiTestSuite;
+import api.support.fixtures.InstanceRelationshipTypeFixture;
+import api.support.http.ResourceClient;
 
 public abstract class ApiTests {
   private static boolean runningOnOwn;
@@ -25,6 +27,8 @@ public abstract class ApiTests {
   protected final ResourceClient precedingSucceedingTitlesClient;
   protected final ResourceClient instanceRelationshipClient;
 
+  protected final InstanceRelationshipTypeFixture instanceRelationshipTypeFixture;
+
   public ApiTests() {
     holdingsStorageClient = ResourceClient.forHoldingsStorage(okapiClient);
     itemsStorageClient = ResourceClient.forItemsStorage(okapiClient);
@@ -35,6 +39,7 @@ public abstract class ApiTests {
     instancesBatchClient = ResourceClient.forInstancesBatch(okapiClient);
     precedingSucceedingTitlesClient = ResourceClient.forPrecedingSucceedingTitles(okapiClient);
     instanceRelationshipClient = ResourceClient.forInstanceRelationship(okapiClient);
+    instanceRelationshipTypeFixture = new InstanceRelationshipTypeFixture(okapiClient);
   }
 
   @BeforeClass

--- a/src/test/java/api/support/fixtures/InstanceRelationshipTypeFixture.java
+++ b/src/test/java/api/support/fixtures/InstanceRelationshipTypeFixture.java
@@ -1,0 +1,27 @@
+package api.support.fixtures;
+
+import java.util.UUID;
+
+import org.folio.inventory.support.http.client.OkapiHttpClient;
+
+import io.vertx.core.json.JsonObject;
+
+public class InstanceRelationshipTypeFixture extends ReferenceRecordFixture {
+  public InstanceRelationshipTypeFixture(OkapiHttpClient httpClient) {
+    super(httpClient, json -> json.getString("name"));
+  }
+
+  public ReferenceRecordResponse boundWith() {
+    return createIfNotExist(newInstanceRelationship("bound-with"));
+  }
+
+  public ReferenceRecordResponse monographicSeries() {
+    return createIfNotExist(newInstanceRelationship("monographic series"));
+  }
+
+  private JsonObject newInstanceRelationship(String name) {
+    return new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("name", name);
+  }
+}

--- a/src/test/java/api/support/fixtures/ReferenceRecordFixture.java
+++ b/src/test/java/api/support/fixtures/ReferenceRecordFixture.java
@@ -1,0 +1,37 @@
+package api.support.fixtures;
+
+import java.util.function.Function;
+
+import org.folio.inventory.support.http.client.OkapiHttpClient;
+
+import api.support.http.ResourceClient;
+import io.vertx.core.json.JsonObject;
+
+public class ReferenceRecordFixture {
+  private final ResourceClient client;
+  private final Function<JsonObject, String> keyMapper;
+
+  public ReferenceRecordFixture(
+    OkapiHttpClient httpClient, Function<JsonObject, String> keyMapper) {
+
+    this.client = ResourceClient.forInstanceRelationshipType(httpClient);
+    this.keyMapper = keyMapper;
+  }
+
+  public ReferenceRecordResponse createIfNotExist(JsonObject toCreate) {
+    try {
+
+      final String expectedKey = keyMapper.apply(toCreate);
+
+      for (JsonObject currentEntity : client.getAll()) {
+        if (expectedKey.equals(keyMapper.apply(currentEntity))) {
+          return new ReferenceRecordResponse(currentEntity);
+        }
+      }
+
+      return new ReferenceRecordResponse(client.create(toCreate).getJson());
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+}

--- a/src/test/java/api/support/fixtures/ReferenceRecordResponse.java
+++ b/src/test/java/api/support/fixtures/ReferenceRecordResponse.java
@@ -1,0 +1,19 @@
+package api.support.fixtures;
+
+import io.vertx.core.json.JsonObject;
+
+public class ReferenceRecordResponse {
+  private final JsonObject representation;
+
+  public ReferenceRecordResponse(JsonObject representation) {
+    this.representation = representation;
+  }
+
+  public String getName() {
+    return representation.getString("name");
+  }
+
+  public String getId() {
+    return representation.getString("id");
+  }
+}

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -194,16 +194,23 @@ public class ResourceClient {
     ExecutionException,
     TimeoutException {
 
+    Response putResponse = attemptToReplace(id, request);
+
+    assertThat(
+      String.format("Failed to update %s %s: %s", resourceName, id, putResponse.getBody()),
+      putResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+  }
+
+  public Response attemptToReplace(UUID id, JsonObject request)
+    throws MalformedURLException, InterruptedException, ExecutionException,
+    TimeoutException {
+
     CompletableFuture<Response> putCompleted = new CompletableFuture<>();
 
     client.put(urlMaker.combine(String.format("/%s", id)), request,
       ResponseHandler.any(putCompleted));
 
-    Response putResponse = putCompleted.get(5, TimeUnit.SECONDS);
-
-    assertThat(
-      String.format("Failed to update %s %s: %s", resourceName, id, putResponse.getBody()),
-      putResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+    return putCompleted.get(5, TimeUnit.SECONDS);
   }
 
   public Response getById(UUID id)

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -145,13 +145,7 @@ public class ResourceClient {
     ExecutionException,
     TimeoutException {
 
-    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-
-    //TODO: Reinstate json checking
-    client.post(urlMaker.combine(""), request,
-      ResponseHandler.any(createCompleted));
-
-    Response response = createCompleted.get(5, TimeUnit.SECONDS);
+    Response response = attemptToCreate(request);
 
     assertThat(
       String.format("Failed to create %s: %s", resourceName, response.getBody()),
@@ -170,6 +164,19 @@ public class ResourceClient {
 
       return new IndividualResource(getCompleted.get(5, TimeUnit.SECONDS));
     }
+  }
+
+  public Response attemptToCreate(JsonObject request)
+    throws MalformedURLException, InterruptedException, ExecutionException,
+    TimeoutException {
+
+    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+
+    //TODO: Reinstate json checking
+    client.post(urlMaker.combine(""), request,
+      ResponseHandler.any(createCompleted));
+
+    return createCompleted.get(5, TimeUnit.SECONDS);
   }
 
   public void replace(UUID id, Builder builder)

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -109,6 +109,11 @@ public class ResourceClient {
       "Instance relationships", "instanceRelationships");
   }
 
+  public static ResourceClient forInstanceRelationshipType(OkapiHttpClient okapiClient) {
+    return new ResourceClient(okapiClient, StorageInterfaceUrls::instanceRelationshipTypeUrl,
+      "Instance relationship types", "instanceRelationshipTypes");
+  }
+
   private ResourceClient(
     OkapiHttpClient client,
     UrlMaker urlMaker, String resourceName,

--- a/src/test/java/api/support/http/StorageInterfaceUrls.java
+++ b/src/test/java/api/support/http/StorageInterfaceUrls.java
@@ -14,6 +14,10 @@ public class StorageInterfaceUrls {
     return viaOkapiURL(String.format("/item-storage/items%s", subPath));
   }
 
+  public static URL instancesStorageUrl(String subPath) {
+    return viaOkapiURL(String.format("/instance-storage/instances%s", subPath));
+  }
+
   public static URL institutionsStorageUrl(String subPath) {
     return viaOkapiURL("/location-units/institutions" + subPath);
   }

--- a/src/test/java/api/support/http/StorageInterfaceUrls.java
+++ b/src/test/java/api/support/http/StorageInterfaceUrls.java
@@ -45,6 +45,10 @@ public class StorageInterfaceUrls {
     return viaOkapiURL("/instance-storage/instance-relationships" + subPath);
   }
 
+  public static URL instanceRelationshipTypeUrl(String subPath) {
+    return viaOkapiURL("/instance-relationship-types" + subPath);
+  }
+
   private static URL viaOkapiURL(String path) {
     try {
       return URLHelper.joinPath(new URL(storageOkapiUrl()), path);

--- a/src/test/java/support/fakes/EndpointFailureDescriptor.java
+++ b/src/test/java/support/fakes/EndpointFailureDescriptor.java
@@ -1,5 +1,7 @@
 package support.fakes;
 
+import io.vertx.core.http.HttpMethod;
+
 import java.util.Date;
 
 public class EndpointFailureDescriptor {
@@ -7,6 +9,7 @@ public class EndpointFailureDescriptor {
   private int statusCode;
   private String contentType;
   private String body;
+  private HttpMethod method;
 
   public Date getFailureExpireDate() {
     return failureExpireDate;
@@ -41,6 +44,15 @@ public class EndpointFailureDescriptor {
 
   public EndpointFailureDescriptor setBody(String body) {
     this.body = body;
+    return this;
+  }
+
+  public HttpMethod getMethod() {
+    return method;
+  }
+
+  public EndpointFailureDescriptor setMethod(HttpMethod method) {
+    this.method = method;
     return this;
   }
 }

--- a/src/test/java/support/fakes/FakeOkapi.java
+++ b/src/test/java/support/fakes/FakeOkapi.java
@@ -4,6 +4,7 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServer;
 import io.vertx.ext.web.Router;
+import support.fakes.processors.StorageConstraintsProcessors;
 import support.fakes.processors.StorageRecordPreProcessors;
 
 public class FakeOkapi extends AbstractVerticle {
@@ -82,12 +83,23 @@ public class FakeOkapi extends AbstractVerticle {
       .withRootPath("/instance-storage/instance-relationships")
       .withCollectionPropertyName("instanceRelationships")
       .withRequiredProperties("superInstanceId", "subInstanceId", "instanceRelationshipTypeId")
+      .withRecordPreProcessors(
+        StorageConstraintsProcessors::instanceRelationshipsConstraints)
       .create().register(router);
 
     new FakeStorageModuleBuilder()
       .withRecordName("preceding succeeding titles")
       .withRootPath("/preceding-succeeding-titles")
       .withCollectionPropertyName("precedingSucceedingTitles")
+      .withRecordPreProcessors(
+        StorageConstraintsProcessors::instancePrecedingSucceedingTitleConstraints)
+      .create().register(router);
+
+    new FakeStorageModuleBuilder()
+      .withRecordName("Instance relationship types")
+      .withRootPath("/instance-relationship-types")
+      .withCollectionPropertyName("instanceRelationshipTypes")
+      .withRequiredProperties("name")
       .create().register(router);
   }
 

--- a/src/test/java/support/fakes/FakeStorageModule.java
+++ b/src/test/java/support/fakes/FakeStorageModule.java
@@ -115,7 +115,9 @@ class FakeStorageModule extends AbstractVerticle {
     }
 
     return endpointFailureDescriptor != null && DateTime.now().toDate()
-      .before(endpointFailureDescriptor.getFailureExpireDate());
+      .before(endpointFailureDescriptor.getFailureExpireDate())
+      && endpointFailureDescriptor.getMethod().equals(routingContext.request()
+      .method());
   }
 
   void registerBatch(Router router, String batchPath) {

--- a/src/test/java/support/fakes/FakeStorageModuleBuilder.java
+++ b/src/test/java/support/fakes/FakeStorageModuleBuilder.java
@@ -1,12 +1,16 @@
 package support.fakes;
 
-import api.ApiTestSuite;
-import io.vertx.core.json.JsonObject;
-
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.BiFunction;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
+
+import api.ApiTestSuite;
+import support.fakes.processors.RecordPreProcessor;
 
 public class FakeStorageModuleBuilder {
   private final String rootPath;
@@ -17,7 +21,7 @@ public class FakeStorageModuleBuilder {
   private final Map<String, Supplier<Object>> defaultProperties;
   private final Boolean hasCollectionDelete;
   private final String recordName;
-  private final List<BiFunction<JsonObject, JsonObject, CompletableFuture<JsonObject>>> recordPreProcessors;
+  private final List<RecordPreProcessor> recordPreProcessors;
 
   FakeStorageModuleBuilder() {
     this(null, null, ApiTestSuite.TENANT_ID, new ArrayList<>(), true, "",
@@ -33,7 +37,7 @@ public class FakeStorageModuleBuilder {
     String recordName,
     Collection<String> uniqueProperties,
     Map<String, Supplier<Object>> defaultProperties,
-    List<BiFunction<JsonObject, JsonObject, CompletableFuture<JsonObject>>> recordPreProcessors) {
+    List<RecordPreProcessor> recordPreProcessors) {
 
     this.rootPath = rootPath;
     this.collectionPropertyName = collectionPropertyName;
@@ -131,10 +135,7 @@ public class FakeStorageModuleBuilder {
       this.recordPreProcessors);
   }
 
-  @SafeVarargs
-  final FakeStorageModuleBuilder withRecordPreProcessors(
-    BiFunction<JsonObject, JsonObject, CompletableFuture<JsonObject>> ... preProcessors) {
-
+  final FakeStorageModuleBuilder withRecordPreProcessors(RecordPreProcessor... preProcessors) {
     return new FakeStorageModuleBuilder(
       this.rootPath,
       this.collectionPropertyName,

--- a/src/test/java/support/fakes/processors/RecordPreProcessor.java
+++ b/src/test/java/support/fakes/processors/RecordPreProcessor.java
@@ -1,0 +1,11 @@
+package support.fakes.processors;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.vertx.core.json.JsonObject;
+
+@FunctionalInterface
+public interface RecordPreProcessor {
+
+  CompletableFuture<JsonObject> process(JsonObject oldItem, JsonObject newItem) throws Exception;
+}

--- a/src/test/java/support/fakes/processors/StorageConstraintsProcessors.java
+++ b/src/test/java/support/fakes/processors/StorageConstraintsProcessors.java
@@ -1,0 +1,117 @@
+package support.fakes.processors;
+
+import static api.ApiTestSuite.createOkapiHttpClient;
+import static api.support.http.StorageInterfaceUrls.instanceRelationshipTypeUrl;
+import static java.util.function.Function.identity;
+import static org.folio.inventory.support.JsonArrayHelper.toList;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import org.folio.inventory.domain.instances.InstanceRelationship;
+import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
+import org.folio.inventory.support.http.client.Response;
+import org.folio.inventory.support.http.client.ResponseHandler;
+import org.folio.inventory.support.http.server.ValidationError;
+import org.folio.inventory.validation.exceptions.UnprocessableEntityException;
+import org.folio.util.StringUtil;
+
+import api.support.http.BusinessLogicInterfaceUrls;
+import io.vertx.core.json.JsonObject;
+
+public final class StorageConstraintsProcessors {
+
+  private StorageConstraintsProcessors() {
+  }
+
+  public static CompletableFuture<JsonObject> instanceRelationshipsConstraints(
+    @SuppressWarnings("unused") JsonObject oldRelationship, JsonObject newRelationship) throws MalformedURLException {
+
+    final InstanceRelationship relationship = new InstanceRelationship(newRelationship);
+
+    return getInstanceByIds(relationship.subInstanceId, relationship.superInstanceId)
+      .thenCombine(get(instanceRelationshipTypeUrl(
+        "/" + relationship.instanceRelationshipTypeId)), (relationships, relationshipType) -> {
+
+        if (relationshipType.getStatusCode() != 200) {
+          throw new UnprocessableEntityException(new ValidationError(
+            "Relationship type does not exist", "instanceRelationshipTypeId",
+            relationship.instanceRelationshipTypeId));
+        }
+
+        if (!relationships.containsKey(relationship.subInstanceId)) {
+          throw new UnprocessableEntityException(new ValidationError(
+            "Sub instance does not exist", "subInstanceId", relationship.subInstanceId));
+        }
+
+        if (!relationships.containsKey(relationship.superInstanceId)) {
+          throw new UnprocessableEntityException(new ValidationError(
+            "Super instance does not exist", "superInstanceId", relationship.superInstanceId));
+        }
+
+        return newRelationship;
+      });
+  }
+
+  public static CompletableFuture<JsonObject> instancePrecedingSucceedingTitleConstraints(
+    @SuppressWarnings("unused") JsonObject oldRelationship, JsonObject newRelationship) throws MalformedURLException {
+
+    final PrecedingSucceedingTitle relationship = PrecedingSucceedingTitle.from(newRelationship);
+
+    if (relationship.precedingInstanceId == null && relationship.succeedingInstanceId == null) {
+      throw new UnprocessableEntityException(
+        new ValidationError("Either preceding or succeeding id must be set",
+          "succeedingInstanceId", null));
+    }
+
+    return getInstanceByIds(relationship.precedingInstanceId, relationship.succeedingInstanceId)
+      .thenCompose(instancesMap -> {
+        if (relationship.precedingInstanceId != null
+          && !instancesMap.containsKey(relationship.precedingInstanceId)) {
+
+          throw new UnprocessableEntityException(new ValidationError(
+            "Preceding instance does not exist", "precedingInstanceId",
+            relationship.precedingInstanceId));
+        }
+
+        if (relationship.succeedingInstanceId != null
+          && !instancesMap.containsKey(relationship.succeedingInstanceId)) {
+
+          throw new UnprocessableEntityException(new ValidationError(
+            "Succeeding instance does not exist", "succeedingInstanceId",
+            relationship.succeedingInstanceId));
+        }
+
+        return CompletableFuture.completedFuture(newRelationship);
+      });
+  }
+
+  private static CompletableFuture<Map<String, JsonObject>> getInstanceByIds(String... ids)
+    throws MalformedURLException {
+
+    final String fullQuery = String.format("?query=id==(%s)&limit=%s",
+      StringUtil.urlEncode(Arrays.stream(ids)
+        .filter(Objects::nonNull)
+        .map(id -> '"' + id + '"')
+        .collect(Collectors.joining(" or "))),
+      ids.length);
+
+    return get(BusinessLogicInterfaceUrls.instances(fullQuery))
+      .thenApply(response -> toList(response.getJson().getJsonArray("instances")))
+      .thenApply(instances -> instances.stream()
+        .collect(Collectors.toMap(instance -> instance.getString("id"), identity())));
+  }
+
+  private static CompletableFuture<Response> get(URL url) throws MalformedURLException {
+    final CompletableFuture<Response> result = new CompletableFuture<>();
+
+    createOkapiHttpClient().get(url, ResponseHandler.any(result));
+
+    return result;
+  }
+}

--- a/src/test/java/support/fakes/processors/StorageConstraintsProcessors.java
+++ b/src/test/java/support/fakes/processors/StorageConstraintsProcessors.java
@@ -2,6 +2,7 @@ package support.fakes.processors;
 
 import static api.ApiTestSuite.createOkapiHttpClient;
 import static api.support.http.StorageInterfaceUrls.instanceRelationshipTypeUrl;
+import static api.support.http.StorageInterfaceUrls.instancesStorageUrl;
 import static java.util.function.Function.identity;
 import static org.folio.inventory.support.JsonArrayHelper.toList;
 
@@ -21,7 +22,6 @@ import org.folio.inventory.support.http.server.ValidationError;
 import org.folio.inventory.validation.exceptions.UnprocessableEntityException;
 import org.folio.util.StringUtil;
 
-import api.support.http.BusinessLogicInterfaceUrls;
 import io.vertx.core.json.JsonObject;
 
 public final class StorageConstraintsProcessors {
@@ -101,7 +101,7 @@ public final class StorageConstraintsProcessors {
         .collect(Collectors.joining(" or "))),
       ids.length);
 
-    return get(BusinessLogicInterfaceUrls.instances(fullQuery))
+    return get(instancesStorageUrl(fullQuery))
       .thenApply(response -> toList(response.getJson().getJsonArray("instances")))
       .thenApply(instances -> instances.stream()
         .collect(Collectors.toMap(instance -> instance.getString("id"), identity())));

--- a/src/test/java/support/fakes/processors/StorageRecordPreProcessors.java
+++ b/src/test/java/support/fakes/processors/StorageRecordPreProcessors.java
@@ -148,7 +148,7 @@ public final class StorageRecordPreProcessors {
     );
   }
 
-  public static BiFunction<JsonObject, JsonObject, CompletableFuture<JsonObject>> setHridProcessor(
+  public static RecordPreProcessor setHridProcessor(
     String hridPrefix) {
 
     return (oldEntity, newEntity) -> {

--- a/src/test/java/support/matchers/ResponseMatchers.java
+++ b/src/test/java/support/matchers/ResponseMatchers.java
@@ -53,6 +53,18 @@ public class ResponseMatchers {
           .appendText(", 'key' - ").appendValue(expectedKey)
           .appendText(" and 'value' - ").appendValue(expectedValue);
       }
+
+      @Override
+      protected void describeMismatchSafely(Response response, Description mismatchDescription) {
+        mismatchDescription.appendText("Status: ").appendValue(response.getStatusCode())
+          .appendText(", body: ");
+
+        if (response.getContentType().startsWith("application/json")) {
+          mismatchDescription.appendValue(response.getJson());
+        } else {
+          mismatchDescription.appendValue(response.getBody());
+        }
+      }
     };
   }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-215

**Purpose:**

Need to handle exception for /inventory/instances endpoints in order to understand what real happens.

**Approach:**

- add failure handle during manipulation with preceding/succeeding titles or instance relationships
- add constraint check for instance relationships and preceding-succeeding title APIs.