### PR TITLE
MODINV-440: Bump commons-io from 2.4 to 2.7 (CVE-2021-29425)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>


### PR DESCRIPTION
This fixes a limited path traversal vulnerability in
FileNameUtils.normalize: https://nvd.nist.gov/vuln/detail/CVE-2021-29425

Multiple mod-inventory dependencies use commons-io and might be affected.