### PR TITLE
MODINV-450: org.xml.sax is accessible from more than one module (xerces:xmlParserAPIs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,16 @@
       <artifactId>mod-source-record-storage-client</artifactId>
       <version>5.2.0-SNAPSHOT</version>
       <type>jar</type>
+      <exclusions>
+        <!-- This is provided by JDK >= 9 causing a compile error (Eclipse doesn't suppress this compile error):
+             "The package org.xml.sax is accessible from more than one module: <unnamed>, java.xml"
+             https://stackoverflow.com/questions/55571046/eclipse-is-confused-by-imports-accessible-from-more-than-one-module
+        -->
+        <exclusion>
+          <groupId>xerces</groupId>
+          <artifactId>xmlParserAPIs</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>


### PR DESCRIPTION
Steps to Reproduce:

* Open mod-inventory in Eclipse

Expected Results: Compiles

Actual Results: Compile error "The package org.xml.sax is accessible from more than one module: `<unnamed>`, `java.xml`"

Additional Information:

https://stackoverflow.com/questions/55571046/eclipse-is-confused-by-imports-accessible-from-more-than-one-module

This pull request fixes a clear violation of the Java specs. The compiler used by Eclipse is not as lenient as the compiler used by maven.