### PR TITLE
MODINV-307: Fix typo in module permissions for mark-withdrawn API.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -52,7 +52,7 @@
           "modulePermissions": [
             "circulation-storage.requests.collection.get",
             "circulation-storage.requests.item.put",
-            "inventory-storage.items.item.post",
+            "inventory-storage.items.item.put",
             "inventory-storage.material-types.item.get",
             "inventory-storage.material-types.collection.get",
             "inventory-storage.loan-types.item.get",


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-307 - Fix typo in mark-item-withdrawn module permission.

### Changes 

There was a typo in modulePermissions for the mark-withdrawn API was `inventory-storage.items.item.post` but required `inventory-storage.items.item.put`