### PR TITLE
Change version to 17.0.0 MODINV-420

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 16.4.0 IN-PROGRESS
+## 17.0.0 IN-PROGRESS
 
 * Sets `isBoundWith` flag on Instances, Items (MODINV-388)
 * Provides end-point `/inventory/items-by-holdings-id` (MODINV-418)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory</artifactId>
   <groupId>org.folio</groupId>
-  <version>16.4.0-SNAPSHOT</version>
+  <version>17.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>


### PR DESCRIPTION
As module depends upon new major (3.0) version of `source-storage-records`. This was changed during the work for [MODINV-422](https://issues.folio.org/browse/MODINV-422).