### PR TITLE
MODINV-120: Add missing inventory/items permissions.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -97,6 +97,7 @@
           "permissionsRequired": ["inventory.items.item.post"],
           "modulePermissions": [
             "inventory-storage.items.item.post",
+            "inventory-storage.items.collection.get",
             "inventory-storage.material-types.item.get",
             "inventory-storage.material-types.collection.get",
             "inventory-storage.loan-types.item.get",
@@ -114,6 +115,8 @@
           "pathPattern": "/inventory/items/{id}",
           "permissionsRequired": ["inventory.items.item.put"],
           "modulePermissions": [
+            "inventory-storage.items.item.get",
+            "inventory-storage.items.collection.get",
             "inventory-storage.items.item.put",
             "users.item.get"
           ]


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-120 - User cannot manage records with mod-inventory permissions only