### PR TITLE
MODINV-287: Allow In process items to be marked as withdrawn.

### DIFF
--- a/src/main/java/org/folio/inventory/validation/ItemMarkAsWithdrawnValidators.java
+++ b/src/main/java/org/folio/inventory/validation/ItemMarkAsWithdrawnValidators.java
@@ -15,6 +15,7 @@ public final class ItemMarkAsWithdrawnValidators {
     EnumSet.of(
       ItemStatusName.AVAILABLE,
       ItemStatusName.IN_TRANSIT,
+      ItemStatusName.IN_PROCESS,
       ItemStatusName.AWAITING_PICKUP,
       ItemStatusName.AWAITING_DELIVERY,
       ItemStatusName.MISSING,

--- a/src/test/java/api/items/ItemMarkWithdrawnApiTest.java
+++ b/src/test/java/api/items/ItemMarkWithdrawnApiTest.java
@@ -32,6 +32,7 @@ import junitparams.Parameters;
 public class ItemMarkWithdrawnApiTest extends ApiTests {
 
   @Parameters({
+    "In process",
     "Available",
     "In transit",
     "Awaiting pickup",
@@ -64,7 +65,8 @@ public class ItemMarkWithdrawnApiTest extends ApiTests {
     "On order",
     "Checked out",
     "Withdrawn",
-    "Claimed returned"
+    "Claimed returned",
+    "Declared lost"
   })
   @Test
   public void cannotWithdrawIItemWhenNotInAllowedStatus(String initialStatus) throws Exception {


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-287 - Can't mark in process items as withdrawn.

### Changes:
Allow `In process` items to be marked as withdrawn.