### PR TITLE
MODINV-378 - Item moving error

### DIFF
--- a/ramls/holdings-record.json
+++ b/ramls/holdings-record.json
@@ -8,10 +8,6 @@
       "description": "the system assigned unique ID of the holdings record; UUID",
       "$ref": "./uuid.json"
     },
-    "_version": {
-      "type": "integer",
-      "description": "Record version for optimistic locking"
-    },
     "hrid": {
       "type": "string",
       "description": "the human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"

--- a/ramls/holdings-record.json
+++ b/ramls/holdings-record.json
@@ -8,6 +8,10 @@
       "description": "the system assigned unique ID of the holdings record; UUID",
       "$ref": "./uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "hrid": {
       "type": "string",
       "description": "the human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"

--- a/src/main/java/org/folio/inventory/resources/MoveApi.java
+++ b/src/main/java/org/folio/inventory/resources/MoveApi.java
@@ -76,7 +76,7 @@ public class MoveApi extends AbstractInventoryResource {
     }
     String toHoldingsRecordId = itemsMoveJsonRequest.getString(TO_HOLDINGS_RECORD_ID);
     List<String> itemIdsToUpdate = toListOfStrings(itemsMoveJsonRequest.getJsonArray(ITEM_IDS));
-    storage.getHoldingsRecordCollection(context)
+    storage.getHoldingCollection(context)
       .findById(toHoldingsRecordId)
       .thenAccept(holding -> {
         if (Objects.nonNull(holding)) {

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -208,10 +208,7 @@ public class ItemApiMoveExamples extends ApiTests {
 
     Response postMoveItemsResponse = moveItems(itemsMoveRequestBody);
 
-    assertThat(postMoveItemsResponse.getStatusCode(), is(500));
-    assertThat(postMoveItemsResponse.getContentType(), containsString(TEXT_PLAIN));
-
-    assertThat(postMoveItemsResponse.getBody(), containsString("Can`t map json to 'Holdingsrecord' entity"));
+    assertThat(postMoveItemsResponse.getStatusCode(), is(200));
   }
 
   @Test

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -3,7 +3,6 @@ package api.items;
 import static api.ApiTestSuite.ID_FOR_FAILURE;
 import static api.support.InstanceSamples.smallAngryPlanet;
 import static org.folio.inventory.support.http.ContentType.APPLICATION_JSON;
-import static org.folio.inventory.support.http.ContentType.TEXT_PLAIN;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -188,7 +187,7 @@ public class ItemApiMoveExamples extends ApiTests {
   }
 
   @Test
-  public void cannotMoveDueToHoldingsRecordSchemasMismatching()
+  public void canMoveToHoldingsRecordWithHoldingSchemasMismatching()
     throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException, IllegalAccessException {
 
     UUID instanceId = UUID.randomUUID();


### PR DESCRIPTION
[MODINV-378](https://issues.folio.org/browse/MODINV-378) - Item moving error

**Purpose**
The new field _version (https://github.com/folio-org/mod-inventory-storage/blob/bc8814fd8859508e5da061961cd36d5ee8f89e20/ramls/holdingsrecord.json#L11) was introduced in scope of story [MODINVSTOR-656](https://issues.folio.org/browse/MODINVSTOR-656). This affect items moving flow with error 500 - Can`t map json to 'Holdingsrecord' entity.

**Approach**
Change from getHoldingsRecordCollection to getHoldingCollection.


