### PR TITLE
Undefined name 'instances_response' in four repos

### DIFF
--- a/okapi-setup/environment/clear-environment-variables.py
+++ b/okapi-setup/environment/clear-environment-variables.py
@@ -2,7 +2,7 @@ import requests
 
 environment_variables = requests.get('http://localhost:9130/_/env')
 
-if(environment_variables.status_code == 200):
+if environment_variables.status_code == 200:
     variable_ids = list(map(lambda variable: variable['name'], environment_variables.json()))
 
     for variable_id in variable_ids:
@@ -10,5 +10,5 @@ if(environment_variables.status_code == 200):
         delete_response = requests.delete(variable_url)
         print('Delete Response for {0}: {1}'.format(variable_url, delete_response.status_code))
 
-else:
+else:  # Undefined name 'instances_response': NameError may be raised which will halt/crash the script
     print('Could not get environment variables from Okapi, status: {1}'.format(instances_response.status_code))


### PR DESCRIPTION
@marcjohnson-kint Should this be `environment_variables.status_code` instead of `instances_response.status_code`?

[flake8](http://flake8.pycqa.org) testing of https://github.com/folio-org/mod-inventory

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./okapi-setup/environment/clear-environment-variables.py:14:80: F821 undefined name 'instances_response'
    print('Could not get environment variables from Okapi, status: {1}'.format(instances_response.status_code))
                                                                               ^
1     F821 undefined name 'instances_response'
1
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.

# This issue is repeated in the following repos...
1. REPO=folio-org/mod-circulation-storage
2. REPO=folio-org/mod-inventory
3. REPO=folio-org/mod-inventory-storage
4. REPO=folio-org/mod-marccat