### PR TITLE
Modinv 403 clean up instance mapping

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
@@ -14,7 +14,6 @@ import org.folio.inventory.domain.instances.InstanceCollection;
 import org.folio.inventory.storage.Storage;
 import org.folio.inventory.storage.external.CollectionResourceClient;
 import org.folio.inventory.storage.external.CollectionResourceRepository;
-import org.folio.inventory.support.InstanceUtil;
 import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
@@ -83,7 +82,7 @@ public class CreateInstanceEventHandler extends AbstractInstanceEventHandler {
       InstanceCollection instanceCollection = storage.getInstanceCollection(context);
       List<String> errors = EventHandlingUtil.validateJsonByRequiredFields(instanceAsJson, requiredFields);
       if (errors.isEmpty()) {
-        Instance mappedInstance = InstanceUtil.jsonToInstance(instanceAsJson);
+        Instance mappedInstance = Instance.fromJson(instanceAsJson);
         addInstance(mappedInstance, instanceCollection)
           .compose(createdInstance -> createPrecedingSucceedingTitles(mappedInstance, precedingSucceedingTitlesRepository).map(createdInstance))
           .onSuccess(ar -> {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
@@ -74,7 +74,7 @@ public class InstanceUpdateDelegate {
       JsonObject existing = JsonObject.mapFrom(existingInstance);
       JsonObject mapped = JsonObject.mapFrom(mappedInstance);
       JsonObject mergedInstanceAsJson = InstanceUtil.mergeInstances(existing, mapped);
-      Instance mergedInstance = InstanceUtil.jsonToInstance(mergedInstanceAsJson);
+      Instance mergedInstance = Instance.fromJson(mergedInstanceAsJson);
       return Future.succeededFuture(mergedInstance);
     } catch (Exception e) {
       LOGGER.error("Error updating instance", e);

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
@@ -32,7 +32,6 @@ import static org.folio.ActionProfile.FolioRecord.INSTANCE;
 import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
-import static org.folio.DataImportEventTypes.DI_INVENTORY_ITEM_CREATED;
 import static org.folio.inventory.domain.instances.Instance.HRID_KEY;
 import static org.folio.inventory.domain.instances.Instance.METADATA_KEY;
 import static org.folio.inventory.domain.instances.Instance.SOURCE_KEY;
@@ -72,7 +71,7 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
       }
 
       Context context = EventHandlingUtil.constructContext(dataImportEventPayload.getTenant(), dataImportEventPayload.getToken(), dataImportEventPayload.getOkapiUrl());
-      Instance instanceToUpdate = InstanceUtil.jsonToInstance(new JsonObject(dataImportEventPayload.getContext().get(INSTANCE.value())));
+      Instance instanceToUpdate = Instance.fromJson(new JsonObject(dataImportEventPayload.getContext().get(INSTANCE.value())));
 
       prepareEvent(dataImportEventPayload);
 
@@ -107,7 +106,7 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
       CollectionResourceRepository precedingSucceedingTitlesRepository = new CollectionResourceRepository(precedingSucceedingTitlesClient);
       List<String> errors = EventHandlingUtil.validateJsonByRequiredFields(instanceAsJson, requiredFields);
       if (errors.isEmpty()) {
-        Instance mappedInstance = InstanceUtil.jsonToInstance(instanceAsJson);
+        Instance mappedInstance = Instance.fromJson(instanceAsJson);
         JsonObject finalInstanceAsJson = instanceAsJson;
         updateInstance(mappedInstance, instanceCollection)
           .compose(ar -> deletePrecedingSucceedingTitles(precedingSucceedingIds, precedingSucceedingTitlesRepository))

--- a/src/main/java/org/folio/inventory/domain/instances/Instance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/Instance.java
@@ -1,14 +1,28 @@
 package org.folio.inventory.domain.instances;
 
+import java.lang.invoke.MethodHandles;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.inventory.common.WebContext;
 import org.folio.inventory.domain.Metadata;
 import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
 import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
+import org.folio.inventory.support.JsonArrayHelper;
+
+import static java.lang.String.format;
+import static org.folio.inventory.support.JsonArrayHelper.toListOfStrings;
 
 public class Instance {
   // JSON property names
@@ -90,6 +104,10 @@ public class Instance {
   private List<String> tags;
   private List<String> natureOfContentTermIds = new ArrayList<>();
 
+  protected static final String INVENTORY_PATH = "/inventory";
+  protected static final String INSTANCES_PATH = INVENTORY_PATH + "/instances";
+  protected static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
   public Instance(
     String id,
     String hrid,
@@ -104,6 +122,180 @@ public class Instance {
     this.instanceTypeId = instanceTypeId;
   }
 
+  /**
+   *
+   * @param instanceJson  JSON from client request or storage server response
+   * @return Instance object that holds all (known) properties from the JSON
+   */
+  public static Instance fromJson(JsonObject instanceJson) {
+
+    return new Instance(
+      instanceJson.getString("id"),
+      instanceJson.getString("hrid"),
+      instanceJson.getString(SOURCE_KEY),
+      instanceJson.getString(TITLE_KEY),
+      instanceJson.getString(INSTANCE_TYPE_ID_KEY))
+      .setIndexTitle(instanceJson.getString(INDEX_TITLE_KEY))
+      .setParentInstances(instanceJson.getJsonArray(PARENT_INSTANCES_KEY))
+      .setChildInstances(instanceJson.getJsonArray(CHILD_INSTANCES_KEY))
+      .setPrecedingTitles(instanceJson.getJsonArray(PRECEDING_TITLES_KEY))
+      .setSucceedingTitles(instanceJson.getJsonArray(SUCCEEDING_TITLES_KEY))
+      .setAlternativeTitles(instanceJson.getJsonArray(ALTERNATIVE_TITLES_KEY))
+      .setEditions(toListOfStrings(instanceJson.getJsonArray(EDITIONS_KEY)))
+      .setSeries(toListOfStrings(instanceJson.getJsonArray(SERIES_KEY)))
+      .setIdentifiers(instanceJson.getJsonArray(IDENTIFIERS_KEY))
+      .setContributors(instanceJson.getJsonArray(CONTRIBUTORS_KEY))
+      .setSubjects(toListOfStrings(instanceJson.getJsonArray(SUBJECTS_KEY)))
+      .setClassifications(instanceJson.getJsonArray(CLASSIFICATIONS_KEY))
+      .setPublication(instanceJson.getJsonArray(PUBLICATION_KEY))
+      .setPublicationFrequency(toListOfStrings(instanceJson.getJsonArray(PUBLICATION_FREQUENCY_KEY)))
+      .setPublicationRange(toListOfStrings(instanceJson.getJsonArray(PUBLICATION_RANGE_KEY)))
+      .setElectronicAccess(instanceJson.getJsonArray(ELECTRONIC_ACCESS_KEY))
+      .setInstanceFormatIds(toListOfStrings(instanceJson.getJsonArray(INSTANCE_FORMAT_IDS_KEY)))
+      .setPhysicalDescriptions(toListOfStrings(instanceJson.getJsonArray(PHYSICAL_DESCRIPTIONS_KEY)))
+      .setLanguages(toListOfStrings(instanceJson.getJsonArray(LANGUAGES_KEY)))
+      .setNotes(instanceJson.getJsonArray(NOTES_KEY))
+      .setModeOfIssuanceId(instanceJson.getString(MODE_OF_ISSUANCE_ID_KEY))
+      .setCatalogedDate(instanceJson.getString(CATALOGED_DATE_KEY))
+      .setPreviouslyHeld(instanceJson.getBoolean(PREVIOUSLY_HELD_KEY))
+      .setStaffSuppress(instanceJson.getBoolean(STAFF_SUPPRESS_KEY))
+      .setDiscoverySuppress(instanceJson.getBoolean(DISCOVERY_SUPPRESS_KEY))
+      .setStatisticalCodeIds(toListOfStrings(instanceJson.getJsonArray(STATISTICAL_CODE_IDS_KEY)))
+      .setSourceRecordFormat(instanceJson.getString(SOURCE_RECORD_FORMAT_KEY))
+      .setStatusId(instanceJson.getString(STATUS_ID_KEY))
+      .setStatusUpdatedDate(instanceJson.getString(STATUS_UPDATED_DATE_KEY))
+      .setTags(getTags(instanceJson))
+      .setNatureOfContentTermIds(toListOfStrings(instanceJson.getJsonArray(NATURE_OF_CONTENT_TERM_IDS_KEY)));
+  }
+
+  /**
+   *
+   * @return  JSON representation of the Instance, compatible with FOLIO's
+   * Instance storage API.
+   */
+  public JsonObject getJsonForStorage() {
+    JsonObject json = new JsonObject();
+    //TODO: Review if this shouldn't be defaulting here
+    json.put("id", getId() != null
+      ? getId()
+      : UUID.randomUUID().toString());
+    json.put(HRID_KEY, hrid);
+    if (source != null) json.put(SOURCE_KEY, source);
+    json.put(MATCH_KEY_KEY, matchKey);
+    json.put(TITLE_KEY, title);
+    json.put(INDEX_TITLE_KEY, indexTitle);
+    json.put(ALTERNATIVE_TITLES_KEY, alternativeTitles);
+    json.put(EDITIONS_KEY, editions);
+    json.put(SERIES_KEY, series);
+    json.put(IDENTIFIERS_KEY, identifiers);
+    json.put(CONTRIBUTORS_KEY, contributors);
+    json.put(SUBJECTS_KEY, subjects);
+    json.put(CLASSIFICATIONS_KEY, classifications);
+    json.put(PUBLICATION_KEY, publication);
+    json.put(PUBLICATION_FREQUENCY_KEY, publicationFrequency);
+    json.put(PUBLICATION_RANGE_KEY, publicationRange);
+    json.put(ELECTRONIC_ACCESS_KEY, electronicAccess);
+    if (instanceTypeId != null) json.put(INSTANCE_TYPE_ID_KEY, instanceTypeId);
+    json.put(INSTANCE_FORMAT_IDS_KEY, instanceFormatIds);
+    json.put(PHYSICAL_DESCRIPTIONS_KEY, physicalDescriptions);
+    json.put(LANGUAGES_KEY, languages);
+    json.put(NOTES_KEY, notes);
+    json.put(MODE_OF_ISSUANCE_ID_KEY, modeOfIssuanceId);
+    json.put(CATALOGED_DATE_KEY, catalogedDate);
+    json.put(PREVIOUSLY_HELD_KEY, previouslyHeld);
+    json.put(STAFF_SUPPRESS_KEY, staffSuppress);
+    json.put(DISCOVERY_SUPPRESS_KEY, discoverySuppress);
+    json.put(STATISTICAL_CODE_IDS_KEY, statisticalCodeIds);
+    if (sourceRecordFormat != null) json.put(SOURCE_RECORD_FORMAT_KEY, sourceRecordFormat);
+    json.put(STATUS_ID_KEY, statusId);
+    json.put(STATUS_UPDATED_DATE_KEY, statusUpdatedDate);
+    json.put(TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray(getTags() == null ? Collections.emptyList() : getTags())));
+    json.put(NATURE_OF_CONTENT_TERM_IDS_KEY, natureOfContentTermIds);
+
+    return json;
+  }
+
+  /**
+   *
+   * @param context
+   * @return JSON representation of the Instance, compatible with Inventory's
+   * Instance schema
+   */
+  public JsonObject getJsonForResponse(WebContext context) {
+    JsonObject json = new JsonObject();
+
+    try {
+      json.put("@context", context.absoluteUrl(
+        INSTANCES_PATH + "/context").toString());
+    } catch (MalformedURLException e) {
+      log.warn(
+        format("Failed to create context link for instance: %s", e.toString()));
+    }
+
+    json.put("id", getId());
+    json.put("hrid", getHrid());
+    json.put(SOURCE_KEY, getSource());
+    json.put(TITLE_KEY, getTitle());
+    putIfNotNull(json, MATCH_KEY_KEY, getMatchKey());
+    putIfNotNull(json, INDEX_TITLE_KEY, getIndexTitle());
+    putIfNotNull(json, PARENT_INSTANCES_KEY, parentInstances);
+    putIfNotNull(json, CHILD_INSTANCES_KEY, childInstances);
+    putIfNotNull(json, ALTERNATIVE_TITLES_KEY, getAlternativeTitles());
+    putIfNotNull(json, EDITIONS_KEY, getEditions());
+    putIfNotNull(json, SERIES_KEY, getSeries());
+    putIfNotNull(json, IDENTIFIERS_KEY, getIdentifiers());
+    putIfNotNull(json, CONTRIBUTORS_KEY, getContributors());
+    putIfNotNull(json, SUBJECTS_KEY, getSubjects());
+    putIfNotNull(json, CLASSIFICATIONS_KEY, getClassifications());
+    putIfNotNull(json, PUBLICATION_KEY, getPublication());
+    putIfNotNull(json, PUBLICATION_FREQUENCY_KEY, getPublicationFrequency());
+    putIfNotNull(json, PUBLICATION_RANGE_KEY, getPublicationRange());
+    putIfNotNull(json, ELECTRONIC_ACCESS_KEY, getElectronicAccess());
+    putIfNotNull(json, INSTANCE_TYPE_ID_KEY, getInstanceTypeId());
+    putIfNotNull(json, INSTANCE_FORMAT_IDS_KEY, getInstanceFormatIds());
+    putIfNotNull(json, PHYSICAL_DESCRIPTIONS_KEY, getPhysicalDescriptions());
+    putIfNotNull(json, LANGUAGES_KEY, getLanguages());
+    putIfNotNull(json, NOTES_KEY, getNotes());
+    putIfNotNull(json, MODE_OF_ISSUANCE_ID_KEY, getModeOfIssuanceId());
+    putIfNotNull(json, CATALOGED_DATE_KEY, getCatalogedDate());
+    putIfNotNull(json, PREVIOUSLY_HELD_KEY, getPreviouslyHeld());
+    putIfNotNull(json, STAFF_SUPPRESS_KEY, getStaffSuppress());
+    putIfNotNull(json, DISCOVERY_SUPPRESS_KEY, getDiscoverySuppress());
+    putIfNotNull(json, STATISTICAL_CODE_IDS_KEY, getStatisticalCodeIds());
+    putIfNotNull(json, SOURCE_RECORD_FORMAT_KEY, getSourceRecordFormat());
+    putIfNotNull(json, STATUS_ID_KEY, getStatusId());
+    putIfNotNull(json, STATUS_UPDATED_DATE_KEY, getStatusUpdatedDate());
+    putIfNotNull(json, METADATA_KEY, getMetadata());
+    putIfNotNull(json, TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray(getTags())));
+    putIfNotNull(json, NATURE_OF_CONTENT_TERM_IDS_KEY, getNatureOfContentTermIds());
+
+    if (precedingTitles != null) {
+      JsonArray precedingTitlesJsonArray = new JsonArray();
+      precedingTitles.forEach(title -> precedingTitlesJsonArray.add(title.toPrecedingTitleJson()));
+      json.put(PRECEDING_TITLES_KEY, precedingTitlesJsonArray );
+    }
+
+    if (succeedingTitles != null) {
+      JsonArray succeedingTitlesJsonArray = new JsonArray();
+      succeedingTitles.forEach(title -> succeedingTitlesJsonArray.add(title.toSucceedingTitleJson()));
+      json.put(SUCCEEDING_TITLES_KEY, succeedingTitlesJsonArray );
+    }
+
+    try {
+      URL selfUrl = context.absoluteUrl(format("%s/%s",
+        INSTANCES_PATH, getId()));
+
+      json.put("links", new JsonObject().put("self", selfUrl.toString()));
+    } catch (MalformedURLException e) {
+      log.warn(
+        format("Failed to create self link for instance: %s", e.toString()));
+    }
+
+    return json;
+  }
+
+
+
   public Instance setMatchKey(String matchKey) {
     this.matchKey = matchKey;
     return this;
@@ -115,27 +307,75 @@ public class Instance {
   }
 
   public Instance setParentInstances(List<InstanceRelationshipToParent> parentInstances) {
-    this.parentInstances = parentInstances;
+    this.parentInstances = (parentInstances != null ? parentInstances : this.parentInstances);
+    return this;
+  }
+
+  public Instance setParentInstances(JsonArray parentInstances) {
+    this.parentInstances = parentInstances != null
+      ? JsonArrayHelper.toList(parentInstances).stream()
+      .map(InstanceRelationshipToParent::new)
+      .collect(Collectors.toList())
+      : new ArrayList<>();
+
     return this;
   }
 
   public Instance setChildInstances(List<InstanceRelationshipToChild> childInstances) {
-    this.childInstances = childInstances;
+    this.childInstances = (childInstances != null ? childInstances : this.childInstances);
     return this;
   }
 
+  public Instance setChildInstances(JsonArray childInstances) {
+    this.childInstances =
+      childInstances != null
+      ? JsonArrayHelper.toList(childInstances).stream()
+              .map(InstanceRelationshipToChild::new)
+              .collect(Collectors.toList())
+      : new ArrayList<>();
+    return this;
+  }
+
+
   public Instance setPrecedingTitles(List<PrecedingSucceedingTitle> precedingTitles) {
-    this.precedingTitles = new ArrayList<>(precedingTitles);
+    this.precedingTitles = (precedingTitles != null ? precedingTitles : this.precedingTitles);
+    return this;
+  }
+
+  public Instance setPrecedingTitles(JsonArray precedingTitles) {
+    this.precedingTitles =  precedingTitles != null
+      ? JsonArrayHelper.toList(precedingTitles).stream()
+      .map(PrecedingSucceedingTitle::from)
+      .collect(Collectors.toList())
+      : new ArrayList<>();
     return this;
   }
 
   public Instance setSucceedingTitles(List<PrecedingSucceedingTitle> succeedingTitles) {
-    this.succeedingTitles = new ArrayList<>(succeedingTitles);
+    this.succeedingTitles = succeedingTitles != null ? succeedingTitles : this.succeedingTitles;
+    return this;
+  }
+
+  public Instance setSucceedingTitles(JsonArray succeedingTitles) {
+    this.succeedingTitles = succeedingTitles != null
+    ? JsonArrayHelper.toList(succeedingTitles).stream()
+      .map(PrecedingSucceedingTitle::from)
+      .collect(Collectors.toList())
+      : new ArrayList<>();
     return this;
   }
 
   public Instance setAlternativeTitles(List<AlternativeTitle> alternativeTitles) {
     this.alternativeTitles = alternativeTitles;
+    return this;
+  }
+
+  public Instance setAlternativeTitles(JsonArray array) {
+    this.alternativeTitles = array != null
+      ? JsonArrayHelper.toList(array).stream()
+      .map(AlternativeTitle::new)
+      .collect(Collectors.toList())
+      : new ArrayList<>();
     return this;
   }
 
@@ -154,8 +394,26 @@ public class Instance {
     return this;
   }
 
+  public Instance setIdentifiers (JsonArray array) {
+    this.identifiers = array != null
+      ? JsonArrayHelper.toList(array).stream()
+      .map(Identifier::new)
+      .collect(Collectors.toList())
+      : new ArrayList<>();
+    return this;
+  }
+
   public Instance setContributors(List<Contributor> contributors) {
     this.contributors = contributors;
+    return this;
+  }
+
+  public Instance setContributors (JsonArray array) {
+    this.contributors = array != null
+      ? JsonArrayHelper.toList(array).stream()
+      .map(Contributor::new)
+      .collect(Collectors.toList())
+      : new ArrayList<>();
     return this;
   }
 
@@ -169,8 +427,26 @@ public class Instance {
     return this;
   }
 
+  public Instance setClassifications(JsonArray array) {
+    this.classifications = array != null
+      ? JsonArrayHelper.toList(array).stream()
+      .map(Classification::new)
+      .collect(Collectors.toList())
+      : new ArrayList<>();
+    return this;
+  }
+
   public Instance setPublication(List<Publication> publication) {
     this.publication = publication;
+    return this;
+  }
+
+  public Instance setPublication(JsonArray array) {
+    this.publication = array != null
+      ? JsonArrayHelper.toList(array).stream()
+      .map(Publication::new)
+      .collect(Collectors.toList())
+      : new ArrayList<>();
     return this;
   }
 
@@ -186,6 +462,15 @@ public class Instance {
 
   public Instance setElectronicAccess(List<ElectronicAccess> electronicAccess) {
     this.electronicAccess = electronicAccess;
+    return this;
+  }
+
+  public Instance setElectronicAccess (JsonArray array) {
+    this.electronicAccess = array != null
+      ? JsonArrayHelper.toList(array).stream()
+      .map(ElectronicAccess::new)
+      .collect(Collectors.toList())
+      : new ArrayList<>();
     return this;
   }
 
@@ -206,6 +491,16 @@ public class Instance {
 
   public Instance setNotes(List<Note> notes) {
     this.notes = notes;
+    return this;
+  }
+
+  public Instance setNotes (JsonArray array) {
+    this.notes =  array != null
+      ? JsonArrayHelper.toList(array).stream()
+      .map(Note::new)
+      .collect(Collectors.toList())
+      : new ArrayList<>();
+
     return this;
   }
 
@@ -521,8 +816,48 @@ public class Instance {
     return copyInstance().setIdentifiers(newIdentifiers);
   }
 
+
   @Override
   public String toString() {
     return String.format("Instance ID: %s, HRID: %s, Title: %s", id, hrid, title);
   }
+
+  private static List<String> getTags(JsonObject instanceRequest) {
+    if (instanceRequest.containsKey(TAGS_KEY)) {
+      try {
+        final JsonObject tags = instanceRequest.getJsonObject(TAGS_KEY);
+        return tags.containsKey(TAG_LIST_KEY) ?
+          JsonArrayHelper.toListOfStrings(tags.getJsonArray(TAG_LIST_KEY)) : new ArrayList<>();
+      } catch (ClassCastException e) {
+        return JsonArrayHelper.toListOfStrings(instanceRequest.getJsonArray(TAGS_KEY));
+      }
+    } else {
+      return new ArrayList<>();
+    }
+  }
+
+  private void putIfNotNull(JsonObject target, String propertyName, String value) {
+    if (value != null) {
+      target.put(propertyName, value);
+    }
+  }
+
+  private void putIfNotNull(JsonObject target, String propertyName, List<String> value) {
+    if (value != null) {
+      target.put(propertyName, value);
+    }
+  }
+
+  private void putIfNotNull(JsonObject target, String propertyName, Object value) {
+    if (value != null) {
+      if (value instanceof List) {
+        target.put(propertyName, value);
+      } else if (value instanceof Boolean) {
+        target.put(propertyName, value);
+      } else {
+        target.put(propertyName, new JsonObject(Json.encode(value)));
+      }
+    }
+  }
+
 }

--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -338,30 +338,6 @@ public abstract class AbstractInstances {
     return format("query=subInstanceId==(%s)+or+superInstanceId==(%s)", idList, idList);
   }
 
-  private void putIfNotNull(JsonObject target, String propertyName, String value) {
-    if (value != null) {
-      target.put(propertyName, value);
-    }
-  }
-
-  private void putIfNotNull(JsonObject target, String propertyName, List<String> value) {
-    if (value != null) {
-      target.put(propertyName, value);
-    }
-  }
-
-  private void putIfNotNull(JsonObject target, String propertyName, Object value) {
-    if (value != null) {
-      if (value instanceof List) {
-        target.put(propertyName, value);
-      } else if (value instanceof Boolean) {
-        target.put(propertyName, value);
-      } else {
-        target.put(propertyName, new JsonObject(Json.encode(value)));
-      }
-    }
-  }
-
   protected OkapiHttpClient createHttpClient(
     RoutingContext routingContext,
     WebContext context)

--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -274,7 +274,11 @@ public abstract class AbstractInstances {
       List<InstanceRelationshipToChild> childInstances = instancesResponse.getChildInstanceMap().get(instance.getId());
       List<PrecedingSucceedingTitle> precedingTitles = instancesResponse.getPrecedingTitlesMap().get(instance.getId());
       List<PrecedingSucceedingTitle> succeedingTitles = instancesResponse.getSucceedingTitlesMap().get(instance.getId());
-      results.add(toRepresentation(instance, parentInstances, childInstances, precedingTitles, succeedingTitles, context));
+      results.add(instance
+        .setParentInstances(parentInstances)
+        .setChildInstances(childInstances)
+        .setPrecedingTitles(precedingTitles)
+        .setSucceedingTitles(succeedingTitles).getJsonForResponse(context));
     });
 
     representation
@@ -284,90 +288,6 @@ public abstract class AbstractInstances {
     return representation;
   }
 
-  /**
-   * Populates an Instance record representation (downwards)
-   *
-   * @param instance        Instance result to transform to representation
-   * @param parentInstances Super instances for this Instance
-   * @param childInstances  Sub instances for this Instance
-   * @param context
-   * @return
-   */
-  protected JsonObject toRepresentation(Instance instance,
-    List<InstanceRelationshipToParent> parentInstances, List<InstanceRelationshipToChild> childInstances,
-    List<PrecedingSucceedingTitle> precedingTitles, List<PrecedingSucceedingTitle> succeedingTitles,
-    WebContext context) {
-    JsonObject resp = new JsonObject();
-
-    try {
-      resp.put("@context", context.absoluteUrl(
-        INSTANCES_PATH + "/context").toString());
-    } catch (MalformedURLException e) {
-      log.warn(
-        format("Failed to create context link for instance: %s", e.toString()));
-    }
-
-    resp.put("id", instance.getId());
-    resp.put("hrid", instance.getHrid());
-    resp.put(Instance.SOURCE_KEY, instance.getSource());
-    resp.put(Instance.TITLE_KEY, instance.getTitle());
-    putIfNotNull(resp, Instance.MATCH_KEY_KEY, instance.getMatchKey());
-    putIfNotNull(resp, Instance.INDEX_TITLE_KEY, instance.getIndexTitle());
-    putIfNotNull(resp, Instance.PARENT_INSTANCES_KEY, parentInstances);
-    putIfNotNull(resp, Instance.CHILD_INSTANCES_KEY, childInstances);
-    putIfNotNull(resp, Instance.ALTERNATIVE_TITLES_KEY, instance.getAlternativeTitles());
-    putIfNotNull(resp, Instance.EDITIONS_KEY, instance.getEditions());
-    putIfNotNull(resp, Instance.SERIES_KEY, instance.getSeries());
-    putIfNotNull(resp, Instance.IDENTIFIERS_KEY, instance.getIdentifiers());
-    putIfNotNull(resp, Instance.CONTRIBUTORS_KEY, instance.getContributors());
-    putIfNotNull(resp, Instance.SUBJECTS_KEY, instance.getSubjects());
-    putIfNotNull(resp, Instance.CLASSIFICATIONS_KEY, instance.getClassifications());
-    putIfNotNull(resp, Instance.PUBLICATION_KEY, instance.getPublication());
-    putIfNotNull(resp, Instance.PUBLICATION_FREQUENCY_KEY, instance.getPublicationFrequency());
-    putIfNotNull(resp, Instance.PUBLICATION_RANGE_KEY, instance.getPublicationRange());
-    putIfNotNull(resp, Instance.ELECTRONIC_ACCESS_KEY, instance.getElectronicAccess());
-    putIfNotNull(resp, Instance.INSTANCE_TYPE_ID_KEY, instance.getInstanceTypeId());
-    putIfNotNull(resp, Instance.INSTANCE_FORMAT_IDS_KEY, instance.getInstanceFormatIds());
-    putIfNotNull(resp, Instance.PHYSICAL_DESCRIPTIONS_KEY, instance.getPhysicalDescriptions());
-    putIfNotNull(resp, Instance.LANGUAGES_KEY, instance.getLanguages());
-    putIfNotNull(resp, Instance.NOTES_KEY, instance.getNotes());
-    putIfNotNull(resp, Instance.MODE_OF_ISSUANCE_ID_KEY, instance.getModeOfIssuanceId());
-    putIfNotNull(resp, Instance.CATALOGED_DATE_KEY, instance.getCatalogedDate());
-    putIfNotNull(resp, Instance.PREVIOUSLY_HELD_KEY, instance.getPreviouslyHeld());
-    putIfNotNull(resp, Instance.STAFF_SUPPRESS_KEY, instance.getStaffSuppress());
-    putIfNotNull(resp, Instance.DISCOVERY_SUPPRESS_KEY, instance.getDiscoverySuppress());
-    putIfNotNull(resp, Instance.STATISTICAL_CODE_IDS_KEY, instance.getStatisticalCodeIds());
-    putIfNotNull(resp, Instance.SOURCE_RECORD_FORMAT_KEY, instance.getSourceRecordFormat());
-    putIfNotNull(resp, Instance.STATUS_ID_KEY, instance.getStatusId());
-    putIfNotNull(resp, Instance.STATUS_UPDATED_DATE_KEY, instance.getStatusUpdatedDate());
-    putIfNotNull(resp, Instance.METADATA_KEY, instance.getMetadata());
-    putIfNotNull(resp, Instance.TAGS_KEY, new JsonObject().put(Instance.TAG_LIST_KEY, new JsonArray(instance.getTags())));
-    putIfNotNull(resp, Instance.NATURE_OF_CONTENT_TERM_IDS_KEY, instance.getNatureOfContentTermIds());
-
-    if (precedingTitles != null) {
-      JsonArray precedingTitlesJsonArray = new JsonArray();
-      precedingTitles.forEach(title -> precedingTitlesJsonArray .add(title.toPrecedingTitleJson()));
-      resp.put(Instance.PRECEDING_TITLES_KEY, precedingTitlesJsonArray );
-    }
-
-    if (succeedingTitles != null) {
-      JsonArray succeedingTitlesJsonArray = new JsonArray();
-      succeedingTitles.forEach(title -> succeedingTitlesJsonArray .add(title.toSucceedingTitleJson()));
-      resp.put(Instance.SUCCEEDING_TITLES_KEY, succeedingTitlesJsonArray );
-    }
-
-    try {
-      URL selfUrl = context.absoluteUrl(format("%s/%s",
-        INSTANCES_PATH, instance.getId()));
-
-      resp.put("links", new JsonObject().put("self", selfUrl.toString()));
-    } catch (MalformedURLException e) {
-      log.warn(
-        format("Failed to create self link for instance: %s", e.toString()));
-    }
-
-    return resp;
-  }
 
   // Utilities
 

--- a/src/main/java/org/folio/inventory/resources/InstancesBatch.java
+++ b/src/main/java/org/folio/inventory/resources/InstancesBatch.java
@@ -24,7 +24,6 @@ import org.folio.inventory.domain.BatchResult;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
 import org.folio.inventory.storage.Storage;
-import org.folio.inventory.support.InstanceUtil;
 import org.folio.inventory.support.http.server.RedirectResponse;
 
 import java.util.ArrayList;
@@ -71,7 +70,7 @@ public class InstancesBatch extends AbstractInstances {
     } else {
       setInstancesIdIfNecessary(validInstances);
       List<Instance> instancesToCreate = validInstances.stream()
-        .map(InstanceUtil::jsonToInstance)
+        .map(Instance::fromJson)
         .collect(Collectors.toList());
 
       storage.getInstanceCollection(webContext).addBatch(instancesToCreate, success -> {
@@ -168,8 +167,7 @@ public class InstancesBatch extends AbstractInstances {
 
   private JsonObject getBatchResponse(List<Instance> createdInstances, List<String> errorMessages, WebContext webContext) {
     List<JsonObject> jsonInstances = createdInstances.stream()
-      .map(instance -> toRepresentation(instance, new ArrayList<>(), new ArrayList<>(),
-        instance.getPrecedingTitles(), instance.getSucceedingTitles(), webContext))
+      .map(instance -> instance.getJsonForResponse(webContext))
       .collect(Collectors.toList());
 
     return new JsonObject()
@@ -203,7 +201,7 @@ public class InstancesBatch extends AbstractInstances {
                                                        RoutingContext routingContext, WebContext webContext) {
     try {
       Map<String, Instance> mapInstanceById = newInstances.stream()
-        .collect(Collectors.toMap(instance -> instance.getString("id"), InstanceUtil::jsonToInstance));
+        .collect(Collectors.toMap(instance -> instance.getString("id"), Instance::fromJson));
 
       List<Future> updateRelationshipsFutures = new ArrayList<>();
       for (Instance createdInstance : createdInstances) {

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleInstanceCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleInstanceCollection.java
@@ -13,22 +13,12 @@ import org.apache.logging.log4j.Logger;
 import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.domain.BatchResult;
-import org.folio.inventory.domain.Metadata;
-import org.folio.inventory.domain.instances.AlternativeTitle;
-import org.folio.inventory.domain.instances.Classification;
-import org.folio.inventory.domain.instances.Contributor;
-import org.folio.inventory.domain.instances.Identifier;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.InstanceCollection;
-import org.folio.inventory.domain.instances.Note;
-import org.folio.inventory.domain.instances.Publication;
-import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
 import org.folio.inventory.support.http.client.Response;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -36,7 +26,6 @@ import java.util.stream.Collectors;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.folio.inventory.support.JsonArrayHelper.toList;
-import static org.folio.inventory.support.JsonArrayHelper.toListOfStrings;
 import static org.folio.inventory.support.http.ContentType.APPLICATION_JSON;
 
 class ExternalStorageModuleInstanceCollection
@@ -61,150 +50,17 @@ class ExternalStorageModuleInstanceCollection
 
   @Override
   protected JsonObject mapToRequest(Instance instance) {
-    JsonObject instanceToSend = new JsonObject();
-    //TODO: Review if this shouldn't be defaulting here
-    instanceToSend.put("id", instance.getId() != null
-      ? instance.getId()
-      : UUID.randomUUID().toString());
-    instanceToSend.put(Instance.HRID_KEY, instance.getHrid());
-    includeIfPresent(instanceToSend, Instance.SOURCE_KEY, instance.getSource());
-    instanceToSend.put(Instance.MATCH_KEY_KEY, instance.getMatchKey());
-    instanceToSend.put(Instance.TITLE_KEY, instance.getTitle());
-    instanceToSend.put(Instance.INDEX_TITLE_KEY, instance.getIndexTitle());
-    instanceToSend.put(Instance.ALTERNATIVE_TITLES_KEY, instance.getAlternativeTitles());
-    instanceToSend.put(Instance.EDITIONS_KEY, instance.getEditions());
-    instanceToSend.put(Instance.SERIES_KEY, instance.getSeries());
-    instanceToSend.put(Instance.IDENTIFIERS_KEY, instance.getIdentifiers());
-    instanceToSend.put(Instance.CONTRIBUTORS_KEY, instance.getContributors());
-    instanceToSend.put(Instance.SUBJECTS_KEY, instance.getSubjects());
-    instanceToSend.put(Instance.CLASSIFICATIONS_KEY, instance.getClassifications());
-    instanceToSend.put(Instance.PUBLICATION_KEY, instance.getPublication());
-    instanceToSend.put(Instance.PUBLICATION_FREQUENCY_KEY, instance.getPublicationFrequency());
-    instanceToSend.put(Instance.PUBLICATION_RANGE_KEY, instance.getPublicationRange());
-    instanceToSend.put(Instance.ELECTRONIC_ACCESS_KEY, instance.getElectronicAccess());
-    includeIfPresent(instanceToSend, Instance.INSTANCE_TYPE_ID_KEY, instance.getInstanceTypeId());
-    instanceToSend.put(Instance.INSTANCE_FORMAT_IDS_KEY, instance.getInstanceFormatIds());
-    instanceToSend.put(Instance.PHYSICAL_DESCRIPTIONS_KEY, instance.getPhysicalDescriptions());
-    instanceToSend.put(Instance.LANGUAGES_KEY, instance.getLanguages());
-    instanceToSend.put(Instance.NOTES_KEY, instance.getNotes());
-    instanceToSend.put(Instance.MODE_OF_ISSUANCE_ID_KEY, instance.getModeOfIssuanceId());
-    instanceToSend.put(Instance.CATALOGED_DATE_KEY, instance.getCatalogedDate());
-    instanceToSend.put(Instance.PREVIOUSLY_HELD_KEY, instance.getPreviouslyHeld());
-    instanceToSend.put(Instance.STAFF_SUPPRESS_KEY, instance.getStaffSuppress());
-    instanceToSend.put(Instance.DISCOVERY_SUPPRESS_KEY, instance.getDiscoverySuppress());
-    instanceToSend.put(Instance.STATISTICAL_CODE_IDS_KEY, instance.getStatisticalCodeIds());
-    includeIfPresent(instanceToSend, Instance.SOURCE_RECORD_FORMAT_KEY, instance.getSourceRecordFormat());
-    instanceToSend.put(Instance.STATUS_ID_KEY, instance.getStatusId());
-    instanceToSend.put(Instance.STATUS_UPDATED_DATE_KEY, instance.getStatusUpdatedDate());
-    instanceToSend.put(Instance.TAGS_KEY, new JsonObject().put(Instance.TAG_LIST_KEY, new JsonArray(instance.getTags() == null ? Collections.emptyList() : instance.getTags())));
-    instanceToSend.put(Instance.NATURE_OF_CONTENT_TERM_IDS_KEY, instance.getNatureOfContentTermIds());
-
-    return instanceToSend;
+    return instance.getJsonForStorage();
   }
 
   @Override
   protected Instance mapFromJson(JsonObject instanceFromServer) {
-    List<JsonObject> identifiers = toList(
-      instanceFromServer.getJsonArray(Instance.IDENTIFIERS_KEY, new JsonArray()));
-
-    List<Identifier> mappedIdentifiers = identifiers.stream()
-      .map(Identifier::new)
-      .collect(Collectors.toList());
-
-    List<JsonObject> alternativeTitles = toList(
-      instanceFromServer.getJsonArray(Instance.ALTERNATIVE_TITLES_KEY, new JsonArray()));
-
-    List<AlternativeTitle> mappedAlternativeTitles = alternativeTitles.stream()
-      .map(AlternativeTitle::new)
-      .collect(Collectors.toList());
-
-    List<JsonObject> contributors = toList(
-      instanceFromServer.getJsonArray(Instance.CONTRIBUTORS_KEY, new JsonArray()));
-
-    List<Contributor> mappedContributors = contributors.stream()
-      .map(Contributor::new)
-      .collect(Collectors.toList());
-
-    List<JsonObject> classifications = toList(
-      instanceFromServer.getJsonArray(Instance.CLASSIFICATIONS_KEY, new JsonArray()));
-
-    List<Classification> mappedClassifications = classifications.stream()
-      .map(Classification::new)
-      .collect(Collectors.toList());
-
-    List<JsonObject> publications = toList(
-      instanceFromServer.getJsonArray(Instance.PUBLICATION_KEY, new JsonArray()));
-
-    List<Publication> mappedPublications = publications.stream()
-      .map(Publication::new)
-      .collect(Collectors.toList());
-
-    List<JsonObject> electronicAccess = toList(
-      instanceFromServer.getJsonArray(Instance.ELECTRONIC_ACCESS_KEY, new JsonArray()));
-
-    List<ElectronicAccess> mappedElectronicAccess = electronicAccess.stream()
-      .map(ElectronicAccess::new)
-      .collect(Collectors.toList());
-
-    List<JsonObject> notes = toList(
-      instanceFromServer.getJsonArray(Instance.NOTES_KEY, new JsonArray()));
-
-    List<Note> mappedNotes = notes.stream()
-      .map(Note::new)
-      .collect(Collectors.toList());
-
-    List<String> tags = instanceFromServer.containsKey(Instance.TAGS_KEY)
-      ? jsonArrayAsListOfStrings(instanceFromServer.getJsonObject(Instance.TAGS_KEY), Instance.TAG_LIST_KEY)
-      : new ArrayList<>();
-
-    JsonObject metadataJson = instanceFromServer.getJsonObject(Instance.METADATA_KEY);
-
-    return new Instance(
-      instanceFromServer.getString("id"),
-      instanceFromServer.getString("hrid"),
-      instanceFromServer.getString(Instance.SOURCE_KEY),
-      instanceFromServer.getString(Instance.TITLE_KEY),
-      instanceFromServer.getString(Instance.INSTANCE_TYPE_ID_KEY))
-      .setMatchKey(instanceFromServer.getString(Instance.MATCH_KEY_KEY))
-      .setIndexTitle(instanceFromServer.getString(Instance.INDEX_TITLE_KEY))
-      .setAlternativeTitles(mappedAlternativeTitles)
-      .setEditions(jsonArrayAsListOfStrings(instanceFromServer, Instance.EDITIONS_KEY))
-      .setSeries(jsonArrayAsListOfStrings(instanceFromServer, Instance.SERIES_KEY))
-      .setIdentifiers(mappedIdentifiers)
-      .setContributors(mappedContributors)
-      .setSubjects(jsonArrayAsListOfStrings(instanceFromServer, Instance.SUBJECTS_KEY))
-      .setClassifications(mappedClassifications)
-      .setPublication(mappedPublications)
-      .setPublicationFrequency(jsonArrayAsListOfStrings(instanceFromServer, Instance.PUBLICATION_FREQUENCY_KEY))
-      .setPublicationRange(jsonArrayAsListOfStrings(instanceFromServer, Instance.PUBLICATION_RANGE_KEY))
-      .setElectronicAccess(mappedElectronicAccess)
-      .setInstanceFormatIds(jsonArrayAsListOfStrings(instanceFromServer, Instance.INSTANCE_FORMAT_IDS_KEY))
-      .setPhysicalDescriptions(jsonArrayAsListOfStrings(instanceFromServer, Instance.PHYSICAL_DESCRIPTIONS_KEY))
-      .setLanguages(jsonArrayAsListOfStrings(instanceFromServer, Instance.LANGUAGES_KEY))
-      .setNotes(mappedNotes)
-      .setModeOfIssuanceId(instanceFromServer.getString(Instance.MODE_OF_ISSUANCE_ID_KEY))
-      .setCatalogedDate(instanceFromServer.getString(Instance.CATALOGED_DATE_KEY))
-      .setPreviouslyHeld(instanceFromServer.getBoolean(Instance.PREVIOUSLY_HELD_KEY))
-      .setStaffSuppress(instanceFromServer.getBoolean(Instance.STAFF_SUPPRESS_KEY))
-      .setDiscoverySuppress(instanceFromServer.getBoolean(Instance.DISCOVERY_SUPPRESS_KEY))
-      .setStatisticalCodeIds(jsonArrayAsListOfStrings(instanceFromServer, Instance.STATISTICAL_CODE_IDS_KEY))
-      .setSourceRecordFormat(instanceFromServer.getString(Instance.SOURCE_RECORD_FORMAT_KEY))
-      .setStatusId(instanceFromServer.getString(Instance.STATUS_ID_KEY))
-      .setStatusUpdatedDate(instanceFromServer.getString(Instance.STATUS_UPDATED_DATE_KEY))
-      .setMetadata(new Metadata(metadataJson))
-      .setTags(tags)
-      .setNatureOfContentTermIds(jsonArrayAsListOfStrings(instanceFromServer, Instance.NATURE_OF_CONTENT_TERM_IDS_KEY));
+    return Instance.fromJson(instanceFromServer);
   }
 
   @Override
   protected String getId(Instance record) {
     return record.getId();
-  }
-
-  private List<String> jsonArrayAsListOfStrings(JsonObject source, String propertyName) {
-    return source.containsKey(propertyName)
-      ? toListOfStrings(source.getJsonArray(propertyName))
-      : new ArrayList<>();
   }
 
   @Override

--- a/src/main/java/org/folio/inventory/support/InstanceUtil.java
+++ b/src/main/java/org/folio/inventory/support/InstanceUtil.java
@@ -2,21 +2,12 @@ package org.folio.inventory.support;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.folio.ChildInstance;
 import org.folio.ParentInstance;
-import org.folio.inventory.domain.instances.AlternativeTitle;
-import org.folio.inventory.domain.instances.Classification;
-import org.folio.inventory.domain.instances.Contributor;
-import org.folio.inventory.domain.instances.Identifier;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.InstanceRelationshipToChild;
 import org.folio.inventory.domain.instances.InstanceRelationshipToParent;
-import org.folio.inventory.domain.instances.Note;
-import org.folio.inventory.domain.instances.Publication;
-import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
-import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;

--- a/src/main/java/org/folio/inventory/support/InstanceUtil.java
+++ b/src/main/java/org/folio/inventory/support/InstanceUtil.java
@@ -30,134 +30,7 @@ public class InstanceUtil {
 
 
 
-  private InstanceUtil() {
-
-  }
-
-  public static Instance jsonToInstance(JsonObject instanceRequest) {
-    List<InstanceRelationshipToParent> parentInstances = instanceRequest.containsKey(Instance.PARENT_INSTANCES_KEY)
-      ? JsonArrayHelper.toList(instanceRequest.getJsonArray(Instance.PARENT_INSTANCES_KEY)).stream()
-      .map(InstanceRelationshipToParent::new)
-      .collect(Collectors.toList())
-      : new ArrayList<>();
-
-    List<InstanceRelationshipToChild> childInstances = instanceRequest.containsKey(Instance.CHILD_INSTANCES_KEY)
-      ? JsonArrayHelper.toList(instanceRequest.getJsonArray(Instance.CHILD_INSTANCES_KEY)).stream()
-      .map(InstanceRelationshipToChild::new)
-      .collect(Collectors.toList())
-      : new ArrayList<>();
-
-    List<PrecedingSucceedingTitle> precedingTitles = instanceRequest.containsKey(Instance.PRECEDING_TITLES_KEY)
-      ? JsonArrayHelper.toList(instanceRequest.getJsonArray(Instance.PRECEDING_TITLES_KEY)).stream()
-      .map(PrecedingSucceedingTitle::from)
-      .collect(Collectors.toList())
-      : new ArrayList<>();
-
-    List<PrecedingSucceedingTitle> succeedingTitles = instanceRequest.containsKey(Instance.SUCCEEDING_TITLES_KEY)
-      ? JsonArrayHelper.toList(instanceRequest.getJsonArray(Instance.SUCCEEDING_TITLES_KEY)).stream()
-      .map(PrecedingSucceedingTitle::from)
-      .collect(Collectors.toList())
-      : new ArrayList<>();
-
-    List<Identifier> identifiers = instanceRequest.containsKey(Instance.IDENTIFIERS_KEY)
-      ? JsonArrayHelper.toList(instanceRequest.getJsonArray(Instance.IDENTIFIERS_KEY)).stream()
-      .map(Identifier::new)
-      .collect(Collectors.toList())
-      : new ArrayList<>();
-
-    List<AlternativeTitle> alternativeTitles = instanceRequest.containsKey(Instance.ALTERNATIVE_TITLES_KEY)
-      ? JsonArrayHelper.toList(instanceRequest.getJsonArray(Instance.ALTERNATIVE_TITLES_KEY)).stream()
-      .map(AlternativeTitle::new)
-      .collect(Collectors.toList())
-      : new ArrayList<>();
-
-    List<Contributor> contributors = instanceRequest.containsKey(Instance.CONTRIBUTORS_KEY)
-      ? JsonArrayHelper.toList(instanceRequest.getJsonArray(Instance.CONTRIBUTORS_KEY)).stream()
-      .map(Contributor::new)
-      .collect(Collectors.toList())
-      : new ArrayList<>();
-
-    List<Classification> classifications = instanceRequest.containsKey(Instance.CLASSIFICATIONS_KEY)
-      ? JsonArrayHelper.toList(instanceRequest.getJsonArray(Instance.CLASSIFICATIONS_KEY)).stream()
-      .map(Classification::new)
-      .collect(Collectors.toList())
-      : new ArrayList<>();
-
-    List<Publication> publications = instanceRequest.containsKey(Instance.PUBLICATION_KEY)
-      ? JsonArrayHelper.toList(instanceRequest.getJsonArray(Instance.PUBLICATION_KEY)).stream()
-      .map(Publication::new)
-      .collect(Collectors.toList())
-      : new ArrayList<>();
-
-    List<ElectronicAccess> electronicAccess = instanceRequest.containsKey(Instance.ELECTRONIC_ACCESS_KEY)
-      ? JsonArrayHelper.toList(instanceRequest.getJsonArray(Instance.ELECTRONIC_ACCESS_KEY)).stream()
-      .map(ElectronicAccess::new)
-      .collect(Collectors.toList())
-      : new ArrayList<>();
-
-    List<Note> notes = instanceRequest.containsKey(Instance.NOTES_KEY)
-      ? JsonArrayHelper.toList(instanceRequest.getJsonArray(Instance.NOTES_KEY)).stream()
-      .map(Note::new)
-      .collect(Collectors.toList())
-      : new ArrayList<>();
-
-    List<String> tags = instanceRequest.containsKey(Instance.TAGS_KEY)
-      ? getTags(instanceRequest) : new ArrayList<>();
-
-    return new Instance(
-      instanceRequest.getString("id"),
-      instanceRequest.getString("hrid"),
-      instanceRequest.getString(Instance.SOURCE_KEY),
-      instanceRequest.getString(Instance.TITLE_KEY),
-      instanceRequest.getString(Instance.INSTANCE_TYPE_ID_KEY))
-      .setIndexTitle(instanceRequest.getString(Instance.INDEX_TITLE_KEY))
-      .setParentInstances(parentInstances)
-      .setChildInstances(childInstances)
-      .setPrecedingTitles(precedingTitles)
-      .setSucceedingTitles(succeedingTitles)
-      .setAlternativeTitles(alternativeTitles)
-      .setEditions(toListOfStrings(instanceRequest, Instance.EDITIONS_KEY))
-      .setSeries(toListOfStrings(instanceRequest, Instance.SERIES_KEY))
-      .setIdentifiers(identifiers)
-      .setContributors(contributors)
-      .setSubjects(toListOfStrings(instanceRequest, Instance.SUBJECTS_KEY))
-      .setClassifications(classifications)
-      .setPublication(publications)
-      .setPublicationFrequency(toListOfStrings(instanceRequest, Instance.PUBLICATION_FREQUENCY_KEY))
-      .setPublicationRange(toListOfStrings(instanceRequest, Instance.PUBLICATION_RANGE_KEY))
-      .setElectronicAccess(electronicAccess)
-      .setInstanceFormatIds(toListOfStrings(instanceRequest, Instance.INSTANCE_FORMAT_IDS_KEY))
-      .setPhysicalDescriptions(toListOfStrings(instanceRequest, Instance.PHYSICAL_DESCRIPTIONS_KEY))
-      .setLanguages(toListOfStrings(instanceRequest, Instance.LANGUAGES_KEY))
-      .setNotes(notes)
-      .setModeOfIssuanceId(instanceRequest.getString(Instance.MODE_OF_ISSUANCE_ID_KEY))
-      .setCatalogedDate(instanceRequest.getString(Instance.CATALOGED_DATE_KEY))
-      .setPreviouslyHeld(instanceRequest.getBoolean(Instance.PREVIOUSLY_HELD_KEY))
-      .setStaffSuppress(instanceRequest.getBoolean(Instance.STAFF_SUPPRESS_KEY))
-      .setDiscoverySuppress(instanceRequest.getBoolean(Instance.DISCOVERY_SUPPRESS_KEY))
-      .setStatisticalCodeIds(toListOfStrings(instanceRequest, Instance.STATISTICAL_CODE_IDS_KEY))
-      .setSourceRecordFormat(instanceRequest.getString(Instance.SOURCE_RECORD_FORMAT_KEY))
-      .setStatusId(instanceRequest.getString(Instance.STATUS_ID_KEY))
-      .setStatusUpdatedDate(instanceRequest.getString(Instance.STATUS_UPDATED_DATE_KEY))
-      .setTags(tags)
-      .setNatureOfContentTermIds(toListOfStrings(instanceRequest, Instance.NATURE_OF_CONTENT_TERM_IDS_KEY));
-  }
-
-  private static List<String> getTags(JsonObject instanceRequest) {
-    try {
-      final JsonObject tags = instanceRequest.getJsonObject(Instance.TAGS_KEY);
-      return tags.containsKey(Instance.TAG_LIST_KEY) ?
-        JsonArrayHelper.toListOfStrings(tags.getJsonArray(Instance.TAG_LIST_KEY)) : new ArrayList<>();
-    } catch (ClassCastException e) {
-      return JsonArrayHelper.toListOfStrings(instanceRequest.getJsonArray(Instance.TAGS_KEY));
-    }
-  }
-
-  private static List<String> toListOfStrings(JsonObject source, String propertyName) {
-    return source.containsKey(propertyName)
-      ? JsonArrayHelper.toListOfStrings(source.getJsonArray(propertyName))
-      : new ArrayList<>();
-  }
+  private InstanceUtil() {}
 
   /**
    * Merges fields from Instances which are NOT controlled by the underlying SRS MARC
@@ -189,7 +62,7 @@ public class InstanceUtil {
     JsonObject existingInstanceAsJson = JsonObject.mapFrom(tmp);
     JsonObject mappedInstanceAsJson = JsonObject.mapFrom(mapped);
     JsonObject mergedInstanceAsJson = InstanceUtil.mergeInstances(existingInstanceAsJson, mappedInstanceAsJson);
-    return InstanceUtil.jsonToInstance(mergedInstanceAsJson);
+    return Instance.fromJson(mergedInstanceAsJson);
   }
 
   private static List<ParentInstance> constructParentInstancesList(Instance existing) {

--- a/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibInstanceHridSetKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibInstanceHridSetKafkaHandlerTest.java
@@ -93,7 +93,7 @@ public class MarcBibInstanceHridSetKafkaHandlerTest {
   @Before
   public void setUp() throws IOException {
     mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
-    existingInstance = InstanceUtil.jsonToInstance(new JsonObject(TestUtil.readFileFromPath(INSTANCE_PATH)));
+    existingInstance = Instance.fromJson(new JsonObject(TestUtil.readFileFromPath(INSTANCE_PATH)));
     record = Json.decodeValue(TestUtil.readFileFromPath(RECORD_PATH), Record.class);
     record.getParsedRecord().withContent(JsonObject.mapFrom(record.getParsedRecord().getContent()).encode());
 

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/MarcBibModifiedPostProcessingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/MarcBibModifiedPostProcessingEventHandlerTest.java
@@ -11,7 +11,6 @@ import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.InstanceCollection;
 import org.folio.inventory.storage.Storage;
-import org.folio.inventory.support.InstanceUtil;
 import org.folio.rest.jaxrs.model.MappingDetail;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
@@ -88,7 +87,7 @@ public class MarcBibModifiedPostProcessingEventHandlerTest {
   @Before
   public void setUp() throws IOException {
     mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
-    existingInstance = InstanceUtil.jsonToInstance(new JsonObject(TestUtil.readFileFromPath(INSTANCE_PATH)));
+    existingInstance = Instance.fromJson(new JsonObject(TestUtil.readFileFromPath(INSTANCE_PATH)));
     record = Json.decodeValue(TestUtil.readFileFromPath(RECORD_PATH), Record.class);
     record.getParsedRecord().withContent(JsonObject.mapFrom(record.getParsedRecord().getContent()).encode());
 
@@ -129,7 +128,7 @@ public class MarcBibModifiedPostProcessingEventHandlerTest {
 
     DataImportEventPayload eventPayload = future.get(5, TimeUnit.SECONDS);
     JsonObject instanceJson = new JsonObject(eventPayload.getContext().get(INSTANCE.value()));
-    Instance updatedInstance = InstanceUtil.jsonToInstance(instanceJson);
+    Instance updatedInstance = Instance.fromJson(instanceJson);
 
     // then
     Assert.assertEquals(existingInstance.getId(), instanceJson.getString("id"));

--- a/src/test/java/org/folio/inventory/eventhandlers/UpdateInstanceEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/UpdateInstanceEventHandlerUnitTest.java
@@ -11,7 +11,6 @@ import org.folio.inventory.dataimport.handlers.actions.UpdateInstanceEventHandle
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.InstanceCollection;
 import org.folio.inventory.storage.Storage;
-import org.folio.inventory.support.InstanceUtil;
 import org.folio.processing.events.utils.ZIPArchiver;
 import org.junit.Assert;
 import org.junit.Before;
@@ -60,7 +59,7 @@ public class UpdateInstanceEventHandlerUnitTest {
     headers.put("x-okapi-tenant", "dummy");
     headers.put("x-okapi-token", "dummy");
     MockitoAnnotations.initMocks(this);
-    existingInstance = InstanceUtil.jsonToInstance(new JsonObject(TestUtil.readFileFromPath(INSTANCE_PATH)));
+    existingInstance = Instance.fromJson(new JsonObject(TestUtil.readFileFromPath(INSTANCE_PATH)));
     updateInstanceEventHandler = new UpdateInstanceEventHandler(new InstanceUpdateDelegate(storage), context);
     when(storage.getInstanceCollection(any())).thenReturn(instanceRecordCollection);
     doAnswer(invocationOnMock -> {


### PR DESCRIPTION
**Problem**

Methods for mapping from Instance JSON to Instance Java object (POJO) and from Instance POJO to Instance JSON are spread across a number of different classes with a fair amount of logic duplication too.

Some mapping methods live in ExternalStorageModuleInstanceCollection, others in AbstractInstances. It then appears that when Instance mapping was needed for either batch - processing or DI (not sure of the history), there was no (easy) way to get at the existing mapping functions in the new, separate contexts, so mapping logic was duplicated and put in InstanceUtil instead.

One problem with this is that the same mapping changes must be implemented in multiple places.

Another problem is it becomes difficult to understand where the mapping happens, and since mapping Inventory objects to and from storage is 75% of what mod-inventory does, the mapping logic should optimally be easy to find and understand. It's not a supporting util function at least.

**Solution**
With this PR, Instance mapping functions would be consolidated and de-duplicated into src/main/java/org/folio/inventory/domain/instances/Instance.java, basically making it more object oriented you could say. Whether the result-set processing of ExternalStorageModuleIntanceCollection or the DI or the batch processing API needs a mapping to or from Instance JSON they can ask Instance to perform the mapping.

With this, Instance will thus have three main mapping methods,

one method for mapping from JSON to Instance POJO – which would apply to both JSON coming from the Inventory storage and JSON coming in from a client request – and
one method for mapping the POJO to a Inventory storage compliant PUT/POST request and
one method for mapping the POJO to a Instance JSON response for the client.

**Additional comments**
This change is related to MODINV-380 which involves mapping changes. It would be preferable to build it on a non-duplicated mapping logic.

No functional changes are intended by this change. All unit tests pass at before, unchanged. Some testing has also been performed with this branch under ui-inventory.
