### PR TITLE
MODINV-311: Adding or changing notes in quickMARC creates error in Instance record notes [BUGFIX].

### DIFF
--- a/ramls/holdings-notes.json
+++ b/ramls/holdings-notes.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Note for holding record",
+  "javaType": "org.folio.rest.jaxrs.model.HoldingsNotes",
+  "type": "object",
+  "additionalProperties": false,
+    "properties": {
+      "holdingsNoteTypeId": {
+        "type": "string",
+        "description": "ID of the type of note",
+        "$ref": "./uuid.json"
+      },
+      "note": {
+        "type": "string",
+        "description": "Text content of the note"
+      },
+      "staffOnly": {
+        "type": "boolean",
+        "description": "If true, determines that the note should not be visible for others than staff",
+        "default": false
+      }
+  }
+}

--- a/ramls/holdings-record.json
+++ b/ramls/holdings-record.json
@@ -107,7 +107,7 @@
       "description": "Receipt status (e.g. pending, awaiting receipt, partially received, fully received, receipt not required, and cancelled)"
     },
     "notes": {
-      "description": "Notes for holdings",
+      "description": "Notes about action, copy, binding etc.",
       "type": "array",
       "items": {
         "type": "object",

--- a/ramls/holdings-record.json
+++ b/ramls/holdings-record.json
@@ -107,26 +107,11 @@
       "description": "Receipt status (e.g. pending, awaiting receipt, partially received, fully received, receipt not required, and cancelled)"
     },
     "notes": {
+      "description": "Notes for holdings",
       "type": "array",
-      "description": "Notes about action, copy, binding etc.",
       "items": {
         "type": "object",
-        "properties": {
-          "holdingsNoteTypeId": {
-            "type": "string",
-            "description": "ID of the type of note",
-            "$ref": "./uuid.json"
-          },
-          "note": {
-            "type": "string",
-            "description": "Text content of the note"
-          },
-          "staffOnly": {
-            "type": "boolean",
-            "description": "If true, determines that the note should not be visible for others than staff",
-            "default": false
-          }
-        }
+        "$ref": "holdings-notes.json"
       }
     },
     "illPolicyId": {

--- a/ramls/item-notes.json
+++ b/ramls/item-notes.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Note for item record",
+  "type": "object",
+  "javaType": "org.folio.rest.jaxrs.model.ItemNotes",
+  "additionalProperties": false,
+  "properties": {
+    "itemNoteTypeId": {
+      "description": "Item note type, refers to a item-note-type reference record",
+      "type": "string"
+    },
+    "note": {
+      "description": "Text to display (e.g. action note, binding, use and reproduction)",
+      "type": "string"
+    },
+    "staffOnly": {
+      "description": "Records the fact that the record should only be displayed for staff",
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -159,7 +159,7 @@
       "type": "string"
     },
     "notes": {
-      "description": "Notes for item",
+      "description": "Notes about action, copy, binding etc.",
       "type": "array",
       "items": {
         "$ref": "item-notes.json"

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -159,7 +159,7 @@
       "type": "string"
     },
     "notes": {
-      "description": "Notes about action, copy, binding etc.",
+      "description": "notes",
       "type": "array",
       "items": {
         "$ref": "item-notes.json"

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -159,25 +159,10 @@
       "type": "string"
     },
     "notes": {
-      "description": "notes",
+      "description": "Notes for item",
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "itemNoteTypeId": {
-            "description": "Item note type, refers to a item-note-type reference record",
-            "type": "string"
-          },
-          "note": {
-            "description": "Text to display (e.g. action note, binding, use and reproduction)",
-            "type": "string"
-          },
-          "staffOnly": {
-            "description": "Records the fact that the record should only be displayed for staff",
-            "type": "boolean",
-            "default": false
-          }
-        }
+        "$ref": "item-notes.json"
       }
     },
     "circulationNotes": {

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
@@ -57,6 +57,7 @@ import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTI
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,7 +69,7 @@ import static org.mockito.Mockito.when;
 
 public class CreateInstanceEventHandlerTest {
 
-  private static final String PARSED_CONTENT_WITH_PRECEDING_SUCCEEDING_TITLES = "{\"leader\": \"01314nam  22003851a 4500\", \"fields\":[ {\"001\":\"ybp7406411\"},{\"780\": {\"ind1\":\"0\",\"ind2\":\"0\", \"subfields\":[{\"t\":\"Houston oil directory\"}]}},{ \"785\": { \"ind1\": \"0\", \"ind2\": \"0\", \"subfields\": [ { \"t\": \"SAIS review of international affairs\" }, {\"x\": \"1945-4724\" }]}}]}";
+  private static final String PARSED_CONTENT = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}}]}\n";
   private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/rules.json";
   public static final String OKAPI_URL = "http://localhost";
 
@@ -171,7 +172,7 @@ public class CreateInstanceEventHandlerTest {
     MappingManager.registerWriterFactory(new InstanceWriterFactory());
 
     HashMap<String, String> context = new HashMap<>();
-    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_PRECEDING_SUCCEEDING_TITLES));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT));
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
     context.put("MAPPING_RULES", mappingRules.encode());
     context.put("MAPPING_PARAMS", new JsonObject().encode());
@@ -195,6 +196,9 @@ public class CreateInstanceEventHandlerTest {
     Assert.assertEquals("MARC", createdInstance.getString("source"));
     Assert.assertThat(createdInstance.getJsonArray("precedingTitles").size(), is(1));
     Assert.assertThat(createdInstance.getJsonArray("succeedingTitles").size(), is(1));
+    Assert.assertThat(createdInstance.getJsonArray("notes").size(), is(2));
+    Assert.assertThat(createdInstance.getJsonArray("notes").getJsonObject(0).getString("instanceNoteTypeId"), notNullValue());
+    Assert.assertThat(createdInstance.getJsonArray("notes").getJsonObject(1).getString("instanceNoteTypeId"), notNullValue());
     verify(mockedClient, times(2)).postAbs(anyString(), any(Handler.class));
   }
 

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
@@ -58,6 +58,7 @@ import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTI
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -69,7 +70,7 @@ import static org.mockito.Mockito.when;
 
 public class ReplaceInstanceEventHandlerTest {
 
-  private static final String PARSED_CONTENT_WITH_PRECEDING_SUCCEEDING_TITLES = "{\"leader\": \"01314nam  22003851a 4500\", \"fields\":[ {\"001\":\"ybp7406411\"},{\"780\": {\"ind1\":\"0\",\"ind2\":\"0\", \"subfields\":[{\"t\":\"Houston oil directory\"}]}},{ \"785\": { \"ind1\": \"0\", \"ind2\": \"0\", \"subfields\": [ { \"t\": \"SAIS review of international affairs\" }, {\"x\": \"1945-4724\" }]}}]}";
+  private static final String PARSED_CONTENT = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}}]}\n";
   private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/rules.json";
   public static final String OKAPI_URL = "http://localhost";
 
@@ -172,7 +173,7 @@ public class ReplaceInstanceEventHandlerTest {
     MappingManager.registerWriterFactory(new InstanceWriterFactory());
 
     HashMap<String, String> context = new HashMap<>();
-    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_PRECEDING_SUCCEEDING_TITLES));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT));
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
     context.put("MAPPING_RULES", mappingRules.encode());
     context.put("MAPPING_PARAMS", new JsonObject().encode());
@@ -200,6 +201,9 @@ public class ReplaceInstanceEventHandlerTest {
     Assert.assertEquals("MARC", createdInstance.getString("source"));
     Assert.assertThat(createdInstance.getJsonArray("precedingTitles").size(), is(1));
     Assert.assertThat(createdInstance.getJsonArray("succeedingTitles").size(), is(1));
+    Assert.assertThat(createdInstance.getJsonArray("notes").size(), is(2));
+    Assert.assertThat(createdInstance.getJsonArray("notes").getJsonObject(0).getString("instanceNoteTypeId"), notNullValue());
+    Assert.assertThat(createdInstance.getJsonArray("notes").getJsonObject(1).getString("instanceNoteTypeId"), notNullValue());
     verify(mockedClient, times(2)).postAbs(anyString(), any(Handler.class));
   }
 


### PR DESCRIPTION
1. Notes for holdings and items moved to the separate files.