### PR TITLE
Update inventory-event-handlers API

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -483,7 +483,7 @@
     },
     {
       "id": "inventory-event-handlers",
-      "version": "0.1",
+      "version": "1.0",
       "handlers": [
         {
           "methods": [

--- a/ramls/inventory-event-handlers.raml
+++ b/ramls/inventory-event-handlers.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Event Handlers API
-version: v0.1
+version: v1.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -9,20 +9,6 @@ documentation:
     content: <b>API for handling events</b>
 
 /inventory/handlers:
-  /data-import:
-    displayName: API for handling all data-import events
-    post:
-      description: "Handler for data-import events"
-      body:
-        application/json:
-      responses:
-        204:
-          description: "Received data-import event"
-        500:
-          description: "Internal server error"
-          body:
-            text/plain:
-              example: "Internal server error"
   /instances:
     displayName: API for handling Instance update events
     post:


### PR DESCRIPTION
After refactoring of data-import flow to go directly through kafka **_/inventory/handlers/data-import_** endpoint has been removed. 'inventory-event-handlers' API version is bumped to reflect that change.