### PR TITLE
Update inventory from 10.9 to 10.10

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "10.9",
+      "version": "10.10",
       "handlers": [
         {
           "methods": ["GET"],
@@ -527,7 +527,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.5"
+      "version": "7.7"
     },
     {
       "id": "instance-storage-batch",

--- a/ramls/inventory.raml
+++ b/ramls/inventory.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory API
-version: v10.9
+version: v10.10
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 


### PR DESCRIPTION
The inventory interface needs to be updated because of adding of contributorsNames index in mod-inventory-storage
Please see https://issues.folio.org/browse/MODINV-390 and its related tickets.