### PR TITLE
MODINV-421 - Permission error while executing GET /inventory/instances endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -327,7 +327,8 @@
             "inventory-storage.instances.item.get",
             "inventory-storage.preceding-succeeding-titles.collection.get",
             "inventory-storage.instance-relationships.collection.get",
-            "inventory-storage.bound-with-parts.collection.get"
+            "inventory-storage.bound-with-parts.collection.get",
+            "inventory-storage.holdings.collection.get"
           ]
         }, {
           "methods": ["GET"],


### PR DESCRIPTION
[MODINV-421](https://issues.folio.org/browse/MODINV-421) - Permission error while executing GET /inventory/instances endpoint

* added missing permission