### PR TITLE
MODINV-419: Instance tags should not be deleted when the instance is updated by an imported MARC record.

### DIFF
--- a/src/main/java/org/folio/inventory/resources/InstancesResponse.java
+++ b/src/main/java/org/folio/inventory/resources/InstancesResponse.java
@@ -14,10 +14,10 @@ import java.util.Map;
 
 public class InstancesResponse {
   private Success<MultipleRecords<Instance>> success;
-  private Map<String, List<InstanceRelationshipToParent>> parentInstanceMap = new HashMap();
-  private Map<String, List<InstanceRelationshipToChild>> childInstanceMap = new HashMap();
-  private Map<String, List<PrecedingSucceedingTitle>> precedingTitlesMap = new HashMap();
-  private Map<String, List<PrecedingSucceedingTitle>> succeedingTitlesMap = new HashMap();
+  private Map<String, List<InstanceRelationshipToParent>> parentInstanceMap = new HashMap<>();
+  private Map<String, List<InstanceRelationshipToChild>> childInstanceMap = new HashMap<>();
+  private Map<String, List<PrecedingSucceedingTitle>> precedingTitlesMap = new HashMap<>();
+  private Map<String, List<PrecedingSucceedingTitle>> succeedingTitlesMap = new HashMap<>();
 
   public Success<MultipleRecords<Instance>> getSuccess() {
     return success;

--- a/src/main/java/org/folio/inventory/support/InstanceUtil.java
+++ b/src/main/java/org/folio/inventory/support/InstanceUtil.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import org.folio.ChildInstance;
 import org.folio.ParentInstance;
+import org.folio.Tags;
 import org.folio.inventory.domain.instances.AlternativeTitle;
 import org.folio.inventory.domain.instances.Classification;
 import org.folio.inventory.domain.instances.Contributor;
@@ -183,6 +184,7 @@ public class InstanceUtil {
       .withStatusId(existing.getStatusId())
       .withStatisticalCodeIds(existing.getStatisticalCodeIds())
       .withNatureOfContentTermIds(existing.getNatureOfContentTermIds())
+      .withTags(new Tags().withTagList(existing.getTags()))
       .withParentInstances(parentInstances)
       .withChildInstances(childInstances);
 

--- a/src/test/java/api/ApiTestSuite.java
+++ b/src/test/java/api/ApiTestSuite.java
@@ -38,7 +38,7 @@ import api.items.MarkItemMissingApiTests;
 import api.items.MarkItemWithdrawnApiTests;
 import api.support.ControlledVocabularyPreparation;
 import api.support.http.ResourceClient;
-import api.tenant.TenantApiExamples;
+import api.tenant.TestTenantApiExamples;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -53,7 +53,7 @@ import support.fakes.FakeOkapi;
   ModsIngestExamples.class,
   IsbnUtilsApiExamples.class,
   ItemAllowedStatusesSchemaTest.class,
-  TenantApiExamples.class,
+  TestTenantApiExamples.class,
   PrecedingSucceedingTitlesApiExamples.class,
   InstanceRelationshipsTest.class,
   EventHandlersApiTest.class,

--- a/src/test/java/api/tenant/TestTenantApiExamples.java
+++ b/src/test/java/api/tenant/TestTenantApiExamples.java
@@ -15,9 +15,9 @@ import api.support.ApiRoot;
 import api.support.ApiTests;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
-public class TenantApiExamples extends ApiTests {
+public class TestTenantApiExamples extends ApiTests {
 
-  public TenantApiExamples() {
+  public TestTenantApiExamples() {
     super();
   }
 

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/util/InstanceUtilTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/util/InstanceUtilTest.java
@@ -1,6 +1,7 @@
 package org.folio.inventory.dataimport.handlers.actions.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -54,6 +55,10 @@ public class InstanceUtilTest {
     List<InstanceRelationshipToChild> children = new ArrayList<>();
     children.add(new InstanceRelationshipToChild("30773a27-b485-4dab-aeb6-b8c04fa3cb19", "30773a27-b485-4dab-aeb6-b8c04fa3cb23", "30773a27-b485-4dab-aeb6-b8c04fa3cb24"));
 
+    List<String> tagList = new ArrayList<>();
+    tagList.add("Tag1");
+    tagList.add("Tag2");
+
     org.folio.inventory.domain.instances.Instance existing =
       new org.folio.inventory.domain.instances.Instance("30773a27-b485-4dab-aeb6-b8c04fa3cb17", "in000000001", "source", "title", "30773a27-b485-4dab-aeb6-b8c04fa3cb19");
     existing.setStatisticalCodeIds(statisticalCodeIds);
@@ -65,6 +70,7 @@ public class InstanceUtilTest {
     existing.setNatureOfContentTermIds(natureOfContentTermIds);
     existing.setParentInstances(parents);
     existing.setChildInstances(children);
+    existing.setTags(tagList);
 
     org.folio.inventory.domain.instances.Instance instance = InstanceUtil.mergeFieldsWhichAreNotControlled(existing, mapped);
     assertEquals("30773a27-b485-4dab-aeb6-b8c04fa3cb17", instance.getId());
@@ -80,6 +86,8 @@ public class InstanceUtilTest {
     assertEquals("", instance.getCatalogedDate());
     assertEquals("30773a27-b485-4dab-aeb6-b8c04fa3cb26", instance.getStatusId());
     assertEquals(natureOfContentTermIds, instance.getNatureOfContentTermIds());
+    assertNotNull(instance.getTags());
+    assertEquals(tagList, instance.getTags());
     assertEquals("30773a27-b485-4dab-aeb6-b8c04fa3cb19", instance.getParentInstances().get(0).getId());
     assertEquals("30773a27-b485-4dab-aeb6-b8c04fa3cb19", instance.getChildInstances().get(0).getId());
   }


### PR DESCRIPTION
This PR was already reviewed and merged to the master, and this fix was reviewed by PO.
Reviewed PR for this: https://github.com/folio-org/mod-inventory/pull/339