### PR TITLE
MODINV-441 Remove commons-io dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,11 +87,6 @@
       <version>4.5.2</version>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.7</version>
-    </dependency>
-    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-isbn-util</artifactId>
       <version>1.3.0</version>

--- a/src/main/java/org/folio/inventory/parsing/ModsParser.java
+++ b/src/main/java/org/folio/inventory/parsing/ModsParser.java
@@ -2,10 +2,10 @@ package org.folio.inventory.parsing;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.apache.commons.io.IOUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -16,6 +16,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,7 +37,7 @@ public class ModsParser {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     factory.setNamespaceAware(false);
     DocumentBuilder builder = factory.newDocumentBuilder();
-    Document doc = builder.parse(IOUtils.toInputStream(xml, "UTF-8"));
+    Document doc = builder.parse(new InputSource(new StringReader(xml)));
 
     XPathFactory xpathFactory = XPathFactory.newInstance();
     XPath xpath = xpathFactory.newXPath();

--- a/src/test/java/org/folio/inventory/TestUtil.java
+++ b/src/test/java/org/folio/inventory/TestUtil.java
@@ -1,8 +1,8 @@
 package org.folio.inventory;
 
-import java.io.File;
 import java.io.IOException;
-import org.apache.commons.io.FileUtils;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Util class contains helper methods for unit testing needs
@@ -10,6 +10,6 @@ import org.apache.commons.io.FileUtils;
 public final class TestUtil {
 
   public static String readFileFromPath(String path) throws IOException {
-    return new String(FileUtils.readFileToByteArray(new File(path)));
+    return Files.readString(Path.of(path));
   }
 }


### PR DESCRIPTION
Removing the commons-io dependency reduces the attack surface of the module and makes the life of the FOLIO security group easier.