### PR TITLE
Revert "MODINV-274: Archive event payload (#193)" 

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -466,7 +466,7 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 357913941,
+        "Memory": 715827883,
         "PortBindings": { "9403/tcp": [ { "HostPort": "%p" } ] }
       }
     },

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,9 @@
       <version>4.5.2</version>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
+      <groupId>org.apache.commons</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>2.0.0</version>
+      <version>1.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/src/main/java/org/folio/inventory/resources/EventHandlers.java
+++ b/src/main/java/org/folio/inventory/resources/EventHandlers.java
@@ -23,7 +23,6 @@ import org.folio.inventory.storage.Storage;
 import org.folio.inventory.support.http.server.ServerErrorResponse;
 import org.folio.inventory.support.http.server.SuccessResponse;
 import org.folio.processing.events.EventManager;
-import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.mapper.reader.record.MarcBibReaderFactory;
 import org.folio.processing.matching.loader.MatchValueLoaderFactory;
@@ -65,9 +64,8 @@ public class EventHandlers {
 
   private void handleEvent(RoutingContext routingContext) {
     try {
-      String zippedPayload = routingContext.getBodyAsString();
-      String unzippedPayload = ZIPArchiver.unzip(zippedPayload);
-      DataImportEventPayload eventPayload = new JsonObject(unzippedPayload).mapTo(DataImportEventPayload.class);
+      JsonObject requestBody = routingContext.getBodyAsJson();
+      DataImportEventPayload eventPayload = requestBody.mapTo(DataImportEventPayload.class);
       routingContext.vertx().executeBlocking(blockingFuture -> EventManager.handleEvent(eventPayload), null);
       SuccessResponse.noContent(routingContext.response());
     } catch (Exception e) {

--- a/src/test/java/api/events/EventHandlersApiTest.java
+++ b/src/test/java/api/events/EventHandlersApiTest.java
@@ -11,7 +11,6 @@ import org.folio.MappingProfile;
 import org.folio.UserInfo;
 import org.folio.inventory.support.http.client.Response;
 import org.folio.inventory.support.http.client.ResponseHandler;
-import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.MappingDetail;
 import org.folio.rest.jaxrs.model.MappingRule;
@@ -21,7 +20,6 @@ import org.folio.rest.jaxrs.model.Record;
 import org.junit.Test;
 import support.fakes.FakeOkapi;
 
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -46,17 +44,17 @@ public class EventHandlersApiTest extends ApiTests {
   }
 
   @Test
-  public void shouldReturnNoContentOnValidBody() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+  public void shouldReturnNoContentOnValidBody() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
     CompletableFuture<Response> conversionCompleted = new CompletableFuture<>();
-    okapiClient.post(ApiRoot.dataImportEventHandler(), ZIPArchiver.zip(new JsonObject().toString()), ResponseHandler.any(conversionCompleted));
+    okapiClient.post(ApiRoot.dataImportEventHandler(), new JsonObject(), ResponseHandler.any(conversionCompleted));
     Response response = conversionCompleted.get(5, TimeUnit.SECONDS);
     assertThat(response.getStatusCode(), is(204));
   }
 
   @Test
-  public void shouldReturnNoContentOnValidData() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+  public void shouldReturnNoContentOnValidData() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
     CompletableFuture<Response> conversionCompleted = new CompletableFuture<>();
-    okapiClient.post(ApiRoot.dataImportEventHandler(), ZIPArchiver.zip(JsonObject.mapFrom(prepareSnapshot()).toString()), ResponseHandler.any(conversionCompleted));
+    okapiClient.post(ApiRoot.dataImportEventHandler(), JsonObject.mapFrom(prepareSnapshot()), ResponseHandler.any(conversionCompleted));
     Response response = conversionCompleted.get(5, TimeUnit.SECONDS);
     assertThat(response.getStatusCode(), is(204));
   }


### PR DESCRIPTION
Data import flow caused mod-inventory to crash. Investigation is ongoing, but we decided to revert the latest changes in order not to impede demo tomorrow.