### PR TITLE
MODINV-277:Disallow editing of Preceding/Succeeding fields when Instance has an underlying MARC record

### DIFF
--- a/src/main/java/org/folio/inventory/config/InventoryConfigurationImpl.java
+++ b/src/main/java/org/folio/inventory/config/InventoryConfigurationImpl.java
@@ -30,7 +30,9 @@ public class InventoryConfigurationImpl implements InventoryConfiguration {
     Instance.TITLE_KEY,
     Instance.INDEX_TITLE_KEY,
     Instance.INSTANCE_TYPE_ID_KEY,
-    Instance.MODE_OF_ISSUANCE_ID_KEY
+    Instance.MODE_OF_ISSUANCE_ID_KEY,
+    Instance.PRECEDING_TITLES_KEY,
+    Instance.SUCCEEDING_TITLES_KEY
     );
 
   public InventoryConfigurationImpl() {

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -566,10 +566,10 @@ public class InstancesApiExamples extends ApiTests {
     assertThat(errors.size(), is(1));
     assertThat(errors.getJsonObject(0).getString("message"), is(
       "Instance is controlled by MARC record, these fields are blocked and can not be updated: " +
-        "physicalDescriptions,notes,languages,identifiers,instanceTypeId,modeOfIssuanceId,subjects," +
+        "physicalDescriptions,notes,languages,precedingTitles,identifiers,instanceTypeId,modeOfIssuanceId,subjects," +
         "source,title,indexTitle,publicationFrequency,electronicAccess,publicationRange," +
-        "classifications,editions,hrid,series,instanceFormatIds,publication,contributors," +
-        "alternativeTitles,precedingTitles,succeedingTitles"));
+        "classifications,succeedingTitles,editions,hrid,series,instanceFormatIds,publication,contributors," +
+        "alternativeTitles"));
 
     // Get existing Instance
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -569,7 +569,7 @@ public class InstancesApiExamples extends ApiTests {
         "physicalDescriptions,notes,languages,identifiers,instanceTypeId,modeOfIssuanceId,subjects," +
         "source,title,indexTitle,publicationFrequency,electronicAccess,publicationRange," +
         "classifications,editions,hrid,series,instanceFormatIds,publication,contributors," +
-        "alternativeTitles"));
+        "alternativeTitles,precedingTitles,succeedingTitles"));
 
     // Get existing Instance
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();


### PR DESCRIPTION
1. Preceding/Succeding titles added to the INSTANCE_BLOCKED_FIELDS.
2. Preceding/Succeding titles added to the InstancesApiExamples.