### PR TITLE
MODINV-274: Archive event payload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,9 @@
       <version>4.5.2</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
+      <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.3.2</version>
+      <version>2.4</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/src/main/java/org/folio/inventory/resources/EventHandlers.java
+++ b/src/main/java/org/folio/inventory/resources/EventHandlers.java
@@ -21,6 +21,7 @@ import org.folio.inventory.storage.Storage;
 import org.folio.inventory.support.http.server.ServerErrorResponse;
 import org.folio.inventory.support.http.server.SuccessResponse;
 import org.folio.processing.events.EventManager;
+import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.mapper.reader.record.MarcBibReaderFactory;
 import org.folio.processing.matching.loader.MatchValueLoaderFactory;
@@ -60,8 +61,9 @@ public class EventHandlers {
 
   private void handleEvent(RoutingContext routingContext) {
     try {
-      JsonObject requestBody = routingContext.getBodyAsJson();
-      DataImportEventPayload eventPayload = requestBody.mapTo(DataImportEventPayload.class);
+      String zippedPayload = routingContext.getBodyAsString();
+      String unzippedPayload = ZIPArchiver.unzip(zippedPayload);
+      DataImportEventPayload eventPayload = new JsonObject(unzippedPayload).mapTo(DataImportEventPayload.class);
       routingContext.vertx().executeBlocking(blockingFuture -> EventManager.handleEvent(eventPayload), null);
       SuccessResponse.noContent(routingContext.response());
     } catch (Exception e) {

--- a/src/test/java/api/events/EventHandlersApiTest.java
+++ b/src/test/java/api/events/EventHandlersApiTest.java
@@ -11,6 +11,7 @@ import org.folio.MappingProfile;
 import org.folio.UserInfo;
 import org.folio.inventory.support.http.client.Response;
 import org.folio.inventory.support.http.client.ResponseHandler;
+import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.MappingDetail;
 import org.folio.rest.jaxrs.model.MappingRule;
@@ -20,6 +21,7 @@ import org.folio.rest.jaxrs.model.Record;
 import org.junit.Test;
 import support.fakes.FakeOkapi;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,17 +46,17 @@ public class EventHandlersApiTest extends ApiTests {
   }
 
   @Test
-  public void shouldReturnNoContentOnValidBody() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+  public void shouldReturnNoContentOnValidBody() throws IOException, InterruptedException, ExecutionException, TimeoutException {
     CompletableFuture<Response> conversionCompleted = new CompletableFuture<>();
-    okapiClient.post(ApiRoot.dataImportEventHandler(), new JsonObject(), ResponseHandler.any(conversionCompleted));
+    okapiClient.post(ApiRoot.dataImportEventHandler(), ZIPArchiver.zip(new JsonObject().toString()), ResponseHandler.any(conversionCompleted));
     Response response = conversionCompleted.get(5, TimeUnit.SECONDS);
     assertThat(response.getStatusCode(), is(204));
   }
 
   @Test
-  public void shouldReturnNoContentOnValidData() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+  public void shouldReturnNoContentOnValidData() throws IOException, InterruptedException, ExecutionException, TimeoutException {
     CompletableFuture<Response> conversionCompleted = new CompletableFuture<>();
-    okapiClient.post(ApiRoot.dataImportEventHandler(), JsonObject.mapFrom(prepareSnapshot()), ResponseHandler.any(conversionCompleted));
+    okapiClient.post(ApiRoot.dataImportEventHandler(), ZIPArchiver.zip(JsonObject.mapFrom(prepareSnapshot()).toString()), ResponseHandler.any(conversionCompleted));
     Response response = conversionCompleted.get(5, TimeUnit.SECONDS);
     assertThat(response.getStatusCode(), is(204));
   }


### PR DESCRIPTION
The mechanism for unzipping and decoding event payload was added from data-import-processing-core. 
JIRA-ticket: https://issues.folio.org/browse/MODINV-274