### PR TITLE
MODINV-428: Propagate publicationPeriod property.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "10.11",
+      "version": "10.12",
       "handlers": [
         {
           "methods": ["GET"],
@@ -524,7 +524,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.7"
+      "version": "7.8"
     },
     {
       "id": "instance-storage-batch",

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -247,6 +247,21 @@
       },
       "uniqueItems": true
     },
+    "publicationPeriod": {
+      "type": "object",
+      "description": "Publication period",
+      "properties": {
+        "start": {
+          "type": "integer",
+          "description": "Publication start year"
+        },
+        "end": {
+          "type": "integer",
+          "description": "Publication end year"
+        }
+      },
+      "additionalProperties": false
+    },
     "electronicAccess": {
       "type": "array",
       "description": "List of electronic access items",

--- a/src/main/java/org/folio/inventory/domain/instances/Instance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/Instance.java
@@ -22,7 +22,10 @@ import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
 import org.folio.inventory.support.JsonArrayHelper;
 
 import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static org.folio.inventory.domain.instances.PublicationPeriod.publicationPeriodFromJson;
 import static org.folio.inventory.support.JsonArrayHelper.toListOfStrings;
+import static org.folio.inventory.support.JsonHelper.includeIfPresent;
 
 public class Instance {
   // JSON property names
@@ -65,6 +68,7 @@ public class Instance {
   public static final String TAGS_KEY = "tags";
   public static final String TAG_LIST_KEY = "tagList";
   public static final String NATURE_OF_CONTENT_TERM_IDS_KEY = "natureOfContentTermIds";
+  public static final String PUBLICATION_PERIOD_KEY = "publicationPeriod";
 
   private final String id;
   private final String hrid;
@@ -105,6 +109,7 @@ public class Instance {
   private Metadata metadata = null;
   private List<String> tags;
   private List<String> natureOfContentTermIds = new ArrayList<>();
+  private PublicationPeriod publicationPeriod;
 
   protected static final String INVENTORY_PATH = "/inventory";
   protected static final String INSTANCES_PATH = INVENTORY_PATH + "/instances";
@@ -171,7 +176,8 @@ public class Instance {
       .setStatusId(instanceJson.getString(STATUS_ID_KEY))
       .setStatusUpdatedDate(instanceJson.getString(STATUS_UPDATED_DATE_KEY))
       .setTags(getTags(instanceJson))
-      .setNatureOfContentTermIds(toListOfStrings(instanceJson.getJsonArray(NATURE_OF_CONTENT_TERM_IDS_KEY)));
+      .setNatureOfContentTermIds(toListOfStrings(instanceJson.getJsonArray(NATURE_OF_CONTENT_TERM_IDS_KEY)))
+      .setPublicationPeriod(publicationPeriodFromJson(instanceJson.getJsonObject(PUBLICATION_PERIOD_KEY)));
   }
 
   /**
@@ -217,6 +223,8 @@ public class Instance {
     json.put(STATUS_UPDATED_DATE_KEY, statusUpdatedDate);
     json.put(TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray(getTags() == null ? Collections.emptyList() : getTags())));
     json.put(NATURE_OF_CONTENT_TERM_IDS_KEY, natureOfContentTermIds);
+    includeIfPresent(json, PUBLICATION_PERIOD_KEY,
+      ofNullable(publicationPeriod).map(PublicationPeriod::toJson));
 
     return json;
   }
@@ -275,6 +283,7 @@ public class Instance {
     putIfNotNull(json, METADATA_KEY, getMetadata());
     putIfNotNull(json, TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray(getTags())));
     putIfNotNull(json, NATURE_OF_CONTENT_TERM_IDS_KEY, getNatureOfContentTermIds());
+    includeIfPresent(json, PUBLICATION_PERIOD_KEY, ofNullable(publicationPeriod).map(PublicationPeriod::toJson));
 
     if (precedingTitles != null) {
       JsonArray precedingTitlesJsonArray = new JsonArray();
@@ -765,7 +774,8 @@ public class Instance {
             .setStatusUpdatedDate(statusUpdatedDate)
             .setMetadata(metadata)
             .setTags(tags)
-            .setNatureOfContentTermIds(natureOfContentTermIds);
+            .setNatureOfContentTermIds(natureOfContentTermIds)
+            .setPublicationPeriod(publicationPeriod);
   }
 
   public Instance copyInstance() {
@@ -797,7 +807,8 @@ public class Instance {
             .setStatusUpdatedDate(statusUpdatedDate)
             .setMetadata(metadata)
             .setTags(tags)
-            .setNatureOfContentTermIds(natureOfContentTermIds);
+            .setNatureOfContentTermIds(natureOfContentTermIds)
+            .setPublicationPeriod(publicationPeriod);
   }
 
   public Instance addIdentifier(Identifier identifier) {
@@ -831,6 +842,10 @@ public class Instance {
     return copyInstance().setIdentifiers(newIdentifiers);
   }
 
+  public Instance setPublicationPeriod(PublicationPeriod period) {
+    this.publicationPeriod = period;
+    return this;
+  }
 
   @Override
   public String toString() {

--- a/src/main/java/org/folio/inventory/domain/instances/Instance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/Instance.java
@@ -1,5 +1,13 @@
 package org.folio.inventory.domain.instances;
 
+import static java.lang.String.format;
+import static org.folio.inventory.domain.instances.PublicationPeriod.publicationPeriodFromJson;
+import static org.folio.inventory.domain.instances.PublicationPeriod.publicationPeriodToJson;
+import static org.folio.inventory.support.JsonArrayHelper.toListOfStrings;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -8,10 +16,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -20,12 +24,6 @@ import org.folio.inventory.domain.Metadata;
 import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
 import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
 import org.folio.inventory.support.JsonArrayHelper;
-
-import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
-import static org.folio.inventory.domain.instances.PublicationPeriod.publicationPeriodFromJson;
-import static org.folio.inventory.support.JsonArrayHelper.toListOfStrings;
-import static org.folio.inventory.support.JsonHelper.includeIfPresent;
 
 public class Instance {
   // JSON property names
@@ -223,8 +221,7 @@ public class Instance {
     json.put(STATUS_UPDATED_DATE_KEY, statusUpdatedDate);
     json.put(TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray(getTags() == null ? Collections.emptyList() : getTags())));
     json.put(NATURE_OF_CONTENT_TERM_IDS_KEY, natureOfContentTermIds);
-    includeIfPresent(json, PUBLICATION_PERIOD_KEY,
-      ofNullable(publicationPeriod).map(PublicationPeriod::toJson));
+    putIfNotNull(json, PUBLICATION_PERIOD_KEY, publicationPeriodToJson(publicationPeriod));
 
     return json;
   }
@@ -283,7 +280,7 @@ public class Instance {
     putIfNotNull(json, METADATA_KEY, getMetadata());
     putIfNotNull(json, TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray(getTags())));
     putIfNotNull(json, NATURE_OF_CONTENT_TERM_IDS_KEY, getNatureOfContentTermIds());
-    includeIfPresent(json, PUBLICATION_PERIOD_KEY, ofNullable(publicationPeriod).map(PublicationPeriod::toJson));
+    putIfNotNull(json, PUBLICATION_PERIOD_KEY, publicationPeriodToJson(publicationPeriod));
 
     if (precedingTitles != null) {
       JsonArray precedingTitlesJsonArray = new JsonArray();

--- a/src/main/java/org/folio/inventory/domain/instances/PublicationPeriod.java
+++ b/src/main/java/org/folio/inventory/domain/instances/PublicationPeriod.java
@@ -1,0 +1,43 @@
+package org.folio.inventory.domain.instances;
+
+import static org.apache.commons.lang3.ObjectUtils.anyNotNull;
+import static org.folio.inventory.support.JsonHelper.includeIfPresent;
+
+import io.vertx.core.json.JsonObject;
+
+public class PublicationPeriod {
+  private final Integer start;
+  private final Integer end;
+
+  public PublicationPeriod(Integer start, Integer end) {
+    this.start = start;
+    this.end = end;
+  }
+
+  public Integer getStart() {
+    return start;
+  }
+
+  public Integer getEnd() {
+    return end;
+  }
+
+  public JsonObject toJson() {
+    var json = new JsonObject();
+    includeIfPresent(json, "start", start);
+    includeIfPresent(json, "end", end);
+
+    return json;
+  }
+
+  public static PublicationPeriod publicationPeriodFromJson(JsonObject pubPeriodJson) {
+    if (pubPeriodJson == null) {
+      return null;
+    }
+
+    var start = pubPeriodJson.getInteger("start");
+    var end = pubPeriodJson.getInteger("end");
+
+    return anyNotNull(start, end) ? new PublicationPeriod(start, end) : null;
+  }
+}

--- a/src/main/java/org/folio/inventory/domain/instances/PublicationPeriod.java
+++ b/src/main/java/org/folio/inventory/domain/instances/PublicationPeriod.java
@@ -22,10 +22,14 @@ public class PublicationPeriod {
     return end;
   }
 
-  public JsonObject toJson() {
+  public static JsonObject publicationPeriodToJson(PublicationPeriod period) {
+    if (period == null || (period.getStart() == null && period.getEnd() == null)) {
+      return null;
+    }
+
     var json = new JsonObject();
-    includeIfPresent(json, "start", start);
-    includeIfPresent(json, "end", end);
+    includeIfPresent(json, "start", period.getStart());
+    includeIfPresent(json, "end", period.getEnd());
 
     return json;
   }

--- a/src/main/java/org/folio/inventory/support/JsonHelper.java
+++ b/src/main/java/org/folio/inventory/support/JsonHelper.java
@@ -1,11 +1,13 @@
 package org.folio.inventory.support;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import org.apache.commons.lang3.StringUtils;
+import java.util.Optional;
 
 import io.vertx.core.json.JsonObject;
 
@@ -28,11 +30,20 @@ public class JsonHelper {
     return null;
   }
 
-  public static void includeIfPresent(
-    JsonObject representation, String propertyName, String value) {
+  public static <T> void includeIfPresent(
+    JsonObject representation, String propertyName, T value) {
 
-    if (representation != null && StringUtils.isNotBlank(propertyName) && value != null) {
+    if (representation != null && isNotBlank(propertyName) && value != null) {
       representation.put(propertyName, value);
+    }
+  }
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  public static <T> void includeIfPresent(
+    JsonObject representation, String propertyName, Optional<T> value) {
+
+    if (representation != null && isNotBlank(propertyName) && value.isPresent()) {
+      representation.put(propertyName, value.get());
     }
   }
 

--- a/src/main/java/org/folio/inventory/support/JsonHelper.java
+++ b/src/main/java/org/folio/inventory/support/JsonHelper.java
@@ -38,15 +38,6 @@ public class JsonHelper {
     }
   }
 
-  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-  public static <T> void includeIfPresent(
-    JsonObject representation, String propertyName, Optional<T> value) {
-
-    if (representation != null && isNotBlank(propertyName) && value.isPresent()) {
-      representation.put(propertyName, value.get());
-    }
-  }
-
   public JsonObject getJsonFileAsJsonObject(String filePath) throws IOException {
     InputStream is = this.getClass().getResourceAsStream(filePath);
     return new JsonObject(readFile(is));

--- a/src/main/java/org/folio/inventory/support/JsonHelper.java
+++ b/src/main/java/org/folio/inventory/support/JsonHelper.java
@@ -7,8 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import java.util.Optional;
-
 import io.vertx.core.json.JsonObject;
 
 public class JsonHelper {

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -51,6 +51,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.inventory.domain.instances.Instance.PUBLICATION_PERIOD_KEY;
 import static org.folio.inventory.domain.instances.Instance.TAGS_KEY;
 import static org.folio.inventory.domain.instances.Instance.TAG_LIST_KEY;
+import static org.folio.inventory.domain.instances.PublicationPeriod.publicationPeriodToJson;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -93,7 +94,7 @@ public class InstancesApiExamples extends ApiTests {
       .put("source", "Local")
       .put("instanceTypeId", ApiTestSuite.getTextInstanceType())
       .put(TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray().add(tagNameOne)))
-      .put(PUBLICATION_PERIOD_KEY, new PublicationPeriod(1000, 2000).toJson())
+      .put(PUBLICATION_PERIOD_KEY, publicationPeriodToJson(new PublicationPeriod(1000, 2000)))
       .put("natureOfContentTermIds",
         new JsonArray(asList(
           ApiTestSuite.getAudiobookNatureOfContentTermId(),
@@ -410,14 +411,14 @@ public class InstancesApiExamples extends ApiTests {
     JsonObject smallAngryPlanet = smallAngryPlanet(id);
     smallAngryPlanet.put("natureOfContentTermIds",
       new JsonArray().add(ApiTestSuite.getBibliographyNatureOfContentTermId()));
-    smallAngryPlanet.put(PUBLICATION_PERIOD_KEY, new PublicationPeriod(1000, 2000).toJson());
+    smallAngryPlanet.put(PUBLICATION_PERIOD_KEY, publicationPeriodToJson(new PublicationPeriod(1000, 2000)));
 
     JsonObject newInstance = createInstance(smallAngryPlanet);
 
     JsonObject updateInstanceRequest = newInstance.copy()
       .put("title", "The Long Way to a Small, Angry Planet")
       .put(TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray().add(tagNameTwo)))
-      .put(PUBLICATION_PERIOD_KEY, new PublicationPeriod(2000, 2012).toJson())
+      .put(PUBLICATION_PERIOD_KEY, publicationPeriodToJson(new PublicationPeriod(2000, 2012)))
       .put("natureOfContentTermIds",
         new JsonArray().add(ApiTestSuite.getAudiobookNatureOfContentTermId()));
 

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -16,11 +16,11 @@ import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
 import org.apache.http.message.BasicHeader;
 import org.folio.inventory.config.InventoryConfiguration;
 import org.folio.inventory.config.InventoryConfigurationImpl;
+import org.folio.inventory.domain.instances.PublicationPeriod;
 import org.folio.inventory.support.JsonArrayHelper;
 import org.folio.inventory.support.http.ContentType;
 import org.folio.inventory.support.http.client.IndividualResource;
 import org.folio.inventory.support.http.client.Response;
-import org.folio.inventory.support.http.client.ResponseHandler;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Assert;
@@ -33,9 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static api.support.InstanceSamples.leviathanWakes;
@@ -50,6 +48,7 @@ import static io.vertx.core.http.HttpMethod.POST;
 import static io.vertx.core.http.HttpMethod.PUT;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.inventory.domain.instances.Instance.PUBLICATION_PERIOD_KEY;
 import static org.folio.inventory.domain.instances.Instance.TAGS_KEY;
 import static org.folio.inventory.domain.instances.Instance.TAG_LIST_KEY;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -94,6 +93,7 @@ public class InstancesApiExamples extends ApiTests {
       .put("source", "Local")
       .put("instanceTypeId", ApiTestSuite.getTextInstanceType())
       .put(TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray().add(tagNameOne)))
+      .put(PUBLICATION_PERIOD_KEY, new PublicationPeriod(1000, 2000).toJson())
       .put("natureOfContentTermIds",
         new JsonArray(asList(
           ApiTestSuite.getAudiobookNatureOfContentTermId(),
@@ -157,6 +157,10 @@ public class InstancesApiExamples extends ApiTests {
     selfLinkShouldBeReachable(createdInstance);
 
     assertThat(createdInstance.getString("hrid"), notNullValue());
+
+    var publicationPeriod = createdInstance.getJsonObject(PUBLICATION_PERIOD_KEY);
+    assertThat(publicationPeriod.getInteger("start"), is(1000));
+    assertThat(publicationPeriod.getInteger("end"), is(2000));
   }
 
   @Test
@@ -406,12 +410,14 @@ public class InstancesApiExamples extends ApiTests {
     JsonObject smallAngryPlanet = smallAngryPlanet(id);
     smallAngryPlanet.put("natureOfContentTermIds",
       new JsonArray().add(ApiTestSuite.getBibliographyNatureOfContentTermId()));
+    smallAngryPlanet.put(PUBLICATION_PERIOD_KEY, new PublicationPeriod(1000, 2000).toJson());
 
     JsonObject newInstance = createInstance(smallAngryPlanet);
 
     JsonObject updateInstanceRequest = newInstance.copy()
       .put("title", "The Long Way to a Small, Angry Planet")
       .put(TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray().add(tagNameTwo)))
+      .put(PUBLICATION_PERIOD_KEY, new PublicationPeriod(2000, 2012).toJson())
       .put("natureOfContentTermIds",
         new JsonArray().add(ApiTestSuite.getAudiobookNatureOfContentTermId()));
 
@@ -446,6 +452,10 @@ public class InstancesApiExamples extends ApiTests {
 
     selfLinkRespectsWayResourceWasReached(updatedInstance);
     selfLinkShouldBeReachable(updatedInstance);
+
+    var publicationPeriod = updatedInstance.getJsonObject(PUBLICATION_PERIOD_KEY);
+    assertThat(publicationPeriod.getInteger("start"), is(2000));
+    assertThat(publicationPeriod.getInteger("end"), is(2012));
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/domain/instances/PublicationPeriodTest.java
+++ b/src/test/java/org/folio/inventory/domain/instances/PublicationPeriodTest.java
@@ -1,0 +1,68 @@
+package org.folio.inventory.domain.instances;
+
+import static org.folio.inventory.domain.instances.PublicationPeriod.publicationPeriodFromJson;
+import static org.folio.inventory.domain.instances.PublicationPeriod.publicationPeriodToJson;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.vertx.core.json.JsonObject;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.converters.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class PublicationPeriodTest {
+
+  @Parameters({
+    "1, 2",
+    "null, 2",
+    "1, null",
+  })
+  @Test
+  public void shouldCreatePublicationPeriodFromJson(@Nullable Integer start, @Nullable Integer end) {
+    var publicationPeriod = publicationPeriodFromJson(publicationPeriodJson(start, end));
+
+    assertThat(publicationPeriod.getStart(), is(start));
+    assertThat(publicationPeriod.getEnd(), is(end));
+  }
+
+  @Test
+  public void shouldNotCreatePublicationPeriodFromJsonWhenJsonIsNull() {
+    assertThat(publicationPeriodFromJson(null), nullValue());
+  }
+
+  @Test
+  public void shouldNotCreatePublicationPeriodFromJsonWhenStartAndEndAreNull() {
+    assertThat(publicationPeriodFromJson(publicationPeriodJson(null, null)), nullValue());
+  }
+
+  @Parameters({
+    "1, 2",
+    "null, 2",
+    "1, null",
+  })
+  @Test
+  public void shouldConvertPublicationPeriodToJson(@Nullable Integer start, @Nullable Integer end) {
+    var json = publicationPeriodToJson(new PublicationPeriod(start, end));
+
+    assertThat(json.getInteger("start"), is(start));
+    assertThat(json.getInteger("end"), is(end));
+  }
+
+  @Test
+  public void shouldNotConvertPublicationPeriodToJsonWhenItIsNull() {
+    assertThat(publicationPeriodToJson(null), nullValue());
+  }
+
+  @Test
+  public void shouldNotConvertPublicationPeriodToJsonWhenStartAndEndAreNull() {
+    assertThat(publicationPeriodToJson(new PublicationPeriod(null, null)), nullValue());
+  }
+
+  private JsonObject publicationPeriodJson(Integer start, Integer end) {
+    return new JsonObject().put("start", start).put("end", end);
+  }
+}

--- a/src/test/java/org/folio/inventory/support/JsonHelperTest.java
+++ b/src/test/java/org/folio/inventory/support/JsonHelperTest.java
@@ -1,0 +1,46 @@
+package org.folio.inventory.support;
+
+import static org.folio.inventory.support.JsonHelper.includeIfPresent;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JsonHelperTest {
+  @Spy
+  private JsonObject representation;
+
+  @Test
+  public void shouldIncludeValue() {
+    includeIfPresent(representation, "key", "value");
+    verify(representation, times(1)).put("key", "value");
+  }
+
+  @Test
+  public void shouldNotIncludeIfRepresentationIsNull() {
+    try {
+      includeIfPresent(null, "key", "value");
+    } catch (Exception ex) {
+      fail("Exception is not expected");
+    }
+  }
+
+  @Test
+  public void shouldNotIncludeIfKeyIsNull() {
+    includeIfPresent(representation, null, "value");
+    verifyZeroInteractions(representation);
+  }
+
+  @Test
+  public void shouldNotIncludeIfValueIsNull() {
+    includeIfPresent(representation, "key", null);
+    verifyZeroInteractions(representation);
+  }
+}


### PR DESCRIPTION
Propagate the `publicationPeriod` property for instance on update/create/get.
Increase `inventory` API version to `10.12`
Require `instance-storage` of `7.8` version