### PR TITLE
MODINV-335: Update folio-libs versions that uses RMB.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,13 +137,13 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-source-record-storage-client</artifactId>
-      <version>4.0.0</version>
+      <version>4.1.0-SNAPSHOT</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>1.2.0</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
 import org.folio.HoldingsRecord;
+import org.folio.dbschema.ObjectMapperTool;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.dataimport.util.ParsedRecordUtil;
@@ -19,7 +20,6 @@ import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.Record;
-import org.folio.rest.tools.utils.ObjectMapperTool;
 
 import java.io.IOException;
 import java.util.UUID;

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -8,6 +8,7 @@ import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
+import org.folio.dbschema.ObjectMapperTool;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.api.request.PagingParameters;
 import org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil;
@@ -25,7 +26,6 @@ import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.Record;
-import org.folio.rest.tools.utils.ObjectMapperTool;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
@@ -8,13 +8,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
 import org.folio.HoldingsRecord;
+import org.folio.dbschema.ObjectMapperTool;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.storage.Storage;
 import org.folio.processing.events.services.handler.EventHandler;
 import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
-import org.folio.rest.tools.utils.ObjectMapperTool;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/src/main/java/org/folio/inventory/resources/EventHandlers.java
+++ b/src/main/java/org/folio/inventory/resources/EventHandlers.java
@@ -7,6 +7,7 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import org.folio.DataImportEventPayload;
+import org.folio.dbschema.ObjectMapperTool;
 import org.folio.inventory.common.WebContext;
 import org.folio.inventory.dataimport.HoldingWriterFactory;
 import org.folio.inventory.dataimport.InstanceWriterFactory;
@@ -37,7 +38,6 @@ import org.folio.processing.matching.loader.MatchValueLoaderFactory;
 import org.folio.processing.matching.reader.MarcValueReaderImpl;
 import org.folio.processing.matching.reader.MatchValueReaderFactory;
 import org.folio.processing.matching.reader.StaticValueReaderImpl;
-import org.folio.rest.tools.utils.ObjectMapperTool;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
@@ -5,9 +5,9 @@ import java.io.IOException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.ObjectWriter;
 import org.folio.HoldingsRecord;
+import org.folio.dbschema.ObjectMapperTool;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.validation.exceptions.JsonMappingException;
-import org.folio.rest.tools.utils.ObjectMapperTool;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-335 - Upgrade to JDK 11

Upgrade RMB based folio libs, that is suggested by @KaterynaSenchenko in the jira comment.