### PR TITLE
MODINV-471 - Ensure version property while updating holdings record using the data-import

### DIFF
--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
@@ -1,19 +1,16 @@
 package org.folio.inventory.storage.external;
 
-import java.io.IOException;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectWriter;
 import org.folio.HoldingsRecord;
 import org.folio.dbschema.ObjectMapperTool;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.validation.exceptions.JsonMappingException;
 
-import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonObject;
+import java.io.IOException;
 
 class ExternalStorageModuleHoldingsRecordCollection
   extends ExternalStorageModuleCollection<HoldingsRecord>
@@ -49,13 +46,9 @@ class ExternalStorageModuleHoldingsRecordCollection
 
   @Override
   protected JsonObject mapToRequest(HoldingsRecord holding) {
-    ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
     try {
-      JsonObject jsonObject = new JsonObject(ow.writeValueAsString(holding));
-      // a workaround that should be revisited - Holdingsrecord schema contains "_version" field which cannot be correctly mapped from the object to json
-      jsonObject.remove("version");
-      return jsonObject;
-    } catch (IOException e) {
+      return JsonObject.mapFrom(holding);
+    } catch (Exception e) {
       LOGGER.error(e);
       throw new JsonMappingException("Can`t map 'Holdingsrecord' entity to json", e);
     }


### PR DESCRIPTION
## Purpose
During the investigation on MODDATAIMP-496 such a message was observed in the mod-inventory-storage log on holdings record update through data-import

> 14:27:58 [] [] [] [] WARN  ?                    Backend notice: severity='NOTICE', code='23F09', message='Ignoring optimistic locking conflict while overwriting changed record fbad6996-f827-498c-8512-92e10e9f8c6b: Stored _version is 1, _version of request is <NULL>', detail='null', hint='null', position='null', internalPosition='null', internalQuery='null', where='PL/pgSQL function holdings_record_set_ol_version() line 8 at RAISE', file='pl_exec.c', line='3862', routine='exec_stmt_raise', schema='diku_mod_inventory_storage', table='holdings_record', column='null', dataType='null', constraint='null'


## Learning
[MODINV-471](https://issues.folio.org/browse/MODINV-471)
