### PR TITLE
MODINV-404 - Item update failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.0.1</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
@@ -100,8 +100,7 @@ public class CreateInstanceEventHandler extends AbstractInstanceEventHandler {
         future.completeExceptionally(new EventProcessingException(msg));
       }
     } catch (Exception e) {
-      String msg = format("Error creating inventory Instance: %s", e);
-      LOGGER.error(msg);
+      LOGGER.error("Error creating inventory Instance", e);
       future.completeExceptionally(e);
     }
     return future;

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -119,8 +119,7 @@ public class UpdateItemEventHandler implements EventHandler {
           }
         });
     } catch (Exception e) {
-      String errorMessage = String.format("Error updating inventory Item: %s", e);
-      LOG.error(errorMessage);
+      LOG.error("Error updating inventory Item", e);
       future.completeExceptionally(e);
     }
     return future;

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
@@ -59,7 +59,7 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
             future.completeExceptionally(new MatchingException(failure.getReason()));
           });
       } catch (UnsupportedEncodingException e) {
-        LOG.error("Failed to retrieve records");
+        LOG.error("Failed to retrieve records", e);
         future.completeExceptionally(e);
       }
     });


### PR DESCRIPTION
## Purpose
to process `###REMOVE###` expression for `StringValue` while updating entities (instance, holdings, item) using data-import

## Approach
* correct errors logging
* update dependency on di-core library


## Learning
[MODINV-404](https://issues.folio.org/browse/MODINV-404)
[MODDICORE-137](https://issues.folio.org/browse/MODDICORE-137)