### PR TITLE
MODINV-291: Add 'Lost and paid' status to allowed item statuses list

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "10.4",
+      "version": "10.5",
       "handlers": [
         {
           "methods": ["GET"],
@@ -289,7 +289,7 @@
   "requires": [
     {
       "id": "item-storage",
-      "version": "8.3"
+      "version": "8.4"
     },
     {
       "id": "instance-storage",

--- a/ramls/inventory.raml
+++ b/ramls/inventory.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory API
-version: v10.4
+version: v10.5
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -258,7 +258,8 @@
             "Declared lost",
             "Order closed",
             "Claimed returned",
-            "Withdrawn"
+            "Withdrawn",
+            "Lost and paid"
           ]
         },
         "date": {

--- a/src/main/java/org/folio/inventory/domain/items/ItemStatusName.java
+++ b/src/main/java/org/folio/inventory/domain/items/ItemStatusName.java
@@ -18,7 +18,8 @@ public enum ItemStatusName {
   DECLARED_LOST("Declared lost"),
   ORDER_CLOSED("Order closed"),
   CLAIMED_RETURNED("Claimed returned"),
-  WITHDRAWN("Withdrawn");
+  WITHDRAWN("Withdrawn"),
+  LOST_AND_PAID("Lost and paid");
 
   private static final Map<String, ItemStatusName> VALUE_TO_INSTANCE_MAP = initValueToInstanceMap();
   private final String value;

--- a/src/test/java/api/items/ItemAllowedStatusesSchemaTest.java
+++ b/src/test/java/api/items/ItemAllowedStatusesSchemaTest.java
@@ -1,35 +1,24 @@
 package api.items;
 
-import static api.support.InstanceSamples.smallAngryPlanet;
 import static java.nio.file.Files.readAllBytes;
 import static java.nio.file.Paths.get;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.folio.inventory.domain.items.ItemStatusName;
-import org.folio.inventory.support.http.client.IndividualResource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import api.support.ApiTests;
-import api.support.builders.HoldingRequestBuilder;
-import api.support.builders.ItemRequestBuilder;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 
 /**
  * This test verifies that ramls/item.json and {@link ItemStatusName} is consistent.
@@ -51,32 +40,6 @@ public class ItemAllowedStatusesSchemaTest extends ApiTests {
 
     assertEquals("Schema enum does not match ItemStatusName values",
       enumAllowedItemStatuses, schemaAllowedItemStatuses);
-  }
-
-  @Test
-  @Parameters(method = "getItemStatusNameEnumAllowedItemStatuses")
-  public void canCreateItemsWithAllStatuses(String itemStatus) throws Exception {
-    final UUID holdingsId = createInstanceAndHolding();
-
-    final IndividualResource createResponse = itemsClient.create(
-      new ItemRequestBuilder()
-        .forHolding(holdingsId)
-        .canCirculate()
-        .withStatus(itemStatus));
-
-    assertThat(createResponse.getJson().getJsonObject("status").getString("name"),
-      is(itemStatus));
-  }
-
-  private UUID createInstanceAndHolding() throws MalformedURLException,
-    InterruptedException, ExecutionException, TimeoutException {
-
-    final IndividualResource instance = instancesClient
-      .create(smallAngryPlanet(UUID.randomUUID()));
-
-    return holdingsStorageClient
-      .create(new HoldingRequestBuilder().forInstance(instance.getId()))
-      .getId();
   }
 
   private Set<String> getSchemaAllowedItemStatuses() throws IOException {

--- a/src/test/java/api/items/ItemApiExamples.java
+++ b/src/test/java/api/items/ItemApiExamples.java
@@ -22,6 +22,7 @@ import static org.folio.inventory.domain.user.User.ID_KEY;
 import static org.folio.inventory.domain.user.User.PERSONAL_KEY;
 import static org.folio.util.StringUtil.urlEncode;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -35,13 +36,13 @@ import static support.matchers.TextDateTimeMatcher.withinSecondsAfter;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.inventory.domain.items.Item;
@@ -50,7 +51,6 @@ import org.folio.inventory.support.http.client.IndividualResource;
 import org.folio.inventory.support.http.client.Response;
 import org.folio.inventory.support.http.client.ResponseHandler;
 import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Seconds;
@@ -118,11 +118,7 @@ public class ItemApiExamples extends ApiTests {
 
     assertThat(createdItem.containsKey(Item.TAGS_KEY), is(true));
 
-    final JsonObject tags = createdItem.getJsonObject(Item.TAGS_KEY);
-    assertThat(tags.containsKey(Item.TAG_LIST_KEY), is(true));
-
-    final JsonArray tagList = tags.getJsonArray(Item.TAG_LIST_KEY);
-    assertThat((ArrayList<String>)tagList.getList(), hasItem("test-tag"));
+    assertThat(getTags(createdItem), hasItem("test-tag"));
 
     assertThat(createdItem.getString("title"), is("Long Way to a Small Angry Planet"));
     assertThat(createdItem.getString("barcode"), is("645398607547"));
@@ -193,15 +189,7 @@ public class ItemApiExamples extends ApiTests {
 
     JsonObject materialType = createdItem.getJsonObject("materialType");
 
-    assertThat(createdItem.containsKey(Item.TAGS_KEY), is(true));
-
-    final JsonObject tags = createdItem.getJsonObject(Item.TAGS_KEY);
-    assertThat(tags.containsKey(Item.TAG_LIST_KEY), is(true));
-
-    final JsonArray tagList = tags.getJsonArray(Item.TAG_LIST_KEY);
-    assertThat(tagList.size(), is(2));
-    assertThat((ArrayList<String>)tagList.getList(), hasItem("test-tag"));
-    assertThat((ArrayList<String>)tagList.getList(), hasItem("test-tag2"));
+    assertThat(getTags(createdItem), hasItems("test-tag", "test-tag2"));
 
     assertThat(materialType.getString("id"), is(ApiTestSuite.getBookMaterialType()));
     assertThat(materialType.getString("name"), is("Book"));
@@ -487,14 +475,7 @@ public class ItemApiExamples extends ApiTests {
     assertThat(getResponse.getStatusCode(), is(200));
     JsonObject updatedItem = getResponse.getJson();
 
-    assertThat(updatedItem.containsKey(Item.TAGS_KEY), is(true));
-    final JsonObject tags = updatedItem.getJsonObject(Item.TAGS_KEY);
-
-    assertThat(tags.containsKey(Item.TAG_LIST_KEY), is(true));
-
-    final JsonArray tagList = tags.getJsonArray(Item.TAG_LIST_KEY);
-    assertThat((ArrayList<String>)tagList.getList(), hasItem(""));
-
+    assertThat(getTags(updatedItem), hasItem(""));
     assertThat(updatedItem.containsKey("id"), is(true));
     assertThat(updatedItem.getString("title"), is("Long Way to a Small Angry Planet"));
     assertThat(updatedItem.getString("barcode"), is("645398607547"));
@@ -801,21 +782,21 @@ public class ItemApiExamples extends ApiTests {
 
     assertThat(items.stream()
       .filter(item -> StringUtils.equals(item.getString("barcode"), "645398607547"))
-      .findFirst().get().getJsonObject("permanentLoanType").getString("id"),
+      .findFirst().orElse(new JsonObject()).getJsonObject("permanentLoanType").getString("id"),
       is(ApiTestSuite.getCanCirculateLoanType()));
 
     assertThat(items.stream()
       .filter(item -> StringUtils.equals(item.getString("barcode"), "645398607547"))
-      .findFirst().get().containsKey("temporaryLoanType"), is(false));
+      .findFirst().orElse(new JsonObject()).containsKey("temporaryLoanType"), is(false));
 
     assertThat(items.stream()
       .filter(item -> StringUtils.equals(item.getString("barcode"), "175848607547"))
-      .findFirst().get().getJsonObject("permanentLoanType").getString("id"),
+      .findFirst().orElse(new JsonObject()).getJsonObject("permanentLoanType").getString("id"),
       is(ApiTestSuite.getCanCirculateLoanType()));
 
     assertThat(items.stream()
       .filter(item -> StringUtils.equals(item.getString("barcode"), "175848607547"))
-      .findFirst().get().getJsonObject("temporaryLoanType").getString("id"),
+      .findFirst().orElse(new JsonObject()).getJsonObject("temporaryLoanType").getString("id"),
       is(ApiTestSuite.getCourseReserveLoanType()));
 
     items.forEach(ItemApiExamples::hasConsistentPermanentLoanType);
@@ -1832,5 +1813,11 @@ public class ItemApiExamples extends ApiTests {
     assertThat(callNumberComponents.getString("suffix"), is(CALL_NUMBER_SUFFIX));
     assertThat(callNumberComponents.getString("prefix"), is(CALL_NUMBER_PREFIX));
     assertThat(callNumberComponents.getString("typeId"), is(CALL_NUMBER_TYPE_ID));
+  }
+
+  private List<String> getTags(JsonObject item) {
+    return item.getJsonObject(Item.TAGS_KEY).getJsonArray(Item.TAG_LIST_KEY).stream()
+      .map(Object::toString)
+      .collect(Collectors.toList());
   }
 }

--- a/src/test/java/api/items/ItemApiExamples.java
+++ b/src/test/java/api/items/ItemApiExamples.java
@@ -50,11 +50,13 @@ import org.folio.inventory.support.http.client.IndividualResource;
 import org.folio.inventory.support.http.client.Response;
 import org.folio.inventory.support.http.client.ResponseHandler;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Seconds;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import api.ApiTestSuite;
 import api.support.ApiRoot;
@@ -64,7 +66,10 @@ import api.support.builders.HoldingRequestBuilder;
 import api.support.builders.ItemRequestBuilder;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 
+@RunWith(JUnitParamsRunner.class)
 public class ItemApiExamples extends ApiTests {
 
   private static final String LAST_CHECK_IN_FIELD = "lastCheckIn";
@@ -1640,6 +1645,36 @@ public class ItemApiExamples extends ApiTests {
 
     Response updateResponse = updateItem(updatedItem);
     assertThat(updateResponse.getStatusCode(), is(204));
+  }
+
+  @Test
+  @Parameters({
+    "Available",
+    "Awaiting pickup",
+    "Awaiting delivery",
+    "Checked out",
+    "In process",
+    "In transit",
+    "Missing",
+    "On order",
+    "Paged",
+    "Declared lost",
+    "Order closed",
+    "Claimed returned",
+    "Withdrawn",
+    "Lost and paid"
+  })
+  public void canCreateItemsWithAllStatuses(String itemStatus) throws Exception {
+    final UUID holdingsId = createInstanceAndHolding();
+
+    final IndividualResource createResponse = itemsClient.create(
+      new ItemRequestBuilder()
+        .forHolding(holdingsId)
+        .canCirculate()
+        .withStatus(itemStatus));
+
+    assertThat(createResponse.getJson().getJsonObject("status").getString("name"),
+      is(itemStatus));
   }
 
   private Response updateItem(JsonObject item) throws MalformedURLException,


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-291 - Add 'Lost and paid' status to allowed item statuses list.

### Changes:
* Add `Lost and paid` status to allowed item's statuses list;
* Update inventory API version;
* Fix some code analysis issues;
 