### PR TITLE
Update kafka wrapper dependency MODINV-373

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.1.0-SNAPSHOT</version>
+      <version>2.0.2</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-client</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>


### PR DESCRIPTION
Update the `kafka-wrapper` dependency to a release version rather than pre-release, in order for it to be releasable.

Also update the `pubsub-client` dependency as that is produced by the same release process.