### PR TITLE
MODINV-466 Support max.request.size configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
@@ -48,6 +48,7 @@ import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED_REA
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_NOT_MATCHED;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_ENV;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_HOST;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_MAX_REQUEST_SIZE;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_PORT;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_REPLICATION_FACTOR;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.OKAPI_URL;
@@ -84,6 +85,7 @@ public class DataImportConsumerVerticle extends AbstractVerticle {
       .kafkaPort(config.getString(KAFKA_PORT))
       .okapiUrl(config.getString(OKAPI_URL))
       .replicationFactor(Integer.parseInt(config.getString(KAFKA_REPLICATION_FACTOR)))
+      .maxRequestSize(Integer.parseInt(config.getString(KAFKA_MAX_REQUEST_SIZE)))
       .build();
     LOGGER.info(format("kafkaConfig: %s", kafkaConfig));
     EventManager.registerKafkaEventPublisher(kafkaConfig, vertx, maxDistributionNumber);

--- a/src/main/java/org/folio/inventory/Launcher.java
+++ b/src/main/java/org/folio/inventory/Launcher.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeoutException;
 
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_ENV;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_HOST;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_MAX_REQUEST_SIZE;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_PORT;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_REPLICATION_FACTOR;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.OKAPI_URL;
@@ -129,6 +130,7 @@ public class Launcher {
     configMap.put(OKAPI_URL, System.getenv().getOrDefault(OKAPI_URL, "http://okapi:9130"));
     configMap.put(KAFKA_REPLICATION_FACTOR, System.getenv().getOrDefault(KAFKA_REPLICATION_FACTOR, "1"));
     configMap.put(KAFKA_ENV, System.getenv().getOrDefault(KAFKA_ENV, "folio"));
+    configMap.put(KAFKA_MAX_REQUEST_SIZE, System.getenv().getOrDefault(KAFKA_MAX_REQUEST_SIZE, "1048576"));
 
     String storageType = System.getProperty("org.folio.metadata.inventory.storage.type");
     String storageLocation = System.getProperty("org.folio.metadata.inventory.storage.location");

--- a/src/main/java/org/folio/inventory/MarcBibInstanceHridSetConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/MarcBibInstanceHridSetConsumerVerticle.java
@@ -21,6 +21,7 @@ import org.folio.util.pubsub.PubSubClientUtils;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_INSTANCE_HRID_SET;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_ENV;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_HOST;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_MAX_REQUEST_SIZE;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_PORT;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_REPLICATION_FACTOR;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.OKAPI_URL;
@@ -44,6 +45,7 @@ public class MarcBibInstanceHridSetConsumerVerticle extends AbstractVerticle {
       .kafkaPort(config.getString(KAFKA_PORT))
       .okapiUrl(config.getString(OKAPI_URL))
       .replicationFactor(Integer.parseInt(config.getString(KAFKA_REPLICATION_FACTOR)))
+      .maxRequestSize(Integer.parseInt(config.getString(KAFKA_MAX_REQUEST_SIZE)))
       .build();
     LOGGER.info("kafkaConfig: {}", kafkaConfig);
 

--- a/src/main/java/org/folio/inventory/QuickMarcConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/QuickMarcConsumerVerticle.java
@@ -23,6 +23,7 @@ import org.folio.util.pubsub.PubSubClientUtils;
 import static java.lang.String.format;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_ENV;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_HOST;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_MAX_REQUEST_SIZE;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_PORT;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_REPLICATION_FACTOR;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.OKAPI_URL;
@@ -76,6 +77,7 @@ public class QuickMarcConsumerVerticle extends AbstractVerticle {
       .kafkaPort(config.getString(KAFKA_PORT))
       .okapiUrl(config.getString(OKAPI_URL))
       .replicationFactor(Integer.parseInt(config.getString(KAFKA_REPLICATION_FACTOR)))
+      .maxRequestSize(Integer.parseInt(config.getString(KAFKA_MAX_REQUEST_SIZE)))
       .build();
     LOGGER.info(format("kafkaConfig: %s", kafkaConfig));
     return kafkaConfig;

--- a/src/main/java/org/folio/inventory/dataimport/util/KafkaConfigConstants.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/KafkaConfigConstants.java
@@ -7,6 +7,7 @@ public final class KafkaConfigConstants {
   public static final String OKAPI_URL = "OKAPI_URL";
   public static final String KAFKA_REPLICATION_FACTOR = "REPLICATION_FACTOR";
   public static final String KAFKA_ENV = "ENV";
+  public static final String KAFKA_MAX_REQUEST_SIZE = "MAX_REQUEST_SIZE";
 
   private KafkaConfigConstants() {
   }

--- a/src/test/java/org/folio/inventory/dataimport/consumers/DataImportConsumerVerticleTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/DataImportConsumerVerticleTest.java
@@ -48,6 +48,7 @@ import static org.folio.DataImportEventTypes.DI_COMPLETED;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_ENV;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_HOST;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_MAX_REQUEST_SIZE;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_PORT;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_REPLICATION_FACTOR;
 import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
@@ -128,7 +129,8 @@ public class DataImportConsumerVerticleTest {
         .put(KAFKA_HOST, hostAndPort[0])
         .put(KAFKA_PORT, hostAndPort[1])
         .put(KAFKA_REPLICATION_FACTOR, "1")
-        .put(KAFKA_ENV, KAFKA_ENV_NAME));
+        .put(KAFKA_ENV, KAFKA_ENV_NAME)
+        .put(KAFKA_MAX_REQUEST_SIZE, "1048576"));
     vertx.deployVerticle(DataImportConsumerVerticle.class.getName(), options, deployAr -> async.complete());
   }
 

--- a/src/test/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandlerTest.java
@@ -46,7 +46,6 @@ import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTI
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -110,6 +109,7 @@ public class DataImportKafkaHandlerTest {
     KafkaConfig kafkaConfig = KafkaConfig.builder()
       .kafkaHost(hostAndPort[0])
       .kafkaPort(hostAndPort[1])
+      .maxRequestSize(1048576)
       .build();
 
     HttpClient client = vertx.createHttpClient();

--- a/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibInstanceHridSetConsumerVerticleTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibInstanceHridSetConsumerVerticleTest.java
@@ -18,6 +18,7 @@ import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
 import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.useDefaults;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_ENV;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_HOST;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_MAX_REQUEST_SIZE;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_PORT;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_REPLICATION_FACTOR;
 
@@ -40,7 +41,8 @@ public class MarcBibInstanceHridSetConsumerVerticleTest {
         .put(KAFKA_HOST, hostAndPort[0])
         .put(KAFKA_PORT, hostAndPort[1])
         .put(KAFKA_REPLICATION_FACTOR, "1")
-        .put(KAFKA_ENV, KAFKA_ENV_NAME))
+        .put(KAFKA_ENV, KAFKA_ENV_NAME)
+        .put(KAFKA_MAX_REQUEST_SIZE, "1048576"))
       .setWorker(true);
 
     Promise<String> promise = Promise.promise();

--- a/src/test/java/org/folio/inventory/quickmarc/consumers/QuickMarcConsumerVerticleTest.java
+++ b/src/test/java/org/folio/inventory/quickmarc/consumers/QuickMarcConsumerVerticleTest.java
@@ -5,6 +5,7 @@ import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.useDefaults;
 
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_ENV;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_HOST;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_MAX_REQUEST_SIZE;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_PORT;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_REPLICATION_FACTOR;
 
@@ -47,7 +48,8 @@ public class QuickMarcConsumerVerticleTest {
         .put(KAFKA_HOST, hostAndPort[0])
         .put(KAFKA_PORT, hostAndPort[1])
         .put(KAFKA_REPLICATION_FACTOR, "1")
-        .put(KAFKA_ENV, KAFKA_ENV_NAME))
+        .put(KAFKA_ENV, KAFKA_ENV_NAME)
+        .put(KAFKA_MAX_REQUEST_SIZE, "1048576"))
       .setWorker(true);
 
     Promise<String> promise = Promise.promise();

--- a/src/test/java/org/folio/inventory/quickmarc/consumers/QuickMarcKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/quickmarc/consumers/QuickMarcKafkaHandlerTest.java
@@ -114,6 +114,7 @@ public class QuickMarcKafkaHandlerTest {
       .envId("env")
       .kafkaHost(hostAndPort[0])
       .kafkaPort(hostAndPort[1])
+      .maxRequestSize(1048576)
       .build();
 
     PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper = new PrecedingSucceedingTitlesHelper(context -> okapiHttpClient);


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-466
https://issues.folio.org/browse/MODPUBSUB-187

When attempting to import a file the import job does not complete due to the following error
org.apache.kafka.common.errors.RecordTooLargeException: The message is 1287037 bytes when serialized which is larger than 1048576, which is the value of the max.request.size configuration.

Update to folio-kafka-wrapper v2.3.2 allows to set max.request.size parameter

https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#producerconfigs_max.request.size