### PR TITLE
MODINV-218: Require title for unconnected preceding/succeeding titles

### DIFF
--- a/src/main/java/org/folio/inventory/exceptions/InternalServerErrorException.java
+++ b/src/main/java/org/folio/inventory/exceptions/InternalServerErrorException.java
@@ -1,0 +1,7 @@
+package org.folio.inventory.exceptions;
+
+public class InternalServerErrorException extends AbstractInventoryException {
+  public InternalServerErrorException(String reason) {
+    super(reason);
+  }
+}

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -14,7 +14,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -415,8 +415,8 @@ public class Instances extends AbstractInstances {
   private CompletableFuture<Instance> withInstanceRelationships(Instance instance,
     Response result) {
 
-    List<InstanceRelationshipToParent> parentInstanceList = new ArrayList();
-    List<InstanceRelationshipToChild> childInstanceList = new ArrayList();
+    List<InstanceRelationshipToParent> parentInstanceList = new ArrayList<>();
+    List<InstanceRelationshipToChild> childInstanceList = new ArrayList<>();
     if (result.getStatusCode() == 200) {
       JsonObject json = result.getJson();
       List<JsonObject> relationsList = JsonArrayHelper.toList(json.getJsonArray("instanceRelationships"));
@@ -454,12 +454,12 @@ public class Instances extends AbstractInstances {
   // Utilities
 
   private List<String> getInstanceIdsFromInstanceResult(Success success) {
-    List<String> instanceIds = new ArrayList();
+    List<String> instanceIds = new ArrayList<>();
     if (success.getResult() instanceof Instance) {
-      instanceIds = Arrays.asList(((Instance) success.getResult()).getId());
+      instanceIds = Collections.singletonList(((Instance) success.getResult()).getId());
     } else if (success.getResult() instanceof MultipleRecords) {
       instanceIds = (((MultipleRecords<Instance>) success.getResult()).records.stream()
-        .map(instance -> instance.getId())
+        .map(Instance::getId)
         .filter(Objects::nonNull)
         .distinct()
         .collect(Collectors.toList()));
@@ -474,7 +474,7 @@ public class Instances extends AbstractInstances {
 
     // if list does not exist create it
     if (itemsList == null) {
-      itemsList = new ArrayList();
+      itemsList = new ArrayList<>();
       itemsList.add(myItem);
       items.put(mapKey, itemsList);
     } else {
@@ -549,14 +549,14 @@ public class Instances extends AbstractInstances {
     List<CompletableFuture<PrecedingSucceedingTitle>> succeedingTitleCompletableFutures) {
 
     return allResultsOf(succeedingTitleCompletableFutures)
-      .thenApply(resultItem -> instance.setSucceedingTitles(resultItem));
+      .thenApply(instance::setSucceedingTitles);
   }
 
   private CompletableFuture<Instance> withPrecedingTitles(Instance instance,
     List<CompletableFuture<PrecedingSucceedingTitle>> precedingTitleCompletableFutures) {
 
     return allResultsOf(precedingTitleCompletableFutures)
-      .thenApply(resultItem -> instance.setPrecedingTitles(resultItem));
+      .thenApply(instance::setPrecedingTitles);
   }
 
   private CompletableFuture<InstancesResponse> withPrecedingTitles(
@@ -564,7 +564,7 @@ public class Instances extends AbstractInstances {
     Map<String, List<CompletableFuture<PrecedingSucceedingTitle>>> precedingTitles) {
 
     return mapToCompletableFutureMap(precedingTitles)
-      .thenApply(res -> instance.setPrecedingTitlesMap(res));
+      .thenApply(instance::setPrecedingTitlesMap);
   }
 
   private CompletableFuture<InstancesResponse> withSucceedingTitles(
@@ -572,7 +572,7 @@ public class Instances extends AbstractInstances {
     Map<String, List<CompletableFuture<PrecedingSucceedingTitle>>> precedingTitles) {
 
     return mapToCompletableFutureMap(precedingTitles)
-      .thenApply(res -> instance.setSucceedingTitlesMap(res));
+      .thenApply(instance::setSucceedingTitlesMap);
   }
 
   private CompletableFuture<Map<String, List<PrecedingSucceedingTitle>>> mapToCompletableFutureMap(

--- a/src/main/java/org/folio/inventory/resources/InstancesBatch.java
+++ b/src/main/java/org/folio/inventory/resources/InstancesBatch.java
@@ -4,6 +4,8 @@ import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.inventory.support.EndpointFailureHandler.getKnownException;
 import static org.folio.inventory.support.EndpointFailureHandler.handleFailure;
+import static org.folio.inventory.support.JsonArrayHelper.toList;
+import static org.folio.inventory.validation.InstancesValidators.isTitleMissingForUnconnectedPrecedingSucceeding;
 
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -19,6 +21,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.folio.inventory.common.WebContext;
 import org.folio.inventory.domain.BatchResult;
 import org.folio.inventory.domain.instances.Instance;
+import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
 import org.folio.inventory.storage.Storage;
 import org.folio.inventory.support.InstanceUtil;
 import org.folio.inventory.support.http.server.RedirectResponse;
@@ -131,6 +134,20 @@ public class InstancesBatch extends AbstractInstances {
       log.error(errorMessage);
       errorMessages.add(errorMessage);
     }
+
+    final List<PrecedingSucceedingTitle> precedingTitles = toList(jsonInstance
+      .getJsonArray(Instance.PRECEDING_TITLES_KEY), PrecedingSucceedingTitle::from);
+    final List<PrecedingSucceedingTitle> succeedingTitles = toList(jsonInstance
+      .getJsonArray(Instance.SUCCEEDING_TITLES_KEY), PrecedingSucceedingTitle::from);
+
+    if (isTitleMissingForUnconnectedPrecedingSucceeding(precedingTitles)) {
+      errorMessages.add("Title is required for unconnected preceding title");
+    }
+
+    if (isTitleMissingForUnconnectedPrecedingSucceeding(succeedingTitles)) {
+      errorMessages.add("Title is required for unconnected succeeding title");
+    }
+
     return errorMessages;
   }
 

--- a/src/main/java/org/folio/inventory/support/CompletableFutures.java
+++ b/src/main/java/org/folio/inventory/support/CompletableFutures.java
@@ -1,0 +1,16 @@
+package org.folio.inventory.support;
+
+import java.util.concurrent.CompletableFuture;
+
+public final class CompletableFutures {
+
+  private CompletableFutures() {}
+
+  public static <T> CompletableFuture<T> failedFuture(Throwable cause) {
+    final CompletableFuture<T> future = new CompletableFuture<>();
+
+    future.completeExceptionally(cause);
+
+    return future;
+  }
+}

--- a/src/main/java/org/folio/inventory/support/JsonArrayHelper.java
+++ b/src/main/java/org/folio/inventory/support/JsonArrayHelper.java
@@ -1,15 +1,22 @@
 package org.folio.inventory.support;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import java.util.ArrayList;
-
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public class JsonArrayHelper {
   public static List<JsonObject> toList(JsonArray array) {
+    if (array == null) {
+      return Collections.emptyList();
+    }
+
     return array
       .stream()
       .map(it -> {
@@ -20,7 +27,7 @@ public class JsonArrayHelper {
           return null;
         }
       })
-      .filter(it -> it != null)
+      .filter(Objects::nonNull)
       .collect(Collectors.toList());
   }
 
@@ -34,9 +41,15 @@ public class JsonArrayHelper {
     return list;
   }
 
-  public static List<Map> toListOfMaps(JsonArray array) {
+  public static List<Map<String, Object>> toListOfMaps(JsonArray array) {
     return JsonArrayHelper.toList(array).stream()
-      .map(it -> it.getMap())
+      .map(JsonObject::getMap)
+      .collect(Collectors.toList());
+  }
+
+  public static <T> List<T> toList(JsonArray array, Function<JsonObject, T> mapper) {
+    return toList(array).stream()
+      .map(mapper)
       .collect(Collectors.toList());
   }
 }

--- a/src/main/java/org/folio/inventory/support/JsonArrayHelper.java
+++ b/src/main/java/org/folio/inventory/support/JsonArrayHelper.java
@@ -3,7 +3,6 @@ package org.folio.inventory.support;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -39,12 +38,6 @@ public class JsonArrayHelper {
       }
     }
     return list;
-  }
-
-  public static List<Map<String, Object>> toListOfMaps(JsonArray array) {
-    return JsonArrayHelper.toList(array).stream()
-      .map(JsonObject::getMap)
-      .collect(Collectors.toList());
   }
 
   public static <T> List<T> toList(JsonArray array, Function<JsonObject, T> mapper) {

--- a/src/main/java/org/folio/inventory/validation/InstancesValidators.java
+++ b/src/main/java/org/folio/inventory/validation/InstancesValidators.java
@@ -1,0 +1,71 @@
+package org.folio.inventory.validation;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.folio.inventory.support.CompletableFutures.failedFuture;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.commons.lang3.StringUtils;
+import org.folio.inventory.domain.instances.Instance;
+import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
+import org.folio.inventory.support.http.server.ValidationError;
+import org.folio.inventory.validation.exceptions.NotFoundException;
+import org.folio.inventory.validation.exceptions.UnprocessableEntityException;
+
+public final class InstancesValidators {
+
+  private InstancesValidators() {}
+
+  public static CompletableFuture<Instance> refuseWhenNoTitleForPrecedingSucceedingUnconnectedTitle(
+    Instance instance) {
+
+    final ValidationError succeedingError = new ValidationError(
+      "Title is required for unconnected succeeding title", "succeedingTitles.title", null);
+    final ValidationError precedingError = new ValidationError(
+      "Title is required for unconnected preceding title", "precedingTitles.title", null);
+
+    return refuseWhenNoTitleForUnconnectedTitle(instance, instance.getSucceedingTitles(), succeedingError)
+      .thenCompose(prev -> refuseWhenNoTitleForUnconnectedTitle(instance, instance.getPrecedingTitles(), precedingError));
+
+  }
+
+  private static CompletableFuture<Instance> refuseWhenNoTitleForUnconnectedTitle(
+    Instance instance, List<PrecedingSucceedingTitle> titles, ValidationError error) {
+
+    return isTitleMissingForUnconnectedPrecedingSucceeding(titles)
+      ? failedFuture(new UnprocessableEntityException(error))
+      : completedFuture(instance);
+  }
+
+  public static boolean isTitleMissingForUnconnectedPrecedingSucceeding(List<PrecedingSucceedingTitle> titles) {
+    if (titles == null || titles.isEmpty()) {
+      return false;
+    }
+
+    return titles.stream()
+      .filter(InstancesValidators::isUnconnectedPrecedingSucceedingTitle)
+      .anyMatch(title -> StringUtils.isBlank(title.title));
+  }
+
+  private static boolean isUnconnectedPrecedingSucceedingTitle(PrecedingSucceedingTitle title) {
+    return title.precedingInstanceId == null && title.succeedingInstanceId == null;
+  }
+
+  public static CompletionStage<Instance> refuseWhenInstanceNotFound(Instance instance) {
+    return instance == null
+      ? failedFuture(new NotFoundException("Instance not found"))
+      : completedFuture(instance);
+  }
+
+  public static CompletionStage<Instance> refuseWhenHridChanged(
+    Instance existingInstance, Instance updatedInstance) {
+
+    return Objects.equals(existingInstance.getHrid(), updatedInstance.getHrid())
+      ? completedFuture(existingInstance)
+      : failedFuture(new UnprocessableEntityException("HRID can not be updated",
+      "hrid", updatedInstance.getHrid()));
+  }
+}

--- a/src/main/java/org/folio/inventory/validation/exceptions/NotFoundException.java
+++ b/src/main/java/org/folio/inventory/validation/exceptions/NotFoundException.java
@@ -1,6 +1,8 @@
 package org.folio.inventory.validation.exceptions;
 
-public class NotFoundException extends Exception {
+import org.folio.inventory.exceptions.AbstractInventoryException;
+
+public class NotFoundException extends AbstractInventoryException {
   public NotFoundException(String message) {
     super(message);
   }

--- a/src/main/java/org/folio/inventory/validation/exceptions/UnprocessableEntityException.java
+++ b/src/main/java/org/folio/inventory/validation/exceptions/UnprocessableEntityException.java
@@ -11,6 +11,10 @@ public class UnprocessableEntityException extends AbstractInventoryException {
     this.validationError = validationError;
   }
 
+  public UnprocessableEntityException(String message, String propertyName, String value) {
+    this(new ValidationError(message, propertyName, value));
+  }
+
   public ValidationError getValidationError() {
     return validationError;
   }

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -63,10 +63,6 @@ public class InstancesApiExamples extends ApiTests {
   private final String tagNameOne = "important";
   private final String tagNameTwo = "very important";
 
-  public InstancesApiExamples() throws MalformedURLException {
-    super();
-  }
-
   @Test
   public void canCreateInstanceWithoutAnIDAndHRID()
     throws InterruptedException,
@@ -557,7 +553,7 @@ public class InstancesApiExamples extends ApiTests {
     assertNotNull(putResponse.getJson().getJsonArray("errors"));
     JsonArray errors = putResponse.getJson().getJsonArray("errors");
     assertThat(errors.size(), is(1));
-    assertThat(errors.getString(0), is(
+    assertThat(errors.getJsonObject(0).getString("message"), is(
       "Instance is controlled by MARC record, these fields are blocked and can not be updated: " +
         "physicalDescriptions,notes,languages,identifiers,instanceTypeId,modeOfIssuanceId,subjects," +
         "source,title,indexTitle,publicationFrequency,electronicAccess,publicationRange," +

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -136,12 +136,12 @@ public class InstancesApiExamples extends ApiTests {
     final JsonObject tags = createdInstance.getJsonObject(TAGS_KEY);
     assertTrue(tags.containsKey(TAG_LIST_KEY));
     final JsonArray tagList = tags.getJsonArray(TAG_LIST_KEY);
-    assertThat((ArrayList<String>)tagList.getList(), hasItem(tagNameOne));
+    assertThat(tagList, hasItem(tagNameOne));
 
     JsonArray natureOfContentTermIds = createdInstance.getJsonArray("natureOfContentTermIds");
     assertThat(natureOfContentTermIds.size(), is(2));
-    assertThat((ArrayList<String>)natureOfContentTermIds.getList(), hasItem(ApiTestSuite.getAudiobookNatureOfContentTermId()));
-    assertThat((ArrayList<String>)natureOfContentTermIds.getList(), hasItem(ApiTestSuite.getBibliographyNatureOfContentTermId()));
+    assertThat(natureOfContentTermIds, hasItem(ApiTestSuite.getAudiobookNatureOfContentTermId()));
+    assertThat(natureOfContentTermIds, hasItem(ApiTestSuite.getBibliographyNatureOfContentTermId()));
 
     expressesDublinCoreMetadata(createdInstance);
     dublinCoreContextLinkRespectsWayResourceWasReached(createdInstance);
@@ -274,7 +274,7 @@ public class InstancesApiExamples extends ApiTests {
     final JsonObject tags = createdAngryPlanetInstance.getJsonObject(TAGS_KEY);
     assertTrue(tags.containsKey(TAG_LIST_KEY));
     final JsonArray tagList = tags.getJsonArray(TAG_LIST_KEY);
-    assertThat((ArrayList<String>)tagList.getList(), hasItems(tagNameOne, tagNameTwo));
+    assertThat(tagList, hasItems(tagNameOne, tagNameTwo));
 
     // Get and assert treasureIslandInstance
     CompletableFuture<Response> getTreasureIslandInstanceCompleted = new CompletableFuture<>();
@@ -398,8 +398,7 @@ public class InstancesApiExamples extends ApiTests {
 
     JsonObject smallAngryPlanet = smallAngryPlanet(id);
     smallAngryPlanet.put("natureOfContentTermIds",
-      new JsonArray(asList(ApiTestSuite.getBibliographyNatureOfContentTermId()))
-    );
+      new JsonArray().add(ApiTestSuite.getBibliographyNatureOfContentTermId()));
 
     JsonObject newInstance = createInstance(smallAngryPlanet);
 
@@ -407,8 +406,7 @@ public class InstancesApiExamples extends ApiTests {
       .put("title", "The Long Way to a Small, Angry Planet")
       .put(TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray().add(tagNameTwo)))
       .put("natureOfContentTermIds",
-        new JsonArray(asList(ApiTestSuite.getAudiobookNatureOfContentTermId()))
-      );
+        new JsonArray().add(ApiTestSuite.getAudiobookNatureOfContentTermId()));
 
     URL instanceLocation = new URL(String.format("%s/%s", ApiRoot.instances(),
       newInstance.getString("id")));
@@ -440,7 +438,7 @@ public class InstancesApiExamples extends ApiTests {
     final JsonObject tags = updatedInstance.getJsonObject(TAGS_KEY);
     assertTrue(tags.containsKey(TAG_LIST_KEY));
     final JsonArray tagList = tags.getJsonArray(TAG_LIST_KEY);
-    assertThat((ArrayList<String>)tagList.getList(), hasItem(tagNameTwo));
+    assertThat(tagList, hasItem(tagNameTwo));
 
     JsonArray natureOfContentTermIds = updatedInstance.getJsonArray("natureOfContentTermIds");
     assertThat(natureOfContentTermIds.size(), is(1));
@@ -627,7 +625,7 @@ public class InstancesApiExamples extends ApiTests {
     createInstance(nod(UUID.randomUUID()));
     createInstance(leviathanWakes(UUID.randomUUID()));
 
-    CompletableFuture<Response> deleteCompleted = new CompletableFuture<Response>();
+    CompletableFuture<Response> deleteCompleted = new CompletableFuture<>();
 
     okapiClient.delete(ApiRoot.instances(), ResponseHandler.any(deleteCompleted));
 
@@ -870,7 +868,7 @@ public class InstancesApiExamples extends ApiTests {
   }
 
   private void hasCollectionProperties(List<JsonObject> instances) {
-    instances.stream().forEach(instance -> {
+    instances.forEach(instance -> {
       try {
         expressesDublinCoreMetadata(instance);
       } catch (JsonLdError jsonLdError) {
@@ -878,13 +876,11 @@ public class InstancesApiExamples extends ApiTests {
       }
     });
 
-    instances.stream().forEach(instance ->
-      dublinCoreContextLinkRespectsWayResourceWasReached(instance));
+    instances.forEach(InstancesApiExamples::dublinCoreContextLinkRespectsWayResourceWasReached);
 
-    instances.stream().forEach(instance ->
-      selfLinkRespectsWayResourceWasReached(instance));
+    instances.forEach(InstancesApiExamples::selfLinkRespectsWayResourceWasReached);
 
-    instances.stream().forEach(instance -> {
+    instances.forEach(instance -> {
       try {
         selfLinkShouldBeReachable(instance);
       } catch (Exception e) {

--- a/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
+++ b/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
@@ -614,7 +614,8 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
     return collection.stream()
       .map(index -> (JsonObject) index)
       .filter(request -> StringUtils.equals(request.getString("id"), id))
-      .findFirst().get();
+      .findFirst()
+      .orElse(null);
   }
 
   private JsonArray getUnconnectedPrecedingSucceedingTitle(

--- a/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
+++ b/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
@@ -4,15 +4,24 @@ import static api.support.InstanceSamples.nod;
 import static api.support.InstanceSamples.smallAngryPlanet;
 import static api.support.InstanceSamples.taoOfPooh;
 import static api.support.InstanceSamples.uprooted;
+import static org.folio.inventory.domain.instances.Instance.PRECEDING_TITLES_KEY;
+import static org.folio.inventory.domain.instances.Instance.SUCCEEDING_TITLES_KEY;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static support.matchers.ResponseMatchers.hasValidationError;
 
 import java.net.MalformedURLException;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.inventory.support.JsonArrayHelper;
 import org.folio.inventory.support.http.client.IndividualResource;
 import org.folio.inventory.support.http.client.Response;
 import org.junit.Test;
@@ -130,6 +139,135 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
     assertPrecedingSucceedingTitles(instanceResponse.getJson().getJsonArray("succeedingTitles")
         .getJsonObject(0), newSucceedingTitle, createdInstance.getId().toString(),
       null);
+  }
+
+  @Test
+  public void titleIsRequiredToCreateAnInstanceWithUnconnectedSucceedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+
+    final JsonObject succeedingTitle = createSemanticWebUnconnectedTitle(UUID.randomUUID().toString());
+    succeedingTitle.remove("title");
+
+    final JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID())
+      .put(SUCCEEDING_TITLES_KEY, new JsonArray()
+        .add(createSemanticWebUnconnectedTitle(UUID.randomUUID().toString()))
+        .add(succeedingTitle));
+
+    final Response response = instancesClient.attemptToCreate(smallAngryPlanetJson);
+
+    assertThat(response, hasValidationError("Title is required for unconnected succeeding title",
+      SUCCEEDING_TITLES_KEY + ".title", null));
+  }
+
+  @Test
+  public void titleIsRequiredToUpdateAnInstanceWithUnconnectedSucceedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+
+    final JsonObject succeedingTitle = createSemanticWebUnconnectedTitle(UUID.randomUUID().toString());
+    final JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID())
+      .put(SUCCEEDING_TITLES_KEY, new JsonArray()
+        .add(succeedingTitle));
+
+    final IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    final JsonObject newSucceedingTitle = succeedingTitle.copy();
+    newSucceedingTitle.remove("title");
+
+    final Response response = instancesClient.attemptToReplace(createdInstance.getId(),
+      createdInstance.getJson().copy().put(SUCCEEDING_TITLES_KEY, new JsonArray()
+        .add(succeedingTitle)
+        .add(newSucceedingTitle)));
+
+    assertThat(response, hasValidationError("Title is required for unconnected succeeding title",
+      SUCCEEDING_TITLES_KEY + ".title", null));
+  }
+
+  @Test
+  public void titleIsRequiredToCreateAnInstanceWithUnconnectedPrecedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+
+    final JsonObject precedingTitle = createSemanticWebUnconnectedTitle(UUID.randomUUID().toString());
+    precedingTitle.remove("title");
+
+    final JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID())
+      .put(PRECEDING_TITLES_KEY, new JsonArray()
+        .add(createSemanticWebUnconnectedTitle(UUID.randomUUID().toString()))
+        .add(precedingTitle));
+
+    final Response response = instancesClient.attemptToCreate(smallAngryPlanetJson);
+
+    assertThat(response, hasValidationError("Title is required for unconnected preceding title",
+      PRECEDING_TITLES_KEY + ".title", null));
+  }
+
+  @Test
+  public void titleIsRequiredToUpdateAnInstanceWithUnconnectedPrecedingTitles()
+    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+
+    final JsonObject precedingTitle = createSemanticWebUnconnectedTitle(UUID.randomUUID().toString());
+    final JsonObject smallAngryPlanetJson = smallAngryPlanet(UUID.randomUUID())
+      .put(PRECEDING_TITLES_KEY, new JsonArray().add(precedingTitle));
+
+    final IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
+
+    final JsonObject newPrecedingTitle = precedingTitle.copy();
+    newPrecedingTitle.remove("title");
+
+    final Response response = instancesClient.attemptToReplace(createdInstance.getId(),
+      createdInstance.getJson().copy().put(PRECEDING_TITLES_KEY, new JsonArray()
+        .add(precedingTitle)
+        .add(newPrecedingTitle)));
+
+    assertThat(response, hasValidationError("Title is required for unconnected preceding title",
+      PRECEDING_TITLES_KEY + ".title", null));
+  }
+
+  @Test
+  public void titleIsRequiredToCreateInstancesUsingBatch()
+    throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+
+    final JsonObject instanceWithValidPrecedingTitle = smallAngryPlanet(UUID.randomUUID())
+      .put(PRECEDING_TITLES_KEY, new JsonArray()
+        .add(createOpenBibliographyUnconnectedTitle(UUID.randomUUID().toString())));
+
+    final JsonObject unconnectedTitleNoTitle = createOpenBibliographyUnconnectedTitle(
+      UUID.randomUUID().toString());
+    unconnectedTitleNoTitle.remove("title");
+
+    final JsonObject instanceWithInvalidPrecedingTitle = smallAngryPlanet(UUID.randomUUID())
+      .put(PRECEDING_TITLES_KEY, new JsonArray().add(unconnectedTitleNoTitle));
+
+    final JsonObject instanceWithValidSucceedingTitle = smallAngryPlanet(UUID.randomUUID())
+      .put(SUCCEEDING_TITLES_KEY, new JsonArray()
+        .add(createSemanticWebUnconnectedTitle(UUID.randomUUID().toString())));
+
+    final JsonObject semanticWebUnconnectedTitleNoTitle = createSemanticWebUnconnectedTitle(
+      UUID.randomUUID().toString());
+    semanticWebUnconnectedTitleNoTitle.remove("title");
+
+    final JsonObject instanceWithInvalidSucceedingTitle = smallAngryPlanet(UUID.randomUUID())
+      .put(SUCCEEDING_TITLES_KEY, new JsonArray().add(semanticWebUnconnectedTitleNoTitle));
+
+
+    final JsonObject request = new JsonObject()
+      .put("instances", new JsonArray().add(instanceWithInvalidPrecedingTitle)
+        .add(instanceWithValidPrecedingTitle)
+        .add(instanceWithValidSucceedingTitle)
+        .add(instanceWithInvalidSucceedingTitle))
+      .put("totalRecords", 4);
+
+    final JsonObject response = instancesBatchClient.create(request)
+      .getJson();
+
+    assertThat(response.getJsonArray("errorMessages").size(), is(2));
+
+    final Map<String, JsonObject> createdValidInstances = JsonArrayHelper
+      .toList(response.getJsonArray("instances")).stream()
+      .collect(Collectors.toMap(json -> json.getString("id"), Function.identity()));
+
+    Arrays.asList(instanceWithValidPrecedingTitle, instanceWithValidSucceedingTitle)
+      .forEach(validInstance -> assertThat(createdValidInstances
+        .get(validInstance.getString("id")), notNullValue()));
   }
 
   @Test

--- a/src/test/java/api/support/ApiTests.java
+++ b/src/test/java/api/support/ApiTests.java
@@ -21,6 +21,7 @@ public abstract class ApiTests {
   protected final ResourceClient itemsStorageClient;
   protected final ResourceClient itemsClient;
   protected final ResourceClient instancesClient;
+  protected final ResourceClient instancesStorageClient;
   protected final ResourceClient isbnClient;
   protected final ResourceClient usersClient;
   protected final ResourceClient instancesBatchClient;
@@ -34,6 +35,7 @@ public abstract class ApiTests {
     itemsStorageClient = ResourceClient.forItemsStorage(okapiClient);
     itemsClient = ResourceClient.forItems(okapiClient);
     instancesClient = ResourceClient.forInstances(okapiClient);
+    instancesStorageClient = ResourceClient.forInstancesStorage(okapiClient);
     isbnClient = ResourceClient.forIsbns(okapiClient);
     usersClient = ResourceClient.forUsers(okapiClient);
     instancesBatchClient = ResourceClient.forInstancesBatch(okapiClient);

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -60,6 +60,11 @@ public class ResourceClient {
       "instances");
   }
 
+  public static ResourceClient forInstancesStorage(OkapiHttpClient okapiClient) {
+    return new ResourceClient(okapiClient, StorageInterfaceUrls::instancesStorageUrl,
+      "instances");
+  }
+
   public static ResourceClient forInstancesBatch(OkapiHttpClient client) {
     return new ResourceClient(client, BusinessLogicInterfaceUrls::instancesBatch,
       "instances");


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-218 - Title should be required for unconnected preceding / succeeding titles.

### Changes:

* Introduce validation to prevent an unconnected title will be created/updated without title.
* Update InstanceBatch as well.
* Refactor Instance.update/create endpoints to use completable futures.