### PR TITLE
MODINV-329 - Move: endpoints invalid status code

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -262,7 +262,7 @@
     },
     {
       "id": "inventory-move",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/inventory-move.raml
+++ b/ramls/inventory-move.raml
@@ -26,7 +26,7 @@ traits:
       application/json:
         type: items_move
     responses:
-      201:
+      200:
         description: "Items moved to another holdings record"
         body:
           application/json:
@@ -49,7 +49,7 @@ traits:
       application/json:
         type: holdings_move
     responses:
-      201:
+      200:
         description: "Holdings record moved to another instance"
         body:
           application/json:

--- a/ramls/inventory-move.raml
+++ b/ramls/inventory-move.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Move API
-version: v0.1
+version: v0.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/src/main/java/org/folio/inventory/resources/MoveApi.java
+++ b/src/main/java/org/folio/inventory/resources/MoveApi.java
@@ -192,7 +192,7 @@ public class MoveApi extends AbstractInventoryResource {
     List<String> nonUpdatedIds = ListUtils.subtract(itemIdsToUpdate, updatedItemIds);
     HttpServerResponse response = routingContext.response();
     if (nonUpdatedIds.isEmpty()) {
-      JsonResponse.successWithEmptyBody(response);
+      JsonResponse.successWithEmptyIds(response);
     } else {
       JsonResponse.successWithIds(response, nonUpdatedIds);
     }

--- a/src/main/java/org/folio/inventory/resources/MoveApi.java
+++ b/src/main/java/org/folio/inventory/resources/MoveApi.java
@@ -2,12 +2,14 @@ package org.folio.inventory.resources;
 
 import static java.util.stream.Collectors.toList;
 import static org.folio.inventory.support.JsonArrayHelper.toListOfStrings;
+import static org.folio.inventory.support.http.server.JsonResponse.success;
 import static org.folio.inventory.support.http.server.JsonResponse.unprocessableEntity;
 import static org.folio.inventory.validation.MoveValidator.holdingsMoveHasRequiredFields;
 import static org.folio.inventory.validation.MoveValidator.itemsMoveHasRequiredFields;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -192,9 +194,9 @@ public class MoveApi extends AbstractInventoryResource {
     List<String> nonUpdatedIds = ListUtils.subtract(itemIdsToUpdate, updatedItemIds);
     HttpServerResponse response = routingContext.response();
     if (nonUpdatedIds.isEmpty()) {
-      JsonResponse.successWithEmptyIds(response);
+      successWithEmptyIds(response);
     } else {
-      JsonResponse.successWithIds(response, nonUpdatedIds);
+      successWithIds(response, nonUpdatedIds);
     }
   }
 
@@ -237,5 +239,13 @@ public class MoveApi extends AbstractInventoryResource {
 
   private MultipleRecordsFetchClient createHoldingsRecordsFetchClient(CollectionResourceClient client) {
     return createFetchClient(client, HOLDINGS_RECORDS_PROPERTY);
+  }
+
+  private void successWithIds(HttpServerResponse response, List<String> ids) {
+    success(response, new JsonObject().put("nonUpdatedIds", ids));
+  }
+
+  private void successWithEmptyIds(HttpServerResponse response) {
+    successWithIds(response, new ArrayList<>());
   }
 }

--- a/src/main/java/org/folio/inventory/support/http/server/JsonResponse.java
+++ b/src/main/java/org/folio/inventory/support/http/server/JsonResponse.java
@@ -1,6 +1,5 @@
 package org.folio.inventory.support.http.server;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,16 +28,6 @@ public class JsonResponse {
                              JsonObject body) {
 
     response(response, body, 200);
-  }
-
-  public static void successWithEmptyIds(HttpServerResponse response) {
-    successWithIds(response, new ArrayList<>());
-  }
-
-  public static void successWithIds(HttpServerResponse response, List<String> ids) {
-    JsonObject nonUpdatedIds = new JsonObject();
-    nonUpdatedIds.put("nonUpdatedIds", ids);
-    response(response, nonUpdatedIds, 200);
   }
 
   public static void unprocessableEntity(
@@ -95,5 +84,4 @@ public class JsonResponse {
     response.write(buffer);
     response.end();
   }
-
 }

--- a/src/main/java/org/folio/inventory/support/http/server/JsonResponse.java
+++ b/src/main/java/org/folio/inventory/support/http/server/JsonResponse.java
@@ -31,13 +31,13 @@ public class JsonResponse {
   }
 
   public static void successWithEmptyBody(HttpServerResponse response) {
-    emptyResponse(response, 200);
+    emptyResponse(response, 201);
   }
 
   public static void successWithIds(HttpServerResponse response, List<String> ids) {
     JsonObject nonUpdatedIds = new JsonObject();
     nonUpdatedIds.put("nonUpdatedIds", ids);
-    response(response, nonUpdatedIds, 200);
+    response(response, nonUpdatedIds, 201);
   }
 
   public static void unprocessableEntity(

--- a/src/main/java/org/folio/inventory/support/http/server/JsonResponse.java
+++ b/src/main/java/org/folio/inventory/support/http/server/JsonResponse.java
@@ -1,5 +1,6 @@
 package org.folio.inventory.support.http.server;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -30,14 +31,14 @@ public class JsonResponse {
     response(response, body, 200);
   }
 
-  public static void successWithEmptyBody(HttpServerResponse response) {
-    emptyResponse(response, 201);
+  public static void successWithEmptyIds(HttpServerResponse response) {
+    successWithIds(response, new ArrayList<>());
   }
 
   public static void successWithIds(HttpServerResponse response, List<String> ids) {
     JsonObject nonUpdatedIds = new JsonObject();
     nonUpdatedIds.put("nonUpdatedIds", ids);
-    response(response, nonUpdatedIds, 201);
+    response(response, nonUpdatedIds, 200);
   }
 
   public static void unprocessableEntity(
@@ -95,9 +96,4 @@ public class JsonResponse {
     response.end();
   }
 
-  private static void emptyResponse(HttpServerResponse response, int statusCode) {
-    response.setStatusCode(statusCode);
-    response.putHeader(HttpHeaders.CONTENT_TYPE, String.format("%s; charset=utf-8", ContentType.APPLICATION_JSON));
-    response.end(new JsonObject().toBuffer());
-  }
 }

--- a/src/main/java/org/folio/inventory/support/http/server/JsonResponse.java
+++ b/src/main/java/org/folio/inventory/support/http/server/JsonResponse.java
@@ -98,6 +98,6 @@ public class JsonResponse {
   private static void emptyResponse(HttpServerResponse response, int statusCode) {
     response.setStatusCode(statusCode);
     response.putHeader(HttpHeaders.CONTENT_TYPE, String.format("%s; charset=utf-8", ContentType.APPLICATION_JSON));
-    response.end();
+    response.end(new JsonObject().toBuffer());
   }
 }

--- a/src/test/java/api/holdings/HoldingsApiMoveExamples.java
+++ b/src/test/java/api/holdings/HoldingsApiMoveExamples.java
@@ -57,8 +57,8 @@ public class HoldingsApiMoveExamples extends ApiTests {
 
     Response postHoldingsMoveResponse = moveHoldingsRecords(holdingsRecordMoveRequestBody);
 
-    assertThat(postHoldingsMoveResponse.getStatusCode(), is(201));
-    assertThat(postHoldingsMoveResponse.getBody(), is(new JsonObject().toString()));
+    assertThat(postHoldingsMoveResponse.getStatusCode(), is(200));
+    assertThat(new JsonObject(postHoldingsMoveResponse.getBody()).getJsonArray("nonUpdatedIds").size(), is(0));
     assertThat(postHoldingsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     JsonObject holdingsRecord1 = holdingsStorageClient.getById(createHoldingsRecord1)
@@ -88,7 +88,7 @@ public class HoldingsApiMoveExamples extends ApiTests {
 
     Response postHoldingsRecordsMoveResponse = moveHoldingsRecords(holdingsRecordMoveRequestBody);
 
-    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(201));
+    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(200));
     assertThat(postHoldingsRecordsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     List notFoundIds = postHoldingsRecordsMoveResponse.getJson()
@@ -194,7 +194,7 @@ public class HoldingsApiMoveExamples extends ApiTests {
     assertThat(nonUpdatedIdsIds.size(), is(1));
     assertThat(nonUpdatedIdsIds.get(0), equalTo(ID_FOR_FAILURE.toString()));
 
-    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(201));
+    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(200));
     assertThat(postHoldingsRecordsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     JsonObject updatedHoldingsRecord1 = holdingsStorageClient.getById(createHoldingsRecord1)

--- a/src/test/java/api/holdings/HoldingsApiMoveExamples.java
+++ b/src/test/java/api/holdings/HoldingsApiMoveExamples.java
@@ -58,7 +58,7 @@ public class HoldingsApiMoveExamples extends ApiTests {
 
     Response postHoldingsMoveResponse = moveHoldingsRecords(holdingsRecordMoveRequestBody);
 
-    assertThat(postHoldingsMoveResponse.getStatusCode(), is(200));
+    assertThat(postHoldingsMoveResponse.getStatusCode(), is(201));
     assertThat(postHoldingsMoveResponse.getBody(), is(StringUtils.EMPTY));
     assertThat(postHoldingsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
@@ -89,7 +89,7 @@ public class HoldingsApiMoveExamples extends ApiTests {
 
     Response postHoldingsRecordsMoveResponse = moveHoldingsRecords(holdingsRecordMoveRequestBody);
 
-    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(200));
+    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(201));
     assertThat(postHoldingsRecordsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     List notFoundIds = postHoldingsRecordsMoveResponse.getJson()
@@ -195,7 +195,7 @@ public class HoldingsApiMoveExamples extends ApiTests {
     assertThat(nonUpdatedIdsIds.size(), is(1));
     assertThat(nonUpdatedIdsIds.get(0), equalTo(ID_FOR_FAILURE.toString()));
 
-    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(200));
+    assertThat(postHoldingsRecordsMoveResponse.getStatusCode(), is(201));
     assertThat(postHoldingsRecordsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     JsonObject updatedHoldingsRecord1 = holdingsStorageClient.getById(createHoldingsRecord1)

--- a/src/test/java/api/holdings/HoldingsApiMoveExamples.java
+++ b/src/test/java/api/holdings/HoldingsApiMoveExamples.java
@@ -8,7 +8,6 @@ import api.support.builders.HoldingsRecordMoveRequestBuilder;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
-import org.apache.commons.lang3.StringUtils;
 import org.folio.inventory.support.http.client.Response;
 import org.folio.inventory.support.http.client.ResponseHandler;
 import org.junit.Assert;
@@ -59,7 +58,7 @@ public class HoldingsApiMoveExamples extends ApiTests {
     Response postHoldingsMoveResponse = moveHoldingsRecords(holdingsRecordMoveRequestBody);
 
     assertThat(postHoldingsMoveResponse.getStatusCode(), is(201));
-    assertThat(postHoldingsMoveResponse.getBody(), is(StringUtils.EMPTY));
+    assertThat(postHoldingsMoveResponse.getBody(), is(new JsonObject().toString()));
     assertThat(postHoldingsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     JsonObject holdingsRecord1 = holdingsStorageClient.getById(createHoldingsRecord1)

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -65,8 +65,8 @@ public class ItemApiMoveExamples extends ApiTests {
 
     Response postItemsMoveResponse = moveItems(itemsMoveRequestBody);
 
-    assertThat(postItemsMoveResponse.getStatusCode(), is(201));
-    assertThat(postItemsMoveResponse.getBody(), is(new JsonObject().toString()));
+    assertThat(postItemsMoveResponse.getStatusCode(), is(200));
+    assertThat(new JsonObject(postItemsMoveResponse.getBody()).getJsonArray("nonUpdatedIds").size(), is(0));
     assertThat(postItemsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     JsonObject updatedItem1 = itemsClient.getById(createItem1.getId())
@@ -100,7 +100,7 @@ public class ItemApiMoveExamples extends ApiTests {
 
     Response postItemsMoveResponse = moveItems(itemsMoveRequestBody);
 
-    assertThat(postItemsMoveResponse.getStatusCode(), is(201));
+    assertThat(postItemsMoveResponse.getStatusCode(), is(200));
     assertThat(postItemsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     List notFoundIds = postItemsMoveResponse.getJson()
@@ -216,7 +216,7 @@ public class ItemApiMoveExamples extends ApiTests {
     assertThat(nonUpdatedIdsIds.size(), is(1));
     assertThat(nonUpdatedIdsIds.get(0), equalTo(ID_FOR_FAILURE.toString()));
 
-    assertThat(postItemsMoveResponse.getStatusCode(), is(201));
+    assertThat(postItemsMoveResponse.getStatusCode(), is(200));
     assertThat(postItemsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     JsonObject updatedItem1 = itemsClient.getById(createItem1.getId())

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -18,7 +18,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.folio.inventory.domain.items.ItemStatusName;
 import org.folio.inventory.support.http.client.IndividualResource;
 import org.folio.inventory.support.http.client.Response;
@@ -67,7 +66,7 @@ public class ItemApiMoveExamples extends ApiTests {
     Response postItemsMoveResponse = moveItems(itemsMoveRequestBody);
 
     assertThat(postItemsMoveResponse.getStatusCode(), is(201));
-    assertThat(postItemsMoveResponse.getBody(), is(StringUtils.EMPTY));
+    assertThat(postItemsMoveResponse.getBody(), is(new JsonObject().toString()));
     assertThat(postItemsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     JsonObject updatedItem1 = itemsClient.getById(createItem1.getId())

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -66,7 +66,7 @@ public class ItemApiMoveExamples extends ApiTests {
 
     Response postItemsMoveResponse = moveItems(itemsMoveRequestBody);
 
-    assertThat(postItemsMoveResponse.getStatusCode(), is(200));
+    assertThat(postItemsMoveResponse.getStatusCode(), is(201));
     assertThat(postItemsMoveResponse.getBody(), is(StringUtils.EMPTY));
     assertThat(postItemsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
@@ -101,7 +101,7 @@ public class ItemApiMoveExamples extends ApiTests {
 
     Response postItemsMoveResponse = moveItems(itemsMoveRequestBody);
 
-    assertThat(postItemsMoveResponse.getStatusCode(), is(200));
+    assertThat(postItemsMoveResponse.getStatusCode(), is(201));
     assertThat(postItemsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     List notFoundIds = postItemsMoveResponse.getJson()
@@ -217,7 +217,7 @@ public class ItemApiMoveExamples extends ApiTests {
     assertThat(nonUpdatedIdsIds.size(), is(1));
     assertThat(nonUpdatedIdsIds.get(0), equalTo(ID_FOR_FAILURE.toString()));
 
-    assertThat(postItemsMoveResponse.getStatusCode(), is(200));
+    assertThat(postItemsMoveResponse.getStatusCode(), is(201));
     assertThat(postItemsMoveResponse.getContentType(), containsString(APPLICATION_JSON));
 
     JsonObject updatedItem1 = itemsClient.getById(createItem1.getId())


### PR DESCRIPTION
Follow-up to [PR#248](https://github.com/folio-org/mod-inventory/pull/248). UI-client requires empty json in body instead of empty body.