### PR TITLE
MODINV-355: Marking item missing clears check in note and check out note fields

### DIFF
--- a/src/main/java/org/folio/inventory/domain/items/Item.java
+++ b/src/main/java/org/folio/inventory/domain/items/Item.java
@@ -508,7 +508,8 @@ public class Item {
       .withElectronicAccess(this.electronicAccess)
       .withStatisticalCodeIds(this.statisticalCodeIds)
       .withPurchaseOrderLineidentifier(purchaseOrderLineidentifier)
-      .withTags(tags);
+      .withTags(tags)
+      .withCirculationNotes(circulationNotes);
   }
 
   @Override

--- a/src/test/java/api/items/MarkItemMissingApiTests.java
+++ b/src/test/java/api/items/MarkItemMissingApiTests.java
@@ -1,6 +1,10 @@
 package api.items;
 
 import static api.support.InstanceSamples.smallAngryPlanet;
+import static org.folio.inventory.domain.items.CirculationNote.NOTE_KEY;
+import static org.folio.inventory.domain.items.CirculationNote.NOTE_TYPE_KEY;
+import static org.folio.inventory.domain.items.CirculationNote.STAFF_ONLY_KEY;
+import static org.folio.inventory.domain.items.Item.CIRCULATION_NOTES_KEY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static support.matchers.ItemMatchers.isMissing;
@@ -41,6 +45,21 @@ public class MarkItemMissingApiTests extends ApiTests {
       .forInstance(instance.getId()));
   }
 
+  @Test
+  public void testMarkItemMissingPreservesCirculationNotes() throws Exception {
+    final IndividualResource createdItem = itemsClient.create(new ItemRequestBuilder()
+      .forHolding(holdingsRecord.getId())
+      .withCheckInNote()
+      .canCirculate());
+
+    final var itemMissing = markItemMissing(createdItem).getJson();
+    final var itemCirculationNotes = itemMissing.getJsonArray(CIRCULATION_NOTES_KEY);
+    final var checkInNote = itemCirculationNotes.getJsonObject(0);
+
+    assertThat(checkInNote.getString(NOTE_TYPE_KEY), is("Check in"));
+    assertThat(checkInNote.getString(NOTE_KEY), is("Please read this note before checking in the item"));
+    assertThat(checkInNote.getBoolean(STAFF_ONLY_KEY), is(false));
+  }
   @Parameters({
     "In process",
     "Available",


### PR DESCRIPTION
## Purpose

This fixes the issue: when item is marked missing, its circulation notes were not populated.


Jira: https://issues.folio.org/browse/MODINV-355