### PR TITLE
Propagate storage data elements to support Inventory as shared index

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "10.6",
+      "version": "10.7",
       "handlers": [
         {
           "methods": ["GET"],
@@ -375,11 +375,11 @@
   "requires": [
     {
       "id": "item-storage",
-      "version": "8.5"
+      "version": "8.6"
     },
     {
       "id": "instance-storage",
-      "version": "7.2"
+      "version": "7.5"
     },
     {
       "id": "instance-storage-batch",

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -15,6 +15,10 @@
       "type": "string",
       "description": "The human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"
     },
+    "matchKey": {
+      "type": "string",
+      "description" : "An unique instance identifier matching a client-side bibliographic record identification. Could be an actual local identifier or a key generated from metadata in the local bibliographic record. Enables the client to determine if a client side bibliographic record already exists as an Instance in Inventory"
+    },
     "source": {
       "type": "string",
       "description": "The metadata source and its format of the underlying record to the instance record. (e.g. FOLIO if it's a record created in Inventory;  MARC if it's a MARC record created in MARCcat or EPKB if it's a record coming from eHoldings)"

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -243,6 +243,7 @@
             "Declared lost",
             "Order closed",
             "Claimed returned",
+            "Unknown",
             "Withdrawn",
             "Lost and paid",
             "Aged to lost"

--- a/src/main/java/org/folio/inventory/domain/instances/Instance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/Instance.java
@@ -13,6 +13,7 @@ import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
 public class Instance {
   // JSON property names
   public static final String HRID_KEY = "hrid";
+  public static final String MATCH_KEY_KEY = "matchKey";
   public static final String SOURCE_KEY = "source";
   public static final String PARENT_INSTANCES_KEY = "parentInstances";
   public static final String CHILD_INSTANCES_KEY = "childInstances";
@@ -52,6 +53,7 @@ public class Instance {
 
   private final String id;
   private final String hrid;
+  private String matchKey;
   private final String source;
   private List<InstanceRelationshipToParent> parentInstances = new ArrayList();
   private List<InstanceRelationshipToChild> childInstances = new ArrayList();
@@ -100,6 +102,11 @@ public class Instance {
     this.source = source;
     this.title = title;
     this.instanceTypeId = instanceTypeId;
+  }
+
+  public Instance setMatchKey(String matchKey) {
+    this.matchKey = matchKey;
+    return this;
   }
 
   public Instance setIndexTitle(String indexTitle) {
@@ -272,6 +279,10 @@ public class Instance {
 
   public String getHrid() {
     return hrid;
+  }
+
+  public String getMatchKey() {
+    return matchKey;
   }
 
   public String getSource() {

--- a/src/main/java/org/folio/inventory/domain/items/ItemStatusName.java
+++ b/src/main/java/org/folio/inventory/domain/items/ItemStatusName.java
@@ -18,6 +18,7 @@ public enum ItemStatusName {
   DECLARED_LOST("Declared lost"),
   ORDER_CLOSED("Order closed"),
   CLAIMED_RETURNED("Claimed returned"),
+  UNKNOWN("Unknown"),
   WITHDRAWN("Withdrawn"),
   LOST_AND_PAID("Lost and paid"),
   AGED_TO_LOST("Aged to lost");

--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -310,6 +310,7 @@ public abstract class AbstractInstances {
     resp.put("hrid", instance.getHrid());
     resp.put(Instance.SOURCE_KEY, instance.getSource());
     resp.put(Instance.TITLE_KEY, instance.getTitle());
+    putIfNotNull(resp, Instance.MATCH_KEY_KEY, instance.getMatchKey());
     putIfNotNull(resp, Instance.INDEX_TITLE_KEY, instance.getIndexTitle());
     putIfNotNull(resp, Instance.PARENT_INSTANCES_KEY, parentInstances);
     putIfNotNull(resp, Instance.CHILD_INSTANCES_KEY, childInstances);

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleInstanceCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleInstanceCollection.java
@@ -63,6 +63,7 @@ class ExternalStorageModuleInstanceCollection
       : UUID.randomUUID().toString());
     instanceToSend.put(Instance.HRID_KEY, instance.getHrid());
     includeIfPresent(instanceToSend, Instance.SOURCE_KEY, instance.getSource());
+    instanceToSend.put(Instance.MATCH_KEY_KEY, instance.getMatchKey());
     instanceToSend.put(Instance.TITLE_KEY, instance.getTitle());
     instanceToSend.put(Instance.INDEX_TITLE_KEY, instance.getIndexTitle());
     instanceToSend.put(Instance.ALTERNATIVE_TITLES_KEY, instance.getAlternativeTitles());
@@ -159,6 +160,7 @@ class ExternalStorageModuleInstanceCollection
       instanceFromServer.getString(Instance.SOURCE_KEY),
       instanceFromServer.getString(Instance.TITLE_KEY),
       instanceFromServer.getString(Instance.INSTANCE_TYPE_ID_KEY))
+      .setMatchKey(instanceFromServer.getString(Instance.MATCH_KEY_KEY))
       .setIndexTitle(instanceFromServer.getString(Instance.INDEX_TITLE_KEY))
       .setAlternativeTitles(mappedAlternativeTitles)
       .setEditions(jsonArrayAsListOfStrings(instanceFromServer, Instance.EDITIONS_KEY))


### PR DESCRIPTION
  - propagate Instance.matchKey
  - propagate Item.status enumeration option "Unknown"
  - requires new minor versions of instance-storage, item-storage