### PR TITLE
MODINV-353: JUnit 4.13.1 fixing TemporaryFolder information disclosure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade junit version from 4.12 to 4.13.1.
References:
https://github.com/junit-team/junit4/security/advisories/GHSA-269g-pwp5-87pp
https://nvd.nist.gov/vuln/detail/CVE-2020-15250