### PR TITLE
MODINV-422 - Update interface version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -572,7 +572,7 @@
     },
     {
       "id": "source-storage-records",
-      "version": "2.0"
+      "version": "3.0"
     },
     {
       "id": "bound-with-parts-storage",


### PR DESCRIPTION
## Purpose
Due to changes made in scope of https://issues.folio.org/browse/MODINV-410 interfaces version should be updated to notify dependant modules about changes. 

## Approach
* updated requires interface version for  "source-storage-records" from 2.0 to 3.0

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
