### PR TITLE
MODINV-272: Include parent/child relationship in instance getById response

### DIFF
--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -406,7 +406,7 @@ public class Instances extends AbstractInstances {
     Instance instance) {
 
     JsonResponse.success(routingContext.response(), toRepresentation(instance,
-      new ArrayList<>(), new ArrayList<>(),
+      instance.getParentInstances(), instance.getChildInstances(),
       instance.getPrecedingTitles(), instance.getSucceedingTitles(), context));
   }
 

--- a/src/test/java/api/ApiTestSuite.java
+++ b/src/test/java/api/ApiTestSuite.java
@@ -13,13 +13,14 @@ import java.util.concurrent.TimeoutException;
 
 import org.folio.inventory.InventoryVerticle;
 import org.folio.inventory.common.VertxAssistant;
-import org.folio.inventory.domain.instances.InstanceRelationship;
 import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
+import api.events.EventHandlersApiTest;
+import api.holdings.HoldingApiExample;
 import api.isbns.IsbnUtilsApiExamples;
 import api.items.ItemAllowedStatusesSchemaTest;
 import api.items.ItemApiExamples;
@@ -42,7 +43,9 @@ import support.fakes.FakeOkapi;
   ItemAllowedStatusesSchemaTest.class,
   TenantApiExamples.class,
   PrecedingSucceedingTitlesApiExamples.class,
-  InstanceRelationshipsTest.class
+  InstanceRelationshipsTest.class,
+  EventHandlersApiTest.class,
+  HoldingApiExample.class
 })
 public class ApiTestSuite {
   public static final int INVENTORY_VERTICLE_TEST_PORT = 9603;


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-272 - Bugfest: Inventory. Instance. Instance relationship data is not saved.

### Changes:
* Instance relationships had been created but was not included to the getById response (however they are included into search by query response).
* Use `instance.getParentInstances()` and `instance.getChildInstances()` instead of empty arrays.