### PR TITLE
Modinv 443 bound with in item by

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 17.1.0 IN-PROGRESS
+
+* Adds `boundWithTitles` property to individual bound-with item (MODINV-443)
+
 ## 17.0.0 2021-06-15
 
 * Sets `isBoundWith` flag on instances and items (MODINV-388)

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -295,6 +295,49 @@
       "default": false,
       "readonly": true
     },
+    "boundWithTitles": {
+      "description": "List of titles that are bound together within this Item",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "description": "A title that is bound with other titles in this Item",
+        "properties": {
+          "briefHoldingsRecord": {
+            "type": "object",
+            "description": "Information about the holdings record that links the title to the bound-with Item",
+            "properties": {
+              "id": {
+                "description": "The UUID of the holdingsRecord",
+                "type": "string"
+              },
+              "hrid": {
+                "description": "The human-readable ID of the holdingsRecord",
+                "type": "string"
+              }
+            }
+          },
+          "briefInstance": {
+            "type": "object",
+            "description": "Information about the Instance / title that is bound with others in this Item",
+            "properties": {
+              "id": {
+                "description": "The UUID of the Instance",
+                "type": "string"
+              },
+              "hrid": {
+                "description": "The human-readable ID of the Instance",
+                "type": "string"
+              },
+              "title": {
+                "description": "The title of the Instance",
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "readonly": true
+    },
     "permanentLoanType": {
       "description": "Permanent loan type, is the default loan type for a given item. Loan types are tenant-defined in a reference table in Settings, Inventory, Item, Loan type (e.g. Can circulate, Course reserves, Reading room, Selected)",
       "type": "object",

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -300,11 +300,11 @@
       "type": "array",
       "items": {
         "type": "object",
-        "description": "A title that is bound with other titles in this Item",
+        "description": "A title that is bound with other titles within this Item",
         "properties": {
           "briefHoldingsRecord": {
             "type": "object",
-            "description": "Information about the holdings record that links the title to the bound-with Item",
+            "description": "Information about a holdings record that links a title to the bound-with Item",
             "properties": {
               "id": {
                 "description": "The UUID of the holdingsRecord",
@@ -314,11 +314,12 @@
                 "description": "The human-readable ID of the holdingsRecord",
                 "type": "string"
               }
-            }
+            },
+            "additionalProperties": false
           },
           "briefInstance": {
             "type": "object",
-            "description": "Information about the Instance / title that is bound with others in this Item",
+            "description": "Information about an Instance / title that is bound with other title within this Item",
             "properties": {
               "id": {
                 "description": "The UUID of the Instance",
@@ -332,9 +333,11 @@
                 "description": "The title of the Instance",
                 "type": "string"
               }
-            }
+            },
+            "additionalProperties": false
           }
-        }
+        },
+        "additionalProperties": false
       },
       "readonly": true
     },

--- a/src/main/java/org/folio/inventory/domain/items/Item.java
+++ b/src/main/java/org/folio/inventory/domain/items/Item.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import io.vertx.core.json.JsonArray;
 import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
 
 import io.vertx.core.json.JsonObject;
@@ -41,6 +42,7 @@ public class Item {
   public static final String LAST_CHECK_IN = "lastCheckIn";
   public static final String COPY_NUMBER_KEY = "copyNumber";
   public static final String EFFECTIVE_SHELVING_ORDER_KEY = "effectiveShelvingOrder";
+  public static final String BOUND_WITH_TITLES_KEY = "boundWithTitles";
 
   public final String id;
   private String hrid;
@@ -86,6 +88,7 @@ public class Item {
   private EffectiveCallNumberComponents effectiveCallNumberComponents;
 
   private boolean isBoundWith = false;
+  private JsonArray boundWithTitles = null;
 
   private final JsonObject metadata;
 
@@ -448,6 +451,15 @@ public class Item {
 
   public Item withIsBoundWith(boolean boundWith) {
     this.isBoundWith = boundWith;
+    return this;
+  }
+
+  public JsonArray getBoundWithTitles () {
+    return boundWithTitles;
+  }
+
+  public Item withBoundWithTitles (JsonArray titles) {
+    this.boundWithTitles = titles;
     return this;
   }
 

--- a/src/main/java/org/folio/inventory/resources/ItemRepresentation.java
+++ b/src/main/java/org/folio/inventory/resources/ItemRepresentation.java
@@ -182,6 +182,7 @@ class ItemRepresentation {
     }
 
     representation.put("isBoundWith", item.getIsBoundWith());
+    includeIfPresent(representation, Item.BOUND_WITH_TITLES_KEY, item.getBoundWithTitles());
 
     return representation;
   }
@@ -253,6 +254,15 @@ class ItemRepresentation {
 
     if (propertyValue != null) {
       representation.put(propertyName, propertyValue);
+    }
+  }
+
+  private void includeIfPresent(
+    JsonObject representation,
+    String propertyName,
+    JsonArray propertyValue) {
+    if (propertyValue != null) {
+      representation.put( propertyName, propertyValue );
     }
   }
 

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -432,7 +432,8 @@ public class Items extends AbstractInventoryResource {
             locationsClient.get(id, newFuture::complete);
           });
 
-        CompletableFuture<Response> boundWithPartsFuture = getBoundWithPartsForMultipleItemsFuture(wrappedItems, boundWithPartsClient);
+        CompletableFuture<Response> boundWithPartsFuture =
+          getBoundWithPartsForMultipleItemsFuture(wrappedItems, boundWithPartsClient);
         allFutures.add(boundWithPartsFuture);
 
         CompletableFuture<Void> allDoneFuture = allOf(allFutures);
@@ -478,77 +479,6 @@ public class Items extends AbstractInventoryResource {
     });
   }
 
-  private CompletableFuture<Response> getBoundWithPartsForMultipleItemsFuture(
-    MultipleRecords<Item> wrappedItems,
-    CollectionResourceClient boundWithPartsClient)
-  {
-    CompletableFuture<Response> future = new CompletableFuture<>();
-
-    List<String> itemIds = wrappedItems.records.stream()
-      .map(Item::getId)
-      .collect(Collectors.toList());
-
-    String boundWithPartsByItemIdsQuery =
-      String.format("itemId==(%s)",
-        itemIds.stream()
-        .map(String::toString)
-        .collect(Collectors.joining(" or ")));
-
-    boundWithPartsByItemIdsQuery = URLEncoder
-      .encode(boundWithPartsByItemIdsQuery, StandardCharsets.UTF_8);
-
-    boundWithPartsClient.getMany(
-      boundWithPartsByItemIdsQuery,
-      itemIds.size(),
-      0,
-      future::complete);
-
-    return future;
-  }
-
-  private CompletableFuture<Response> getBoundWithPartsForItemFuture(
-    Item item,
-    CollectionResourceClient boundWithPartsClient)
-  {
-
-    CompletableFuture<Response> future = new CompletableFuture<>();
-
-    String boundWithPartsByItemIdQuery = String.format("itemId==(%s)",
-      item.getId());
-
-    boundWithPartsClient.getMany(
-      boundWithPartsByItemIdQuery,
-      1000,
-      0,
-      future::complete);
-
-    return future;
-  }
-
-
-  private void setBoundWithFlagsOnItems(MultipleRecords<Item> wrappedItems,
-                                        CompletableFuture<Response> boundWithPartsFuture) {
-
-    Response response = boundWithPartsFuture.join();
-    if (response != null && response.hasBody() && response.getStatusCode()==200) {
-      JsonArray boundWithParts = response.getJson().getJsonArray("boundWithParts");
-      if (boundWithParts != null && !boundWithParts.isEmpty()) {
-        Set<String> boundWithItemIds = boundWithParts
-          .stream()
-          .map(o -> ((JsonObject) o).getString("itemId"))
-          .collect(Collectors.toSet());
-
-        for (Item item : wrappedItems.records) {
-          if (boundWithItemIds.contains(item.getId())) {
-            item.withIsBoundWith(true);
-          }
-        }
-      }
-    } else {
-      log.error("Failed to retrieve bound-with parts, status code:  " + (response != null ? response.getStatusCode() : "null response"));
-    }
-
-  }
 
   private OkapiHttpClient createHttpClient(
     RoutingContext routingContext,
@@ -731,19 +661,15 @@ public class Items extends AbstractInventoryResource {
         CompletableFuture<Response> effectiveLocationFuture = getReferenceRecord(
           item.getEffectiveLocationId(), locationsClient, allFutures);
 
-        CompletableFuture<Response> boundWithPartsFuture =
-          getBoundWithPartsForItemFuture(item, boundWithPartsClient);
-
-        allFutures.add(boundWithPartsFuture);
-
-
+        allFutures.add(
+          setBoundWithTitlesOnItemFuture( item,
+            boundWithPartsClient, holdingsClient, instancesClient )
+        );
 
         CompletableFuture<Void> allDoneFuture = allOf(allFutures);
 
         allDoneFuture.thenAccept(v -> {
           try {
-            int boundWithPartsCount = getTotalRecords(boundWithPartsFuture);
-            item.withIsBoundWith(boundWithPartsCount>0);
             JsonObject representation = includeReferenceRecordInformationInItem(
                       webContext, item, holding, instance,
                       materialTypeFuture,
@@ -773,27 +699,6 @@ public class Items extends AbstractInventoryResource {
       });
     });
   }
-
-  /**
-   *
-   * @param futureResponse response of a GET request for multiple records
-   * @return value of "totalRecords" from the response,
-   * or, -1 if the GET request was unsuccessful, if no JSON body was found
-   * in the response, or if the response did not contain a 'totalRecords'
-   * property (ie if it was a single record, getById response)
-   */
-  private int getTotalRecords (CompletableFuture<Response> futureResponse) {
-    Response response = futureResponse.join();
-    if (response.getStatusCode() == 200) {
-      JsonObject responseJson = response.getJson();
-      if (responseJson != null) {
-        if (responseJson.containsKey("totalRecords")) {
-          return responseJson.getInteger("totalRecords");
-        }
-      }
-    }
-    return -1;
- }
 
   private void invalidOkapiUrlResponse(RoutingContext routingContext, WebContext context) {
     ServerErrorResponse.internalError(routingContext.response(),
@@ -829,7 +734,7 @@ public class Items extends AbstractInventoryResource {
     CompletableFuture<Response> temporaryLocationFuture,
     CompletableFuture<Response> permanentLocationFuture,
     CompletableFuture<Response> effectiveLocationFuture) {
-
+log.info("Item has boundWithTitles? " + (item.getBoundWithTitles() != null));
     JsonObject foundMaterialType =
       referenceRecordFrom(item.getMaterialTypeId(), materialTypeFuture);
 
@@ -951,6 +856,190 @@ public class Items extends AbstractInventoryResource {
       return !newNote.getStaffOnly().equals(oldNote.getStaffOnly());
     }
   }
+
+  private CompletableFuture<Response> setBoundWithTitlesOnItemFuture(
+    Item item,
+    CollectionResourceClient boundWithPartsClient,
+    CollectionResourceClient holdingsClient,
+    CollectionResourceClient instancesClient
+  ) {
+    return getBoundWithPartsForItemFuture( item, boundWithPartsClient ).thenCompose( partsResponse -> {
+      JsonArray boundWithParts = (JsonArray) partsResponse.getJson().getJsonArray(
+        "boundWithParts" );
+      if ( boundWithParts.isEmpty() ) {
+        item.withIsBoundWith( false );
+        return CompletableFuture.completedFuture( null );
+      } else {
+        log.info( "Found bound-with parts?: " + boundWithParts.encodePrettily() );
+        List<String> holdingsRecordIds = getStringPropertyFromJsonArray(
+          boundWithParts, "holdingsRecordId" );
+        log.info( "They have holdingsRecord IDs: " + holdingsRecordIds );
+        CompletableFuture<Response> holdingsFetched = new CompletableFuture<>();
+        holdingsClient.getMany( multipleRecordsCqlQuery( holdingsRecordIds ),
+          holdingsRecordIds.size(), 0, holdingsFetched::complete );
+        return holdingsFetched.thenCompose( holdingsResponse -> {
+          JsonArray holdingsRecords = holdingsResponse.getJson().getJsonArray(
+            "holdingsRecords" );
+          log.info(
+            "Found holdings for bound-with parts?: " + holdingsRecords.encodePrettily() );
+          List<String> instanceIds = getStringPropertyFromJsonArray(
+            holdingsRecords, "instanceId" );
+          log.info( "They have instance IDs: " + instanceIds );
+          CompletableFuture<Response> instancesFetched = new CompletableFuture<>();
+          instancesClient.getMany( multipleRecordsCqlQuery( instanceIds ),
+            instanceIds.size(), 0, instancesFetched::complete );
+          return instancesFetched.thenCompose( instancesResponse -> {
+            JsonArray instances = instancesResponse.getJson().getJsonArray(
+              "instances" );
+            log.info(
+              "Found Instances for bound-with parts?: " + instances.encodePrettily() );
+            Map<String, JsonObject> instancesByIdMap = new HashMap();
+            instances.stream().forEach( instance -> {
+              instancesByIdMap.put( ( (JsonObject) instance ).getString( "id" ),
+                (JsonObject) instance );
+            } );
+            JsonArray boundWithTitles = new JsonArray();
+            holdingsRecords.stream().forEach( record -> {
+              JsonObject holdingsRecord = (JsonObject) record;
+              JsonObject boundWithTitle = new JsonObject();
+              JsonObject shortHoldingsRecord = new JsonObject();
+              JsonObject shortInstance = new JsonObject();
+              String instanceId = holdingsRecord.getString( "instanceId" );
+              shortHoldingsRecord.put( "id", holdingsRecord.getString( "id" ) );
+              shortHoldingsRecord.put( "hrid",
+                holdingsRecord.getString( "hrid" ) );
+              shortInstance.put( "id", instanceId );
+              shortInstance.put( "title",
+                instancesByIdMap.get( instanceId ).getString( "title" ) );
+              shortInstance.put( "hrid",
+                instancesByIdMap.get( instanceId ).getString( "hrid" ) );
+
+              boundWithTitle.put( "holdingsRecord", shortHoldingsRecord );
+              boundWithTitle.put( "instance", shortInstance );
+              boundWithTitles.add( boundWithTitle );
+            } );
+            if ( !boundWithTitles.isEmpty() )
+            {
+              log.info(
+                "Built bound-with titles: " + boundWithTitles.encodePrettily() );
+              item.withBoundWithTitles( boundWithTitles ).withIsBoundWith( true );
+            }
+            return CompletableFuture.completedFuture( null );
+          } );
+        });
+      }
+    });
+  }
+
+  private CompletableFuture<JsonArray> joinWithHoldings (JsonArray entities, CollectionResourceClient holdingsClient) {
+    List<String> holdingsRecordIds = getStringPropertyFromJsonArray(
+      entities, "holdingsRecordId" );
+    CompletableFuture<Response> holdingsFetched = new CompletableFuture<>();
+    holdingsClient.getMany( multipleRecordsCqlQuery( holdingsRecordIds ),
+      holdingsRecordIds.size(), 0, holdingsFetched::complete );
+    return holdingsFetched.thenCompose( holdingsResponse -> {
+      JsonArray holdingsRecords = holdingsResponse.getJson().getJsonArray(
+        "holdingsRecords" );
+      log.info(
+        "Found holdings for bound-with parts?: " + holdingsRecords.encodePrettily() );
+
+      return CompletableFuture.completedFuture( holdingsRecords );
+    });
+  }
+
+  private CompletableFuture<JsonArray> joinWithInstances (JsonArray entities, CollectionResourceClient instancesClient) {
+    List<String> instanceIds = getStringPropertyFromJsonArray(
+      entities, "instanceId" );
+    log.info( "They have instance IDs: " + instanceIds );
+    CompletableFuture<Response> instancesFetched = new CompletableFuture<>();
+    instancesClient.getMany( multipleRecordsCqlQuery( instanceIds ),
+      instanceIds.size(), 0, instancesFetched::complete );
+    return instancesFetched.thenCompose( instancesResponse -> {
+      JsonArray instances = instancesResponse.getJson().getJsonArray(
+        "instances" );
+      log.info(
+        "Found Instances for bound-with parts?: " + instances.encodePrettily() );
+      return CompletableFuture.completedFuture( instances );
+    });
+  }
+
+  private List<String> getStringPropertyFromJsonArray( JsonArray entities, String propertyName) {
+    return entities.stream()
+      .map(o -> ((JsonObject)o).getString(propertyName))
+      .collect( Collectors.toList());
+  }
+
+  private CompletableFuture<Response> getBoundWithPartsForItemFuture(
+    Item item,
+    CollectionResourceClient boundWithPartsClient)
+  {
+
+    CompletableFuture<Response> future = new CompletableFuture<>();
+
+    String boundWithPartsByItemIdQuery = String.format("itemId==(%s)",
+      item.getId());
+
+    boundWithPartsClient.getMany(
+      boundWithPartsByItemIdQuery,
+      1000,
+      0,
+      future::complete);
+
+    return future;
+  }
+
+  private void setBoundWithFlagsOnItems(MultipleRecords<Item> wrappedItems,
+                                        CompletableFuture<Response> boundWithPartsFuture) {
+
+    Response response = boundWithPartsFuture.join();
+    if (response != null && response.hasBody() && response.getStatusCode()==200) {
+      JsonArray boundWithParts = response.getJson().getJsonArray("boundWithParts");
+      if (boundWithParts != null && !boundWithParts.isEmpty()) {
+        Set<String> boundWithItemIds = boundWithParts
+          .stream()
+          .map(o -> ((JsonObject) o).getString("itemId"))
+          .collect(Collectors.toSet());
+
+        for (Item item : wrappedItems.records) {
+          if (boundWithItemIds.contains(item.getId())) {
+            item.withIsBoundWith(true);
+          }
+        }
+      }
+    } else {
+      log.error("Failed to retrieve bound-with parts, status code:  " + (response != null ? response.getStatusCode() : "null response"));
+    }
+
+  }
+
+  private CompletableFuture<Response> getBoundWithPartsForMultipleItemsFuture(
+    MultipleRecords<Item> wrappedItems,
+    CollectionResourceClient boundWithPartsClient)
+  {
+    CompletableFuture<Response> future = new CompletableFuture<>();
+
+    List<String> itemIds = wrappedItems.records.stream()
+      .map(Item::getId)
+      .collect(Collectors.toList());
+
+    String boundWithPartsByItemIdsQuery =
+      String.format("itemId==(%s)",
+        itemIds.stream()
+          .map(String::toString)
+          .collect(Collectors.joining(" or ")));
+
+    boundWithPartsByItemIdsQuery = URLEncoder
+      .encode(boundWithPartsByItemIdsQuery, StandardCharsets.UTF_8);
+
+    boundWithPartsClient.getMany(
+      boundWithPartsByItemIdsQuery,
+      itemIds.size(),
+      0,
+      future::complete);
+
+    return future;
+  }
+
 }
 
 

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -909,23 +909,23 @@ public class Items extends AbstractInventoryResource {
     holdingsRecords.stream().forEach( record -> {
       JsonObject holdingsRecord = (JsonObject) record;
       JsonObject boundWithTitle = new JsonObject();
-      JsonObject shortHoldingsRecord = new JsonObject();
-      JsonObject shortInstance = new JsonObject();
+      JsonObject briefHoldingsRecord = new JsonObject();
+      JsonObject briefInstance = new JsonObject();
       String instanceId = holdingsRecord.getString( "instanceId" );
-      shortHoldingsRecord.put( "id", holdingsRecord.getString( "id" ) );
-      shortHoldingsRecord.put( "hrid", holdingsRecord.getString( "hrid" ) );
-      shortInstance.put( "id", instanceId );
-      shortInstance.put( "title", instancesByIdMap.get( instanceId ).getString( "title" ) );
-      shortInstance.put( "hrid", instancesByIdMap.get( instanceId ).getString( "hrid" ) );
-      boundWithTitle.put( "holdingsRecord", shortHoldingsRecord );
-      boundWithTitle.put( "instance", shortInstance );
+      briefHoldingsRecord.put( "id", holdingsRecord.getString( "id" ) );
+      briefHoldingsRecord.put( "hrid", holdingsRecord.getString( "hrid" ) );
+      briefInstance.put( "id", instanceId );
+      briefInstance.put( "title", instancesByIdMap.get( instanceId ).getString( "title" ) );
+      briefInstance.put( "hrid", instancesByIdMap.get( instanceId ).getString( "hrid" ) );
+      boundWithTitle.put( "briefHoldingsRecord", briefHoldingsRecord );
+      boundWithTitle.put( "briefInstance", briefInstance );
       boundWithTitles.add( boundWithTitle );
     } );
     return boundWithTitles;
   }
 
   /**
-   * "Joins" a JSON array of entities by 'holdingsRecordId' with holdingsRecords fetched from storage
+   * For a set of entities with a 'holdingsRecordId' property, this method fetches holdingsRecords from storage by those holdingsRecordIds
    * @param entities  Array of records with a property named 'holdingsRecordId'
    * @param holdingsClient Client for fetching holdings records from storage
    * @return Array of holdings records found by provided entities' holdingsRecordIds

--- a/src/test/java/api/BoundWithTests.java
+++ b/src/test/java/api/BoundWithTests.java
@@ -102,6 +102,38 @@ public class BoundWithTests extends ApiTests
 
   }
 
+  @Test
+  public void boundWithTitlesArePresentInBoundWithItem () throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException
+  {
+    IndividualResource instance1 = instancesStorageClient.create( InstanceSamples.smallAngryPlanet( UUID.randomUUID() ) );
+    IndividualResource holdings1a = holdingsStorageClient.create(new HoldingRequestBuilder()
+      .forInstance(instance1.getId()).permanentlyInMainLibrary().withCallNumber( "HOLDINGS 1A" ));
+    IndividualResource item1a = itemsClient.create(new ItemRequestBuilder()
+      .forHolding( holdings1a.getId() ).withBarcode( "ITEM 1A" ));
+
+    IndividualResource instance2 = instancesStorageClient.create( InstanceSamples.girlOnTheTrain( UUID.randomUUID() ) );
+    IndividualResource holdings2a = holdingsStorageClient.create(new HoldingRequestBuilder()
+      .forInstance( instance2.getId()).permanentlyInMainLibrary().withCallNumber( "HOLDINGS 2A" ) );
+
+    IndividualResource instance3 = instancesStorageClient.create( InstanceSamples.leviathanWakes( UUID.randomUUID() ) );
+    IndividualResource holdings3a = holdingsStorageClient.create(new HoldingRequestBuilder()
+      .forInstance(instance3.getId()).permanentlyInMainLibrary().withCallNumber( "HOLDINGS 3A" ));
+
+    boundWithPartsStorageClient.create(
+      makeObjectBoundWithPart( item1a.getJson().getString("id"), holdings1a.getJson().getString( "id" ) ));
+    boundWithPartsStorageClient.create(
+      makeObjectBoundWithPart( item1a.getJson().getString("id"), holdings2a.getJson().getString( "id" ) ));
+    boundWithPartsStorageClient.create(
+      makeObjectBoundWithPart( item1a.getJson().getString("id"), holdings3a.getJson().getString( "id" ) ));
+
+    Response itemResponse = okapiClient.get(ApiTestSuite.apiRoot()+
+      "/inventory/items/"+item1a.getId())
+      .toCompletableFuture().get(5, SECONDS);
+
+    assertThat("Item has boundWithTitles array with three titles",
+      itemResponse.getJson().getJsonArray( "boundWithTitles" ).size(), is(3));
+  }
+
   // NOTE: To be investigated: Several of these tests could possibly falsely pass
   //       due to the complexities of the queries, not all of which are
   //       necessarily supported by the fake storage modules.


### PR DESCRIPTION
For Items that are bound-withs, the Inventory UI needs to display the list of titles that are bound together within the Item - in the Item details view.

This change is meant to assist the UI rendering logic by providing the required information in the Item itself.  See the mock-up in UIIN-1545 for the fields to be shown. 

The suggested solution is to embed the list of titles in the Item. This is similar to how a single Instance title is embedded in the Item representation for a non-bound-with Item.  

The information needed is:  instance.title, instance.id (for linking), instance.hrid, holdingsRecord.id (for linking) and holdingsRecord.hrid.  More properties could be added later if necessary. 

Since there's no current need for this information to be present in Items of a result set, the information is currently only set on a single Item retrieved by its REST path (UUID). This is to avoid unnecessary processing but he logic might be applied to Items in result sets too, if the need arises.  