### PR TITLE
Add logging for event correlationId

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -76,6 +76,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
         String correlationId = extractCorrelationId(record.headers());
         LOGGER.info(format("Data import event payload has been received with event type: %s correlationId: %s", eventPayload.getEventType(), correlationId));
 
+        eventPayload.getContext().put(CORRELATION_ID_HEADER, correlationId);
         EventManager.handleEvent(eventPayload).whenComplete((processedPayload, throwable) -> {
           if (throwable != null) {
             promise.fail(throwable);
@@ -122,7 +123,8 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
 
   private String extractCorrelationId(List<KafkaHeader> headers) {
     return headers.stream()
-      .filter(header -> header.key().equals(CORRELATION_ID_HEADER)).findFirst()
+      .filter(header -> header.key().equals(CORRELATION_ID_HEADER))
+      .findFirst()
       .map(header -> header.value().toString())
       .orElse(null);
   }

--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -1,20 +1,16 @@
 package org.folio.inventory.dataimport.consumers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
-
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import io.vertx.ext.web.client.WebClient;
-import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
-
 import org.folio.DataImportEventPayload;
 import org.folio.dbschema.ObjectMapperTool;
 import org.folio.inventory.dataimport.HoldingWriterFactory;
@@ -37,7 +33,6 @@ import org.folio.inventory.dataimport.handlers.matching.loaders.InstanceLoader;
 import org.folio.inventory.dataimport.handlers.matching.loaders.ItemLoader;
 import org.folio.inventory.storage.Storage;
 import org.folio.kafka.AsyncRecordHandler;
-import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.EventManager;
 import org.folio.processing.events.utils.ZIPArchiver;


### PR DESCRIPTION
## Purpose
to facilitate tracing of processing flow of a particular record

## Approach
* correlationId is set to payload context before handling to be published with result event using di-core library (https://github.com/folio-org/data-import-processing-core/pull/138)
* correlationId is logged from a kafka event header


## Learning
[MODSOURMAN-437](https://issues.folio.org/browse/MODSOURMAN-437)