### PR TITLE
Remove limit of 10 parents/children in single instance (MODINV-446)

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/PrecedingSucceedingTitlesHelper.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/PrecedingSucceedingTitlesHelper.java
@@ -47,9 +47,9 @@ public class PrecedingSucceedingTitlesHelper {
 
     Promise<List<JsonObject>> promise = Promise.promise();
     String instanceId = instance.getId();
-    String queryForPrecedingSucceedingInstances = String.format("query=succeedingInstanceId==(%s)+or+precedingInstanceId==(%s)", instanceId, instanceId);
+    String queryForPrecedingSucceedingInstances = String.format("succeedingInstanceId==(%s) or precedingInstanceId==(%s)", instanceId, instanceId);
 
-    precedingSucceedingTitlesClient.getMany(queryForPrecedingSucceedingInstances, response -> {
+    precedingSucceedingTitlesClient.getAll(queryForPrecedingSucceedingInstances, response -> {
       if (response.getStatusCode() == 200) {
         JsonObject json = response.getJson();
         List<JsonObject> precedingSucceedingTitles = JsonArrayHelper.toList(json.getJsonArray("precedingSucceedingTitles"));

--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -134,7 +134,7 @@ public abstract class AbstractInstances {
     CollectionResourceRepository precedingSucceedingTitlesRepository =
       new CollectionResourceRepository(precedingSucceedingTitlesClient);
 
-    List<String> instanceId = Collections.singletonList( instance.getId() );
+    List<String> instanceId = List.of(instance.getId());
     String query = createQueryForPrecedingSucceedingInstances(instanceId);
 
     CompletableFuture<Response> future = new CompletableFuture<>();

--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -7,8 +7,6 @@ import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,7 +73,7 @@ public abstract class AbstractInstances {
     String query = createQueryForRelatedInstances(instanceId);
 
     CompletableFuture<Response> future = new CompletableFuture<>();
-    relatedInstancesClient.getMany(query, Integer.MAX_VALUE, 0, future::complete);
+    relatedInstancesClient.getAll(query, future::complete);
 
     return future.thenCompose(result ->
       updateInstanceRelationships(instance, relatedInstancesRepository, result));
@@ -138,7 +136,7 @@ public abstract class AbstractInstances {
     String query = createQueryForPrecedingSucceedingInstances(instanceId);
 
     CompletableFuture<Response> future = new CompletableFuture<>();
-    precedingSucceedingTitlesClient.getMany(query, future::complete);
+    precedingSucceedingTitlesClient.getAll(query, future::complete);
 
     return future.thenCompose(result ->
       updatePrecedingSucceedingTitles(instance, precedingSucceedingTitlesRepository, result));
@@ -342,7 +340,7 @@ public abstract class AbstractInstances {
 
   protected String createQueryForPrecedingSucceedingInstances(List<String> instanceIds) {
     String idList = instanceIds.stream().distinct().collect(Collectors.joining(" or "));
-    return format("query=succeedingInstanceId==(%s)+or+precedingInstanceId==(%s)", idList, idList);
+    return format("succeedingInstanceId==(%s) or precedingInstanceId==(%s)", idList, idList);
   }
 
   protected <T> CompletableFuture<List<T>> allResultsOf(
@@ -355,7 +353,7 @@ public abstract class AbstractInstances {
 
   protected String createQueryForRelatedInstances(List<String> instanceIds) {
     String idList = instanceIds.stream().distinct().collect(Collectors.joining(" or "));
-    return format("subInstanceId==(%s)+or+superInstanceId==(%s)", idList, idList);
+    return format("subInstanceId==(%s) or superInstanceId==(%s)", idList, idList);
   }
 
   protected OkapiHttpClient createHttpClient(

--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -8,6 +8,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,11 +71,11 @@ public abstract class AbstractInstances {
     CollectionResourceClient relatedInstancesClient = createInstanceRelationshipsClient(
       routingContext, context);
     CollectionResourceRepository relatedInstancesRepository = new CollectionResourceRepository(relatedInstancesClient);
-    List<String> instanceId = Arrays.asList(instance.getId());
+    List<String> instanceId = Collections.singletonList( instance.getId() );
     String query = createQueryForRelatedInstances(instanceId);
 
     CompletableFuture<Response> future = new CompletableFuture<>();
-    relatedInstancesClient.getMany(query, future::complete);
+    relatedInstancesClient.getMany(query, Integer.MAX_VALUE, 0, future::complete);
 
     return future.thenCompose(result ->
       updateInstanceRelationships(instance, relatedInstancesRepository, result));
@@ -133,7 +134,7 @@ public abstract class AbstractInstances {
     CollectionResourceRepository precedingSucceedingTitlesRepository =
       new CollectionResourceRepository(precedingSucceedingTitlesClient);
 
-    List<String> instanceId = Arrays.asList(instance.getId());
+    List<String> instanceId = Collections.singletonList( instance.getId() );
     String query = createQueryForPrecedingSucceedingInstances(instanceId);
 
     CompletableFuture<Response> future = new CompletableFuture<>();
@@ -256,7 +257,7 @@ public abstract class AbstractInstances {
    *
    * @param instancesResponse Set of Instances to transform to representations
    * @param context
-   * @return
+   * @return Result set as JSON object
    */
   protected JsonObject toRepresentation(InstancesResponse instancesResponse,
     WebContext context) {
@@ -354,7 +355,7 @@ public abstract class AbstractInstances {
 
   protected String createQueryForRelatedInstances(List<String> instanceIds) {
     String idList = instanceIds.stream().distinct().collect(Collectors.joining(" or "));
-    return format("query=subInstanceId==(%s)+or+superInstanceId==(%s)", idList, idList);
+    return format("subInstanceId==(%s)+or+superInstanceId==(%s)", idList, idList);
   }
 
   protected OkapiHttpClient createHttpClient(

--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -71,7 +71,7 @@ public abstract class AbstractInstances {
     CollectionResourceClient relatedInstancesClient = createInstanceRelationshipsClient(
       routingContext, context);
     CollectionResourceRepository relatedInstancesRepository = new CollectionResourceRepository(relatedInstancesClient);
-    List<String> instanceId = Collections.singletonList( instance.getId() );
+    List<String> instanceId = List.of(instance.getId());
     String query = createQueryForRelatedInstances(instanceId);
 
     CompletableFuture<Response> future = new CompletableFuture<>();

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -398,7 +398,7 @@ public class Instances extends AbstractInstances {
     String instanceId, RoutingContext routingContext, WebContext webContext ) {
     CompletableFuture<Response> holdingsFuture = new CompletableFuture<>();
 
-    createHoldingsStorageClient(routingContext, webContext).getMany("query=instanceId=="+instanceId, holdingsFuture::complete);
+    createHoldingsStorageClient(routingContext, webContext).getAll("instanceId=="+instanceId, holdingsFuture::complete);
     return holdingsFuture.thenCompose(
       response -> {
         List<String> holdingsRecordsList =
@@ -599,7 +599,7 @@ public class Instances extends AbstractInstances {
 
     CompletableFuture<Response> precedingSucceedingTitlesFetched = new CompletableFuture<>();
 
-    precedingSucceedingTitlesClient.getMany(queryForPrecedingSucceedingInstances, precedingSucceedingTitlesFetched::complete);
+    precedingSucceedingTitlesClient.getAll(queryForPrecedingSucceedingInstances, precedingSucceedingTitlesFetched::complete);
 
     return precedingSucceedingTitlesFetched
       .thenCompose(response ->

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -536,7 +536,7 @@ public class Instances extends AbstractInstances {
     if (relatedInstancesClient != null) {
       CompletableFuture<Response> relatedInstancesFetched = new CompletableFuture<>();
 
-      relatedInstancesClient.getMany( query, Integer.MAX_VALUE, 0, relatedInstancesFetched::complete);
+      relatedInstancesClient.getMany(query, Integer.MAX_VALUE, 0, relatedInstancesFetched::complete);
 
       return relatedInstancesFetched
         .thenCompose(response -> withInstanceRelationships(instance, response));

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -536,7 +536,7 @@ public class Instances extends AbstractInstances {
     if (relatedInstancesClient != null) {
       CompletableFuture<Response> relatedInstancesFetched = new CompletableFuture<>();
 
-      relatedInstancesClient.getMany(query, relatedInstancesFetched::complete);
+      relatedInstancesClient.getMany( query, Integer.MAX_VALUE, 0, relatedInstancesFetched::complete);
 
       return relatedInstancesFetched
         .thenCompose(response -> withInstanceRelationships(instance, response));

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -13,8 +13,6 @@ import java.io.UnsupportedEncodingException;
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -493,9 +491,6 @@ public class Items extends AbstractInventoryResource {
         itemIds.stream()
         .map(String::toString)
         .collect(Collectors.joining(" or ")));
-
-    boundWithPartsByItemIdsQuery = URLEncoder
-      .encode(boundWithPartsByItemIdsQuery, StandardCharsets.UTF_8);
 
     boundWithPartsClient.getMany(
       boundWithPartsByItemIdsQuery,

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -13,8 +13,6 @@ import java.io.UnsupportedEncodingException;
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -1032,9 +1030,6 @@ public class Items extends AbstractInventoryResource {
         itemIds.stream()
           .map(String::toString)
           .collect(Collectors.joining(" or ")));
-
-    boundWithPartsByItemIdsQuery = URLEncoder
-      .encode(boundWithPartsByItemIdsQuery, StandardCharsets.UTF_8);
 
     boundWithPartsClient.getMany(
       boundWithPartsByItemIdsQuery,

--- a/src/main/java/org/folio/inventory/resources/ItemsByHoldingsRecordId.java
+++ b/src/main/java/org/folio/inventory/resources/ItemsByHoldingsRecordId.java
@@ -22,8 +22,6 @@ import java.io.UnsupportedEncodingException;
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -109,7 +107,7 @@ public class ItemsByHoldingsRecordId extends Items
             BOUND_WITH_PARTS_STORAGE_PATH);
 
         boundWithPartsClient.getMany(
-          URLEncoder.encode(queryByHoldingsRecordId + queryByHoldingsRecordsItemIds, StandardCharsets.UTF_8),
+          queryByHoldingsRecordId + queryByHoldingsRecordsItemIds,
           1000,
           0,
           response2 -> {

--- a/src/main/java/org/folio/inventory/storage/external/CollectionResourceClient.java
+++ b/src/main/java/org/folio/inventory/storage/external/CollectionResourceClient.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external;
 
+import static org.folio.util.StringUtil.urlEncode;
+
 import io.vertx.core.json.JsonObject;
 import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.inventory.support.http.client.Response;
@@ -48,29 +50,31 @@ public class CollectionResourceClient {
       .thenAccept(responseHandler);
   }
 
-  public void getMany(String query, Consumer<Response> responseHandler) {
-    String url = isProvided(query)
-      ? String.format("%s?%s", collectionRoot, query)
-      : collectionRoot.toString();
-
-    client.get(url)
-      .thenAccept(responseHandler);
-  }
-
+  /**
+   * Run the query using some limit and offset.
+   *
+   * @param cqlQuery the query without percent (url) encoding
+   */
   public void getMany(
     String cqlQuery,
     Integer pageLimit,
     Integer pageOffset,
     Consumer<Response> responseHandler) {
 
-    //TODO: Replace with query string creator that checks each parameter
-    String url = isProvided(cqlQuery)
-      ? String.format("%s?query=%s&limit=%s&offset=%s", collectionRoot, cqlQuery,
-      pageLimit, pageOffset)
-      : collectionRoot.toString();
-
+    String url = collectionRoot + "?"
+        + (isProvided(cqlQuery) ? ("query=" + urlEncode(cqlQuery) + "&") : "")
+        + "limit=" + pageLimit + "&offset=" + pageOffset;
     client.get(url)
       .thenAccept(responseHandler);
+  }
+
+  /**
+   * Runs the query while setting limit to maximum and offset to zero to get all records.
+   *
+   * @param cqlQuery the query without percent (url) encoding
+   */
+  public void getAll(String cqlQuery, Consumer<Response> responseHandler) {
+    getMany(cqlQuery, Integer.MAX_VALUE, 0, responseHandler);
   }
 
   private boolean isProvided(String query) {

--- a/src/main/java/org/folio/inventory/storage/external/CollectionResourceRepository.java
+++ b/src/main/java/org/folio/inventory/storage/external/CollectionResourceRepository.java
@@ -4,7 +4,6 @@ import java.util.concurrent.CompletableFuture;
 
 import org.folio.inventory.exceptions.ExternalResourceFetchException;
 import org.folio.inventory.support.http.client.Response;
-import org.folio.util.StringUtil;
 
 public class CollectionResourceRepository {
   private final CollectionResourceClient resourceClient;
@@ -16,7 +15,7 @@ public class CollectionResourceRepository {
   public CompletableFuture<Response> getMany(CqlQuery query, Limit limit, Offset offset) {
     final CompletableFuture<Response> future = new CompletableFuture<>();
 
-    resourceClient.getMany(StringUtil.urlEncode(query.toString()), limit.getLimit(),
+    resourceClient.getMany(query.toString(), limit.getLimit(),
       offset.getOffset(), future::complete);
 
     return future.thenCompose(response -> handleResponse(response, 200));

--- a/src/main/java/org/folio/inventory/storage/external/CqlQuery.java
+++ b/src/main/java/org/folio/inventory/storage/external/CqlQuery.java
@@ -5,6 +5,7 @@ import static java.lang.String.format;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.folio.util.StringUtil;
 
 public final class CqlQuery {
   private final String query;
@@ -24,22 +25,22 @@ public final class CqlQuery {
   public static CqlQuery exactMatchAny(String indexName, Collection<String> values) {
     final String valuesQuery = values.stream()
       .filter(Objects::nonNull)
-      .map(value -> "\"" + value + "\"")
+      .map(StringUtil::cqlEncode)
       .collect(Collectors.joining(" or "));
 
     return new CqlQuery(format("%s==(%s)", indexName, valuesQuery));
   }
 
   public static CqlQuery exactMatch(String indexName, String value) {
-    return new CqlQuery(format("%s==\"%s\"", indexName, value));
+    return new CqlQuery(format("%s==%s", indexName, StringUtil.cqlEncode(value)));
   }
 
   public static CqlQuery match(String indexName, String value) {
-    return new CqlQuery(format("%s=\"%s\"", indexName, value));
+    return new CqlQuery(format("%s=%s", indexName, StringUtil.cqlEncode(value)));
   }
 
   public static CqlQuery notEqual(String indexName, String value) {
-    return new CqlQuery(format("%s<>\"%s\"", indexName, value));
+    return new CqlQuery(format("%s<>%s", indexName, StringUtil.cqlEncode(value)));
   }
 
   @Override

--- a/src/main/java/org/folio/inventory/storage/external/MultipleRecordsFetchClient.java
+++ b/src/main/java/org/folio/inventory/storage/external/MultipleRecordsFetchClient.java
@@ -2,8 +2,6 @@ package org.folio.inventory.storage.external;
 
 import static org.apache.commons.collections4.ListUtils.partition;
 import static org.folio.inventory.support.JsonArrayHelper.toList;
-import static org.folio.util.StringUtil.urlEncode;
-
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -49,8 +47,7 @@ public class MultipleRecordsFetchClient {
   private CompletableFuture<Response> getAllMatched(CqlQuery query) {
     final CompletableFuture<Response> future = new CompletableFuture<>();
 
-    resourceClient.getMany(urlEncode(query.toString()), Integer.MAX_VALUE, 0,
-      future::complete);
+    resourceClient.getAll(query.toString(), future::complete);
 
     return future.thenCompose(response -> {
       if (response.getStatusCode() != expectedStatus) {

--- a/src/main/java/org/folio/inventory/storage/external/ReferenceRecordClient.java
+++ b/src/main/java/org/folio/inventory/storage/external/ReferenceRecordClient.java
@@ -3,9 +3,7 @@ package org.folio.inventory.storage.external;
 import io.vertx.core.json.JsonObject;
 import org.folio.inventory.support.JsonArrayHelper;
 import org.folio.inventory.support.http.client.Response;
-
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import org.folio.util.StringUtil;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -30,7 +28,7 @@ public class ReferenceRecordClient {
     CompletableFuture<ReferenceRecord> overallFuture
       = new CompletableFuture<>();
 
-    collectionResourceClient.getMany(query, requestFuture::complete);
+    collectionResourceClient.getAll(query, requestFuture::complete);
 
     requestFuture.thenAccept(response -> {
       if(response == null) {
@@ -69,7 +67,7 @@ public class ReferenceRecordClient {
 
   private static String getReferenceRecordQuery(String name) {
 
-    return "query=" + URLEncoder.encode(String.format("name==\"%s\"", name), StandardCharsets.UTF_8);
+    return "name==" + StringUtil.cqlEncode(name);
   }
 
   public static class ReferenceRecordClientException extends Exception {

--- a/src/main/java/org/folio/inventory/support/CqlHelper.java
+++ b/src/main/java/org/folio/inventory/support/CqlHelper.java
@@ -1,10 +1,8 @@
 package org.folio.inventory.support;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.folio.util.StringUtil;
 
 /**
  * Helper for CQL queries.
@@ -12,17 +10,11 @@ import java.util.stream.Collectors;
 public class CqlHelper {
   private CqlHelper() { }
 
-  private static final Pattern cqlChar = Pattern.compile("[*?^\"\\\\]");
-
   public static String multipleRecordsCqlQuery(List<String> recordIds) {
     if(recordIds.isEmpty()) {
       return null;
     }
-    else {
-      String query = buildQueryByIds(recordIds);
-      return URLEncoder.encode(query, StandardCharsets.UTF_8);
-
-    }
+    return buildQueryByIds(recordIds);
   }
 
   /**
@@ -46,19 +38,6 @@ public class CqlHelper {
    * @return CQL expression
    */
   public static String barcodeIs(String barcode) {
-    return "barcode==\"" + cqlMask(barcode) + "\"";
-  }
-
-  /**
-   * Mask these special CQL characters by prepending a backslash: * ? ^ " \
-   *
-   * @param s  the String to mask
-   * @return s with all special CQL characters masked
-   */
-  public static String cqlMask(String s) {
-    if (s == null) {
-      return null;
-    }
-    return cqlChar.matcher(s).replaceAll("\\\\$0");  // one backslash plus the matching character
+    return "barcode==" + StringUtil.cqlEncode(barcode);
   }
 }

--- a/src/test/java/api/InstanceRelationshipsTest.java
+++ b/src/test/java/api/InstanceRelationshipsTest.java
@@ -62,6 +62,24 @@ public class InstanceRelationshipsTest extends ApiTests {
   }
 
   @Test
+  public void canFetchOneInstancesWith11Children() throws Exception {
+    UUID superInstanceId = UUID.randomUUID();
+    instancesClient.create(smallAngryPlanet(superInstanceId)
+        .put("title", randomString("super")));
+
+    for (int i = 0; i < 11; i++) {
+      UUID subInstanceId = UUID.randomUUID();
+      instancesClient.create(nod(subInstanceId).put("title", randomString("sub")));
+      instanceRelationshipClient.create(
+        createInstanceRelationships(superInstanceId, subInstanceId));
+    }
+
+    var json = instancesClient.getById(superInstanceId).getJson();
+    assertThat(json.getJsonArray("parentInstances").size(), is(0));
+    assertThat(json.getJsonArray("childInstances").size(), is(11));
+  }
+
+  @Test
   public void canForwardInstanceRelationshipsFetchFailure() throws Exception {
     final int expectedCount = 4;
     createSuperInstanceSubInstance(expectedCount);

--- a/src/test/java/org/folio/inventory/storage/external/CqlQueryTest.java
+++ b/src/test/java/org/folio/inventory/storage/external/CqlQueryTest.java
@@ -1,0 +1,25 @@
+package org.folio.inventory.storage.external;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+public class CqlQueryTest {
+
+  @Test
+  public void exactMatch() {
+    assertThat(CqlQuery.exactMatch("foo", "bar*baz").toString(), is("foo==\"bar\\*baz\""));
+  }
+
+  @Test
+  public void match() {
+    assertThat(CqlQuery.match("foo", "bar\\baz").toString(), is("foo=\"bar\\\\baz\""));
+  }
+
+  @Test
+  public void notEqual() {
+    assertThat(CqlQuery.notEqual("foo", "bar\"baz").toString(), is("foo<>\"bar\\\"baz\""));
+  }
+
+}


### PR DESCRIPTION
When retrieving a single instance by ID,  the default RMB limit of 10 records has been in effect and ui-inventory, for example, could thus only display the first 10 parent and/or child relationships of an instance. 

With this PR this limitation would be removed. 

When retrieving multiple instances by query, there was already no such limit or parents/children of each instance in the result set.

The same issue is fixed for precedingSucceedingTitles.

A new getAll method is used for this.

The getMany without limit/offset parameters is no longer in use and is deleted.

The urlEncoding and cqlEncoding is fixed - for separation of concerns:
* When building a CQL query do cqlEncoding. For example in CqlQuery.
* When building a URL do urlEncoding.

CQL encoding and URL encoding is moved to the correct places. This reduces the code and improved readability.

