### PR TITLE
MODINV-432: zeroing proceeding succeeding Titles ids

### DIFF
--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -61,6 +61,7 @@ public class Instances extends AbstractInstances {
   private static final String BLOCKED_FIELDS_CONFIG_PATH = INVENTORY_PATH + "/config/instances/blocked-fields";
   private static final String BLOCKED_FIELDS_UPDATE_ERROR_MESSAGE = "Instance is controlled by MARC record, "
     + "these fields are blocked and can not be updated: ";
+  private static final String ID = "id";
 
   public Instances(final Storage storage, final HttpClient client) {
     super(storage, client);
@@ -294,6 +295,7 @@ public class Instances extends AbstractInstances {
     }
     for (int index = 0; index < precedingSucceedingTitles.size(); index++) {
       JsonObject jsonObject = precedingSucceedingTitles.getJsonObject(index);
+      jsonObject.put(ID, null);
       jsonObject.put(PrecedingSucceedingTitle.PRECEDING_INSTANCE_ID_KEY, null);
       jsonObject.put(PrecedingSucceedingTitle.SUCCEEDING_INSTANCE_ID_KEY, null);
     }

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -477,7 +477,6 @@ public class InstancesApiExamples extends ApiTests {
     JsonArray procedingTitles = new JsonArray();
     procedingTitles.add(
       new JsonObject()
-        .put("id", "69938f33-17f3-45f6-b62a-122a304d7b86")
         .put("title", "Chilton's automotive industries")
         .put("identifiers", new JsonArray().add(
           new JsonObject()
@@ -492,6 +491,7 @@ public class InstancesApiExamples extends ApiTests {
     JsonObject updateInstanceRequest = newInstance.copy()
       .put(TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray().add(tagNameTwo)))
       .put(PUBLICATION_PERIOD_KEY, publicationPeriodToJson(new PublicationPeriod(2000, 2012)))
+      .put(PRECEDING_TITLES_KEY, procedingTitles)
       .put("natureOfContentTermIds",
         new JsonArray().add(ApiTestSuite.getAudiobookNatureOfContentTermId()));
 


### PR DESCRIPTION
UI side also doesn't send Id within preceding and succeeding Titles but on Back-side the service has that ID and comparing it between updating and existing data. To attain proper comparing I avoid comparing ids.