### PR TITLE
MODINV-369: Item with Lost and paid status throws an error when withdrawn

### DIFF
--- a/src/main/java/org/folio/inventory/validation/MarkAsWithdrawnValidators.java
+++ b/src/main/java/org/folio/inventory/validation/MarkAsWithdrawnValidators.java
@@ -14,6 +14,7 @@ import org.folio.inventory.support.http.server.ValidationError;
 public final class MarkAsWithdrawnValidators {
   private static final Set<ItemStatusName> ALLOWED_STATUS_TO_MARK_WITHDRAWN = of(
     ItemStatusName.AVAILABLE,
+    ItemStatusName.LOST_AND_PAID,
     ItemStatusName.IN_TRANSIT,
     ItemStatusName.IN_PROCESS,
     ItemStatusName.AWAITING_PICKUP,

--- a/src/test/java/api/items/MarkItemWithdrawnApiTests.java
+++ b/src/test/java/api/items/MarkItemWithdrawnApiTests.java
@@ -46,6 +46,7 @@ public class MarkItemWithdrawnApiTests extends ApiTests {
     "In transit",
     "Awaiting pickup",
     "Awaiting delivery",
+    "Lost and paid",
     "Missing",
     "Paged"
   })


### PR DESCRIPTION
The module has a "whitelist" of statuses from which an item can be moved
to withdrawn.  "Lost and Paid" was not on that list, hence the error.  I
just added the status to the list.

refs: https://issues.folio.org/browse/MODINV-369