### PR TITLE
MODINV-329 - Move: endpoints invalid status code

### DIFF
--- a/src/main/java/org/folio/inventory/support/http/server/JsonResponse.java
+++ b/src/main/java/org/folio/inventory/support/http/server/JsonResponse.java
@@ -31,13 +31,13 @@ public class JsonResponse {
   }
 
   public static void successWithEmptyBody(HttpServerResponse response) {
-    emptyResponse(response, 200);
+    emptyResponse(response, 201);
   }
 
   public static void successWithIds(HttpServerResponse response, List<String> ids) {
     JsonObject nonUpdatedIds = new JsonObject();
     nonUpdatedIds.put("nonUpdatedIds", ids);
-    response(response, nonUpdatedIds, 200);
+    response(response, nonUpdatedIds, 201);
   }
 
   public static void unprocessableEntity(

--- a/src/test/java/api/holdings/HoldingsApiMoveExamples.java
+++ b/src/test/java/api/holdings/HoldingsApiMoveExamples.java
@@ -58,7 +58,7 @@ public class HoldingsApiMoveExamples extends ApiTests {
 
     Response postHoldingsMoveResponse = moveHoldingsRecords(holdingsRecordMoveRequestBody);
 
-    assertThat(postHoldingsMoveResponse.getStatusCode(), is(200));
+    assertThat(postHoldingsMoveResponse.getStatusCode(), is(201));
     assertThat(postHoldingsMoveResponse.getBody(), is(StringUtils.EMPTY));
     assertThat(postHoldingsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
@@ -89,7 +89,7 @@ public class HoldingsApiMoveExamples extends ApiTests {
 
     Response postHoldingsRecordsMoveResponse = moveHoldingsRecords(holdingsRecordMoveRequestBody);
 
-    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(200));
+    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(201));
     assertThat(postHoldingsRecordsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     List notFoundIds = postHoldingsRecordsMoveResponse.getJson()
@@ -195,7 +195,7 @@ public class HoldingsApiMoveExamples extends ApiTests {
     assertThat(nonUpdatedIdsIds.size(), is(1));
     assertThat(nonUpdatedIdsIds.get(0), equalTo(ID_FOR_FAILURE.toString()));
 
-    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(200));
+    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(201));
     assertThat(postHoldingsRecordsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     JsonObject updatedHoldingsRecord1 = holdingsStorageClient.getById(createHoldingsRecord1)

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -66,7 +66,7 @@ public class ItemApiMoveExamples extends ApiTests {
 
     Response postItemsMoveResponse = moveItems(itemsMoveRequestBody);
 
-    assertThat(postItemsMoveResponse.getStatusCode(), is(200));
+    assertThat(postItemsMoveResponse.getStatusCode(), is(201));
     assertThat(postItemsMoveResponse.getBody(), is(StringUtils.EMPTY));
     assertThat(postItemsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
@@ -101,7 +101,7 @@ public class ItemApiMoveExamples extends ApiTests {
 
     Response postItemsMoveResponse = moveItems(itemsMoveRequestBody);
 
-    assertThat(postItemsMoveResponse.getStatusCode(), is(200));
+    assertThat(postItemsMoveResponse.getStatusCode(), is(201));
     assertThat(postItemsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     List notFoundIds = postItemsMoveResponse.getJson()
@@ -217,7 +217,7 @@ public class ItemApiMoveExamples extends ApiTests {
     assertThat(nonUpdatedIdsIds.size(), is(1));
     assertThat(nonUpdatedIdsIds.get(0), equalTo(ID_FOR_FAILURE.toString()));
 
-    assertThat(postItemsMoveResponse.getStatusCode(), is(200));
+    assertThat(postItemsMoveResponse.getStatusCode(), is(201));
     assertThat(postItemsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     JsonObject updatedItem1 = itemsClient.getById(createItem1.getId())


### PR DESCRIPTION
Fix for http status code mismatching [MODINV-329](https://issues.folio.org/browse/MODINV-329).