### PR TITLE
MODINV-433 Fix error updating instance after hrid has been set to srs record

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-source-record-storage-client</artifactId>
-      <version>5.1.0-SNAPSHOT</version>
+      <version>5.1.0</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibInstanceHridSetKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibInstanceHridSetKafkaHandler.java
@@ -6,7 +6,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 
-import io.vertx.kafka.client.producer.KafkaHeader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -24,7 +23,6 @@ import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.Record;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -36,14 +34,14 @@ import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
 public class MarcBibInstanceHridSetKafkaHandler implements AsyncRecordHandler<String, String> {
 
   private static final Logger LOGGER = LogManager.getLogger(MarcBibInstanceHridSetKafkaHandler.class);
-  private static final String MARC_KEY = "MARC";
+  private static final String MARC_KEY = "MARC_BIB";
   private static final String MAPPING_RULES_KEY = "MAPPING_RULES";
   private static final String MAPPING_PARAMS_KEY = "MAPPING_PARAMS";
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperTool.getMapper();
   private static final String CORRELATION_ID_HEADER = "correlationId";
 
-  private InstanceUpdateDelegate instanceUpdateDelegate;
-  private KafkaInternalCache kafkaInternalCache;
+  private final InstanceUpdateDelegate instanceUpdateDelegate;
+  private final KafkaInternalCache kafkaInternalCache;
 
   public MarcBibInstanceHridSetKafkaHandler(InstanceUpdateDelegate instanceUpdateDelegate, KafkaInternalCache kafkaInternalCache) {
     this.instanceUpdateDelegate = instanceUpdateDelegate;
@@ -57,6 +55,7 @@ public class MarcBibInstanceHridSetKafkaHandler implements AsyncRecordHandler<St
       Event event = OBJECT_MAPPER.readValue(record.value(), Event.class);
       if (!kafkaInternalCache.containsByKey(event.getId())) {
         kafkaInternalCache.putToCache(event.getId());
+        @SuppressWarnings("unchecked")
         HashMap<String, String> eventPayload = OBJECT_MAPPER.readValue(ZIPArchiver.unzip(event.getEventPayload()), HashMap.class);
         Map<String, String> headersMap = KafkaHeaderUtils.kafkaHeadersToMap(record.headers());
         String correlationId = headersMap.get(CORRELATION_ID_HEADER);

--- a/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibInstanceHridSetKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibInstanceHridSetKafkaHandlerTest.java
@@ -7,8 +7,6 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
-import org.folio.ActionProfile;
-import org.folio.MappingProfile;
 import org.folio.inventory.TestUtil;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.domain.Success;
@@ -16,31 +14,21 @@ import org.folio.inventory.dataimport.handlers.actions.InstanceUpdateDelegate;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.InstanceCollection;
 import org.folio.inventory.storage.Storage;
-import org.folio.inventory.support.InstanceUtil;
 import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.jaxrs.model.Event;
-import org.folio.rest.jaxrs.model.MappingDetail;
-import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Consumer;
 
-import static org.folio.ActionProfile.Action.MODIFY;
-import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -62,29 +50,6 @@ public class MarcBibInstanceHridSetKafkaHandlerTest {
   @Mock
   private KafkaInternalCache kafkaInternalCache;
 
-  private ActionProfile actionProfile = new ActionProfile()
-    .withId(UUID.randomUUID().toString())
-    .withName("Update instance")
-    .withAction(MODIFY)
-    .withFolioRecord(ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC);
-
-  private MappingProfile mappingProfile = new MappingProfile()
-    .withId(UUID.randomUUID().toString())
-    .withName("Update instance")
-    .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
-    .withExistingRecordType(MARC_BIBLIOGRAPHIC)
-    .withMappingDetails(new MappingDetail());
-
-  private ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
-    .withProfileId(actionProfile.getId())
-    .withContentType(ACTION_PROFILE)
-    .withContent(JsonObject.mapFrom(actionProfile).getMap())
-    .withChildSnapshotWrappers(Collections.singletonList(
-      new ProfileSnapshotWrapper()
-        .withProfileId(mappingProfile.getId())
-        .withContentType(MAPPING_PROFILE)
-        .withContent(JsonObject.mapFrom(mappingProfile).getMap())));
-
   private JsonObject mappingRules;
   private Record record;
   private Instance existingInstance;
@@ -98,20 +63,20 @@ public class MarcBibInstanceHridSetKafkaHandlerTest {
     record.getParsedRecord().withContent(JsonObject.mapFrom(record.getParsedRecord().getContent()).encode());
 
     MockitoAnnotations.initMocks(this);
-    Mockito.when(mockedStorage.getInstanceCollection(any(Context.class))).thenReturn(mockedInstanceCollection);
+    when(mockedStorage.getInstanceCollection(any(Context.class))).thenReturn(mockedInstanceCollection);
 
     doAnswer(invocationOnMock -> {
       Consumer<Success<Instance>> successHandler = invocationOnMock.getArgument(1);
       successHandler.accept(new Success<>(existingInstance));
       return null;
-    }).when(mockedInstanceCollection).findById(anyString(), any(Consumer.class), any(Consumer.class));
+    }).when(mockedInstanceCollection).findById(anyString(), any(), any());
 
     doAnswer(invocationOnMock -> {
       Instance instance = invocationOnMock.getArgument(0);
       Consumer<Success<Instance>> successHandler = invocationOnMock.getArgument(1);
       successHandler.accept(new Success<>(instance));
       return null;
-    }).when(mockedInstanceCollection).update(any(Instance.class), any(Consumer.class), any(Consumer.class));
+    }).when(mockedInstanceCollection).update(any(Instance.class), any(), any());
 
     marcBibInstanceHridSetKafkaHandler = new MarcBibInstanceHridSetKafkaHandler(new InstanceUpdateDelegate(mockedStorage), kafkaInternalCache);
   }
@@ -121,7 +86,7 @@ public class MarcBibInstanceHridSetKafkaHandlerTest {
     // given
     Async async = context.async();
     Map<String, String> payload = new HashMap<>();
-    payload.put("MARC", Json.encode(record));
+    payload.put("MARC_BIB", Json.encode(record));
     payload.put("MAPPING_RULES", mappingRules.encode());
     payload.put("MAPPING_PARAMS", new JsonObject().encode());
 
@@ -130,7 +95,7 @@ public class MarcBibInstanceHridSetKafkaHandlerTest {
     when(kafkaRecord.key()).thenReturn(expectedKafkaRecordKey);
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
 
-    Mockito.when(kafkaInternalCache.containsByKey("01")).thenReturn(false);
+    when(kafkaInternalCache.containsByKey("01")).thenReturn(false);
 
     // when
     Future<String> future = marcBibInstanceHridSetKafkaHandler.handle(kafkaRecord);
@@ -154,7 +119,7 @@ public class MarcBibInstanceHridSetKafkaHandlerTest {
     Event event = new Event().withId("01").withEventPayload(ZIPArchiver.zip(Json.encode(payload)));
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
 
-    Mockito.when(kafkaInternalCache.containsByKey("01")).thenReturn(false);
+    when(kafkaInternalCache.containsByKey("01")).thenReturn(false);
 
     // when
     Future<String> future = marcBibInstanceHridSetKafkaHandler.handle(kafkaRecord);
@@ -173,7 +138,7 @@ public class MarcBibInstanceHridSetKafkaHandlerTest {
     Event event = new Event().withId("01").withEventPayload(null);
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
 
-    Mockito.when(kafkaInternalCache.containsByKey("01")).thenReturn(false);
+    when(kafkaInternalCache.containsByKey("01")).thenReturn(false);
 
     // when
     Future<String> future = marcBibInstanceHridSetKafkaHandler.handle(kafkaRecord);
@@ -190,7 +155,7 @@ public class MarcBibInstanceHridSetKafkaHandlerTest {
     // given
     Async async = context.async();
     Map<String, String> payload = new HashMap<>();
-    payload.put("MARC", Json.encode(record));
+    payload.put("MARC_BIB", Json.encode(record));
     payload.put("MAPPING_RULES", mappingRules.encode());
     payload.put("MAPPING_PARAMS", new JsonObject().encode());
 
@@ -199,7 +164,7 @@ public class MarcBibInstanceHridSetKafkaHandlerTest {
     when(kafkaRecord.key()).thenReturn(expectedKafkaRecordKey);
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
 
-    Mockito.when(kafkaInternalCache.containsByKey("01")).thenReturn(true);
+    when(kafkaInternalCache.containsByKey("01")).thenReturn(true);
 
     // when
     Future<String> future = marcBibInstanceHridSetKafkaHandler.handle(kafkaRecord);


### PR DESCRIPTION
## Purpose 
Fix error updating instance after hrid has been set to srs record
https://issues.folio.org/browse/MODINV-433

##  Approach
* Change expected kafka event property from MARC to MARC_BIB
* Cleanup codesmells 