### PR TITLE
MODINV-299: Add 'Aged to lost' item status.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "10.5",
+      "version": "10.6",
       "handlers": [
         {
           "methods": ["GET"],
@@ -358,7 +358,7 @@
   "requires": [
     {
       "id": "item-storage",
-      "version": "8.4"
+      "version": "8.5"
     },
     {
       "id": "instance-storage",

--- a/ramls/inventory.raml
+++ b/ramls/inventory.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory API
-version: v10.5
+version: v10.6
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -244,7 +244,8 @@
             "Order closed",
             "Claimed returned",
             "Withdrawn",
-            "Lost and paid"
+            "Lost and paid",
+            "Aged to lost"
           ]
         },
         "date": {

--- a/src/main/java/org/folio/inventory/domain/items/ItemStatusName.java
+++ b/src/main/java/org/folio/inventory/domain/items/ItemStatusName.java
@@ -19,7 +19,8 @@ public enum ItemStatusName {
   ORDER_CLOSED("Order closed"),
   CLAIMED_RETURNED("Claimed returned"),
   WITHDRAWN("Withdrawn"),
-  LOST_AND_PAID("Lost and paid");
+  LOST_AND_PAID("Lost and paid"),
+  AGED_TO_LOST("Aged to lost");
 
   private static final Map<String, ItemStatusName> VALUE_TO_INSTANCE_MAP = initValueToInstanceMap();
   private final String value;

--- a/src/test/java/api/items/ItemApiExamples.java
+++ b/src/test/java/api/items/ItemApiExamples.java
@@ -1643,7 +1643,8 @@ public class ItemApiExamples extends ApiTests {
     "Order closed",
     "Claimed returned",
     "Withdrawn",
-    "Lost and paid"
+    "Lost and paid",
+    "Aged to lost"
   })
   public void canCreateItemsWithAllStatuses(String itemStatus) throws Exception {
     final UUID holdingsId = createInstanceAndHolding();


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-299 - Add 'Aged to lost' status to allowed item statuses list


### Changes: 

* Add new `Aged to lost` item status;
* Update `inventory` API version.
* Require `item-storage:8.5`