### PR TITLE
MODINV-483 Generate Holdings from Marc Holdings

### DIFF
--- a/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
@@ -46,6 +46,7 @@ import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MATCHED_READ
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_NOT_MATCHED;
+import static org.folio.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_ENV;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_HOST;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_MAX_REQUEST_SIZE;
@@ -62,6 +63,7 @@ public class DataImportConsumerVerticle extends AbstractVerticle {
   private static final int DEFAULT_HTTP_TIMEOUT_IN_MILLISECONDS = 3000;
 
   private static final List<DataImportEventTypes> EVENT_TYPES = List.of(DI_SRS_MARC_BIB_RECORD_CREATED,
+    DI_SRS_MARC_HOLDING_RECORD_CREATED,
     DI_SRS_MARC_BIB_RECORD_MODIFIED, DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING,
     DI_SRS_MARC_BIB_RECORD_MATCHED, DI_SRS_MARC_BIB_RECORD_NOT_MATCHED,
     DI_SRS_MARC_BIB_RECORD_MATCHED_READY_FOR_POST_PROCESSING,

--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -18,6 +18,7 @@ import org.folio.inventory.dataimport.ItemWriterFactory;
 import org.folio.inventory.dataimport.handlers.actions.CreateHoldingEventHandler;
 import org.folio.inventory.dataimport.handlers.actions.CreateInstanceEventHandler;
 import org.folio.inventory.dataimport.handlers.actions.CreateItemEventHandler;
+import org.folio.inventory.dataimport.handlers.actions.CreateMarcHoldingsEventHandler;
 import org.folio.inventory.dataimport.handlers.actions.InstanceUpdateDelegate;
 import org.folio.inventory.dataimport.handlers.actions.MarcBibMatchedPostProcessingEventHandler;
 import org.folio.inventory.dataimport.handlers.actions.MarcBibModifiedPostProcessingEventHandler;
@@ -116,6 +117,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     EventManager.registerEventHandler(new CreateItemEventHandler(storage));
     EventManager.registerEventHandler(new CreateHoldingEventHandler(storage));
     EventManager.registerEventHandler(new CreateInstanceEventHandler(storage, precedingSucceedingTitlesHelper));
+    EventManager.registerEventHandler(new CreateMarcHoldingsEventHandler(storage));
     EventManager.registerEventHandler(new UpdateItemEventHandler(storage));
     EventManager.registerEventHandler(new UpdateHoldingEventHandler(storage));
     EventManager.registerEventHandler(new ReplaceInstanceEventHandler(storage, precedingSucceedingTitlesHelper));

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
@@ -100,7 +100,7 @@ public class CreateHoldingEventHandler implements EventHandler {
 
   @Override
   public boolean isEligible(DataImportEventPayload dataImportEventPayload) {
-    if (dataImportEventPayload.getCurrentNode() != null && ACTION_PROFILE == dataImportEventPayload.getCurrentNode().getContentType()) {
+    if (dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()) != null && dataImportEventPayload.getCurrentNode() != null && ACTION_PROFILE == dataImportEventPayload.getCurrentNode().getContentType()) {
       ActionProfile actionProfile = JsonObject.mapFrom(dataImportEventPayload.getCurrentNode().getContent()).mapTo(ActionProfile.class);
       return actionProfile.getAction() == ActionProfile.Action.CREATE && actionProfile.getFolioRecord() == ActionProfile.FolioRecord.HOLDINGS;
     }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandler.java
@@ -99,12 +99,7 @@ public class CreateMarcHoldingsEventHandler implements EventHandler {
           fillInstanceId(dataImportEventPayload, holdingJson, instanceId);
           var holdingsRecords = storage.getHoldingsRecordCollection(context);
           HoldingsRecord holding = null;
-          try {
-            holding = ObjectMapperTool.getMapper().readValue(dataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord.class);
-          } catch (JsonProcessingException e) {
-            LOGGER.error("Failed to parse Holdings", e);
-            future.completeExceptionally(e);
-          }
+          holding = Json.decodeValue(dataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord.class);
           return addHoldings(holding, holdingsRecords)
             .onSuccess(createdHoldings -> {
               LOGGER.info("Created Holding record");

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandler.java
@@ -1,0 +1,241 @@
+package org.folio.inventory.dataimport.handlers.actions;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
+import static org.folio.ActionProfile.FolioRecord.MARC_HOLDINGS;
+import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING;
+import static org.folio.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.constructContext;
+import static org.folio.inventory.dataimport.util.ParsedRecordUtil.getControlFieldValue;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
+
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.folio.ActionProfile;
+import org.folio.DataImportEventPayload;
+import org.folio.Holdings;
+import org.folio.HoldingsRecord;
+import org.folio.dbschema.ObjectMapperTool;
+import org.folio.inventory.common.Context;
+import org.folio.inventory.common.api.request.PagingParameters;
+import org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil;
+import org.folio.inventory.domain.HoldingsRecordCollection;
+import org.folio.inventory.domain.instances.InstanceCollection;
+import org.folio.inventory.storage.Storage;
+import org.folio.inventory.validation.exceptions.JsonMappingException;
+import org.folio.processing.events.services.handler.EventHandler;
+import org.folio.processing.exceptions.EventProcessingException;
+import org.folio.processing.mapping.defaultmapper.RecordMapper;
+import org.folio.processing.mapping.defaultmapper.RecordMapperBuilder;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.rest.jaxrs.model.Record;
+
+public class CreateMarcHoldingsEventHandler implements EventHandler {
+
+  private static final Logger LOGGER = LogManager.getLogger(CreateMarcHoldingsEventHandler.class);
+  private static final String ERROR_HOLDING_MSG = "Error loading inventory holdings for MARC BIB";
+  private static final String INSTANCE_ID_DOES_NOT_EXISTS = "Instance id must be set up in the SRS module";
+  protected static final String MARC_FORMAT = "MARC_HOLDINGS";
+  protected static final String MAPPING_RULES_KEY = "MAPPING_RULES";
+  protected static final String MAPPING_PARAMS_KEY = "MAPPING_PARAMS";
+  protected static final String HOLDINGS_PATH = "holdings";
+  protected static final String HOLDINGS_PATH_FIELD = "holdings";
+  protected static final String INSTANCE_ID_FIELD = "instanceId";
+  protected static final String PERMANENT_LOCATION_ID_FIELD = "permanentLocationId";
+  protected static final String PERMANENT_LOCATION_ID_ERROR_MESSAGE = "Can`t create Holding entity: 'permanentLocationId' is empty";
+  protected static final String SAVE_HOLDING_ERROR_MESSAGE = "Can`t save new holding";
+  protected static final String CONTEXT_EMPTY_ERROR_MESSAGE = "Can`t create Holding entity: context is empty or doesn`t exists";
+  protected static final String PAYLOAD_DATA_HAS_NO_INSTANCE_ID_ERROR_MSG = "Failed to extract instanceId from instance entity or parsed record";
+  static final String ACTION_HAS_NO_MAPPING_MSG = "Action profile to create a Holding entity requires a mapping profile";
+
+  private final Storage storage;
+
+  public CreateMarcHoldingsEventHandler(Storage storage) {
+    this.storage = storage;
+  }
+
+  @Override
+  public CompletableFuture<DataImportEventPayload> handle(DataImportEventPayload dataImportEventPayload) {
+    CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
+    try {
+      dataImportEventPayload.setEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value());
+
+      if (dataImportEventPayload.getContext() == null
+        || StringUtils.isEmpty(dataImportEventPayload.getContext().get(MARC_HOLDINGS.value()))) {
+        throw new EventProcessingException(CONTEXT_EMPTY_ERROR_MESSAGE);
+      }
+      if (dataImportEventPayload.getCurrentNode().getChildSnapshotWrappers().isEmpty()) {
+        LOGGER.error(ACTION_HAS_NO_MAPPING_MSG);
+        return CompletableFuture.failedFuture(new EventProcessingException(ACTION_HAS_NO_MAPPING_MSG));
+      }
+
+      prepareEvent(dataImportEventPayload);
+
+      defaultMapRecordToHoldings(dataImportEventPayload);
+
+      JsonObject holdingAsJson = new JsonObject(dataImportEventPayload.getContext().get(HOLDINGS.value()));
+      if (holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD) != null) {
+        holdingAsJson = holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD);
+      }
+      holdingAsJson.put("id", UUID.randomUUID().toString());
+
+      JsonObject holdingJson = holdingAsJson;
+
+      findInstanceIdByHrid(dataImportEventPayload, holdingAsJson).thenCompose(instanceId -> {
+        LOGGER.info("TODO in the compose");
+
+        if(isBlank(instanceId))
+        {
+          throw new EventProcessingException("Instance id not found");
+        }
+
+        fillInstanceId(dataImportEventPayload, holdingJson, instanceId);
+        checkIfPermanentLocationIdExists(holdingJson);
+
+        Context context = constructContext(dataImportEventPayload.getTenant(), dataImportEventPayload.getToken(), dataImportEventPayload.getOkapiUrl());
+        HoldingsRecordCollection holdingsRecords = storage.getHoldingsRecordCollection(context);
+
+        HoldingsRecord holding = null;
+        try {
+          holding = ObjectMapperTool.getMapper().readValue(dataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord.class);
+        } catch (JsonProcessingException e) {
+          e.printStackTrace();
+        }
+        addHoldings(holding, holdingsRecords)
+          .onSuccess(createdHoldings -> {
+            LOGGER.info("Created Holding record");
+            dataImportEventPayload.getContext().put(HOLDINGS.value(), Json.encodePrettily(createdHoldings));
+            future.complete(dataImportEventPayload);
+          })
+          .onFailure(e -> {
+            LOGGER.error(SAVE_HOLDING_ERROR_MESSAGE, e);
+            future.completeExceptionally(e);
+          });
+      return future;
+      });
+    } catch (Exception e) {
+      LOGGER.error("Failed to create Holdings", e);
+      future.completeExceptionally(e);
+    }
+    return future;
+  }
+
+  private org.folio.Holdings defaultMapRecordToHoldings(DataImportEventPayload dataImportEventPayload) {
+    try {
+      HashMap<String, String> context = dataImportEventPayload.getContext();
+      JsonObject mappingRules = new JsonObject(context.get(MAPPING_RULES_KEY));
+      JsonObject parsedRecord = new JsonObject((String) new JsonObject(context.get(MARC_HOLDINGS.value()))
+        .mapTo(Record.class).getParsedRecord().getContent());
+      MappingParameters mappingParameters = new JsonObject(context.get(MAPPING_PARAMS_KEY)).mapTo(MappingParameters.class);
+      RecordMapper<Holdings> recordMapper = RecordMapperBuilder.buildMapper(MARC_FORMAT);
+      var holdings = recordMapper.mapRecord(parsedRecord, mappingParameters, mappingRules);
+      dataImportEventPayload.getContext().put(HOLDINGS.value(), Json.encode(new JsonObject().put(HOLDINGS_PATH, JsonObject.mapFrom(holdings))));
+      return holdings;
+    } catch (Exception e) {
+      LOGGER.error("Failed to map Record to Holdings", e);
+      throw new JsonMappingException("Error in default mapper.", e);
+    }
+  }
+
+  private CompletableFuture<String> findInstanceIdByHrid(DataImportEventPayload dataImportEventPayload, JsonObject holdingAsJson) throws JsonProcessingException {
+    CompletableFuture<String> future = new CompletableFuture<>();
+    if (StringUtils.isBlank(holdingAsJson.getString(INSTANCE_ID_FIELD))) {
+      var recordAsString = dataImportEventPayload.getContext().get("MARC_HOLDINGS");
+      Record record = ObjectMapperTool.getMapper().readValue(recordAsString, Record.class);
+      var instanceHrid = getControlFieldValue(record, "004");
+      LOGGER.info("004 field in the marc holdings: " + instanceHrid);
+
+      if (isBlank(instanceHrid)) {
+        throw new EventProcessingException("The field 004 for marc holdings must be not null");
+      }
+
+      Context context = EventHandlingUtil.constructContext(dataImportEventPayload.getTenant(), dataImportEventPayload.getToken(), dataImportEventPayload.getOkapiUrl());
+      InstanceCollection instanceCollection = storage.getInstanceCollection(context);
+
+      try {
+        instanceCollection.findByCql(format("hrid=%s", instanceHrid), PagingParameters.defaults(),
+          findResult -> {
+            String instanceId = null;
+            if (findResult.getResult() != null && findResult.getResult().totalRecords == 1) {
+              var records = findResult.getResult().records;
+              var instance = records.stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No instance with hrid: " + instanceHrid));
+              instanceId = instance.getId();
+              LOGGER.info("Instance id found in the storage: " + instanceId);
+            }
+            future.complete(instanceId);
+          },
+          failure -> {
+            LOGGER.error(ERROR_HOLDING_MSG + format(". StatusCode: %s. Message: %s", failure.getStatusCode(), failure.getReason()));
+            future.complete(EMPTY);
+          });
+      } catch (UnsupportedEncodingException e) {
+        LOGGER.error(ERROR_HOLDING_MSG, e);
+        future.completeExceptionally(e);
+      }
+    }
+    return future;
+  }
+
+  public boolean isEligible(DataImportEventPayload dataImportEventPayload) {
+    if (dataImportEventPayload.getContext().get(MARC_HOLDINGS.value()) != null && dataImportEventPayload.getCurrentNode() != null && ACTION_PROFILE == dataImportEventPayload.getCurrentNode().getContentType()) {
+      ActionProfile actionProfile = JsonObject.mapFrom(dataImportEventPayload.getCurrentNode().getContent()).mapTo(ActionProfile.class);
+      return actionProfile.getAction() == ActionProfile.Action.CREATE && actionProfile.getFolioRecord() == ActionProfile.FolioRecord.HOLDINGS;
+    }
+    return false;
+  }
+
+  public boolean isPostProcessingNeeded() {
+    return true;
+  }
+
+  public String getPostProcessingInitializationEventType() {
+    return DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING.value();
+  }
+
+  protected void checkIfPermanentLocationIdExists(JsonObject holdingAsJson) {
+    if (isEmpty(holdingAsJson.getString(PERMANENT_LOCATION_ID_FIELD))) {
+      throw new EventProcessingException(PERMANENT_LOCATION_ID_ERROR_MESSAGE);
+    }
+  }
+
+  protected void fillInstanceId(DataImportEventPayload dataImportEventPayload, JsonObject holdingAsJson, String instanceId) {
+    holdingAsJson.put(INSTANCE_ID_FIELD, instanceId);
+    dataImportEventPayload.getContext().put(HOLDINGS.value(), holdingAsJson.encode());
+  }
+
+  protected Future<HoldingsRecord> addHoldings(HoldingsRecord holdings, HoldingsRecordCollection holdingsRecordCollection) {
+    Promise<HoldingsRecord> promise = Promise.promise();
+    holdingsRecordCollection.add(holdings,
+      success -> promise.complete(success.getResult()),
+      failure -> {
+        LOGGER.error(format("Error posting Holdings cause %s, status code %s", failure.getReason(), failure.getStatusCode()));
+        promise.fail(failure.getReason());
+      });
+    return promise.future();
+  }
+
+  protected void prepareEvent(DataImportEventPayload dataImportEventPayload) {
+    dataImportEventPayload.getEventsChain().add(dataImportEventPayload.getEventType());
+    dataImportEventPayload.setCurrentNode(dataImportEventPayload.getCurrentNode().getChildSnapshotWrappers().get(0));
+    dataImportEventPayload.getContext().put(HOLDINGS.value(), new JsonObject().encode());
+  }
+
+}

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandler.java
@@ -32,11 +32,9 @@ import org.folio.DataImportEventPayload;
 import org.folio.Holdings;
 import org.folio.HoldingsRecord;
 import org.folio.dbschema.ObjectMapperTool;
-import org.folio.inventory.common.Context;
 import org.folio.inventory.common.api.request.PagingParameters;
 import org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil;
 import org.folio.inventory.domain.HoldingsRecordCollection;
-import org.folio.inventory.domain.instances.InstanceCollection;
 import org.folio.inventory.storage.Storage;
 import org.folio.inventory.validation.exceptions.JsonMappingException;
 import org.folio.processing.events.services.handler.EventHandler;
@@ -182,7 +180,7 @@ public class CreateMarcHoldingsEventHandler implements EventHandler {
 
   @Override
   public boolean isEligible(DataImportEventPayload dataImportEventPayload) {
-    if (dataImportEventPayload.getContext().get(MARC_HOLDINGS.value()) != null && dataImportEventPayload.getCurrentNode() != null && ACTION_PROFILE == dataImportEventPayload.getCurrentNode().getContentType()) {
+    if (dataImportEventPayload.getCurrentNode() != null && dataImportEventPayload.getContext().get(MARC_HOLDINGS.value()) != null && ACTION_PROFILE == dataImportEventPayload.getCurrentNode().getContentType()) {
       var actionProfile = JsonObject.mapFrom(dataImportEventPayload.getCurrentNode().getContent()).mapTo(ActionProfile.class);
       return actionProfile.getAction() == ActionProfile.Action.CREATE && actionProfile.getFolioRecord() == ActionProfile.FolioRecord.HOLDINGS;
     }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandler.java
@@ -98,8 +98,7 @@ public class CreateMarcHoldingsEventHandler implements EventHandler {
         .compose(instanceId -> {
           fillInstanceId(dataImportEventPayload, holdingJson, instanceId);
           var holdingsRecords = storage.getHoldingsRecordCollection(context);
-          HoldingsRecord holding = null;
-          holding = Json.decodeValue(dataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord.class);
+          HoldingsRecord holding = Json.decodeValue(dataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord.class);
           return addHoldings(holding, holdingsRecords)
             .onSuccess(createdHoldings -> {
               LOGGER.info("Created Holding record");

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandler.java
@@ -91,10 +91,10 @@ public class CreateMarcHoldingsEventHandler implements EventHandler {
       }
       holdingAsJson.put("id", UUID.randomUUID().toString());
       var holdingJson = holdingAsJson;
+      checkIfPermanentLocationIdExists(holdingJson);
 
       findInstanceIdByHrid(dataImportEventPayload, holdingAsJson).thenCompose(instanceId -> {
         fillInstanceId(dataImportEventPayload, holdingJson, instanceId);
-        checkIfPermanentLocationIdExists(holdingJson);
         var context = constructContext(dataImportEventPayload.getTenant(), dataImportEventPayload.getToken(), dataImportEventPayload.getOkapiUrl());
         var holdingsRecords = storage.getHoldingsRecordCollection(context);
         HoldingsRecord holding = null;

--- a/src/main/java/org/folio/inventory/dataimport/util/ParsedRecordUtil.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/ParsedRecordUtil.java
@@ -3,8 +3,16 @@ package org.folio.inventory.dataimport.util;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.Record;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.marc4j.MarcJsonReader;
+import org.marc4j.MarcReader;
+import org.marc4j.marc.ControlField;
 
 public final class ParsedRecordUtil {
 
@@ -38,6 +46,36 @@ public final class ParsedRecordUtil {
     return (content instanceof String)
       ? new JsonObject((String) content)
       : JsonObject.mapFrom(content);
+  }
+
+  /**
+   * Extracts value from specified field
+   *
+   * @param record record
+   * @param tag    tag of data field
+   * @return value from the specified field, or null
+   */
+  public static String getControlFieldValue(Record record, String tag) {
+    if (record != null && record.getParsedRecord() != null && record.getParsedRecord().getContent() != null) {
+      MarcReader reader = buildMarcReader(record);
+      try {
+        if (reader.hasNext()) {
+          org.marc4j.marc.Record marcRecord = reader.next();
+          return marcRecord.getControlFields().stream()
+            .filter(controlField -> controlField.getTag().equals(tag))
+            .findFirst()
+            .map(ControlField::getData)
+            .orElse(null);
+        }
+      } catch (Exception e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private static MarcReader buildMarcReader(Record record) {
+    return new MarcJsonReader(new ByteArrayInputStream(record.getParsedRecord().getContent().toString().getBytes(StandardCharsets.UTF_8)));
   }
 
   public enum AdditionalSubfields {

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
@@ -499,9 +499,13 @@ public class CreateHoldingEventHandlerTest {
 
   @Test
   public void isEligibleShouldReturnTrue() {
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-      .withContext(new HashMap<>())
+      .withContext(context)
       .withProfileSnapshot(profileSnapshotWrapper)
       .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
     assertTrue(createHoldingEventHandler.isEligible(dataImportEventPayload));

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandlerTest.java
@@ -1,0 +1,593 @@
+//package org.folio.inventory.dataimport.handlers.actions;
+//
+//import static org.junit.Assert.assertFalse;
+//import static org.junit.Assert.assertTrue;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.Mockito.doAnswer;
+//import static org.mockito.Mockito.when;
+//
+//import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
+//import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
+//import static org.folio.ActionProfile.FolioRecord.MARC_HOLDINGS;
+//import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_CREATED;
+//import static org.folio.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
+//import static org.folio.inventory.dataimport.handlers.actions.AbstractHoldingsEventHandler.ACTION_HAS_NO_MAPPING_MSG;
+//import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
+//import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
+//import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
+//
+//import java.io.IOException;
+//import java.io.UnsupportedEncodingException;
+//import java.util.ArrayList;
+//import java.util.Collections;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.UUID;
+//import java.util.concurrent.CompletableFuture;
+//import java.util.concurrent.ExecutionException;
+//import java.util.concurrent.TimeUnit;
+//import java.util.concurrent.TimeoutException;
+//import java.util.function.Consumer;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.google.common.collect.Lists;
+//import io.vertx.core.json.Json;
+//import io.vertx.core.json.JsonObject;
+//import org.junit.Assert;
+//import org.junit.Before;
+//import org.junit.Test;
+//import org.marc4j.MarcJsonReader;
+//import org.mockito.Mock;
+//import org.mockito.Mockito;
+//import org.mockito.MockitoAnnotations;
+//import org.mockito.Spy;
+//
+//import org.folio.ActionProfile;
+//import org.folio.DataImportEventPayload;
+//import org.folio.Holdings;
+//import org.folio.HoldingsRecord;
+//import org.folio.JobProfile;
+//import org.folio.Location;
+//import org.folio.MappingProfile;
+//import org.folio.inventory.TestUtil;
+//import org.folio.inventory.common.api.request.PagingParameters;
+//import org.folio.inventory.common.domain.MultipleRecords;
+//import org.folio.inventory.common.domain.Success;
+//import org.folio.inventory.dataimport.HoldingWriterFactory;
+//import org.folio.inventory.domain.HoldingsRecordCollection;
+//import org.folio.inventory.domain.instances.Instance;
+//import org.folio.inventory.storage.Storage;
+//import org.folio.processing.mapping.MappingManager;
+//import org.folio.processing.mapping.defaultmapper.processor.RuleExecutionContext;
+//import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+//import org.folio.processing.mapping.mapper.reader.Reader;
+//import org.folio.processing.mapping.mapper.reader.record.marc.MarcBibReaderFactory;
+//import org.folio.processing.mapping.mapper.reader.record.marc.MarcHoldingsReaderFactory;
+//import org.folio.processing.value.StringValue;
+//import org.folio.rest.jaxrs.model.EntityType;
+//import org.folio.rest.jaxrs.model.ExternalIdsHolder;
+//import org.folio.rest.jaxrs.model.MappingDetail;
+//import org.folio.rest.jaxrs.model.MappingRule;
+//import org.folio.rest.jaxrs.model.ParsedRecord;
+//import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+//import org.folio.rest.jaxrs.model.Record;
+//
+//public class CreateMarcHoldingsEventHandlerTest {
+//
+//  private static final String PARSED_CONTENT_WITH_INSTANCE_ID = "{ \"leader\": \"01314nam  22003851a 4500\", \"fields\":[ {\"001\":\"ybp7406411\"}, {\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } } ] }";
+//  private static final String PARSED_CONTENT_WITHOUT_INSTANCE_ID = "{ \"leader\":\"01314nam  22003851a 4500\", \"fields\":[ { \"001\":\"ybp7406411\" } ] }";
+//  private static final String PARSED_HOLDINGS_RECORD = "src/test/resources/marc/parsed-holdings-record.json";
+////  private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/rules.json";
+//  private static final String PERMANENT_LOCATION_ID = "fe19bae4-da28-472b-be90-d442e2428ead";
+//  private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/marc-holdings-rules.json";
+//
+//  @Mock
+//  private Storage storage;
+//  @Mock
+//  HoldingsRecordCollection holdingsRecordsCollection;
+//  @Spy
+//  private MarcHoldingsReaderFactory fakeReaderFactory = new MarcHoldingsReaderFactory();
+//
+//  private JsonObject mappingRules;
+//
+//  private JobProfile jobProfile = new JobProfile()
+//    .withId(UUID.randomUUID().toString())
+//    .withName("Create MARC Bibs")
+//    .withDataType(JobProfile.DataType.MARC);
+//
+//  private ActionProfile actionProfile = new ActionProfile()
+//    .withId(UUID.randomUUID().toString())
+//    .withName("Create preliminary Item")
+//    .withAction(ActionProfile.Action.CREATE)
+//    .withFolioRecord(HOLDINGS);
+//
+//  private MappingProfile mappingProfile = new MappingProfile()
+//    .withId(UUID.randomUUID().toString())
+//    .withName("Prelim item from MARC")
+//    //TODO ask Pavlo
+//    .withIncomingRecordType(EntityType.HOLDINGS)
+//    .withExistingRecordType(EntityType.HOLDINGS)
+//    .withMappingDetails(new MappingDetail()
+//      .withMappingFields(Collections.singletonList(
+//        new MappingRule().withPath("permanentLocationId").withValue("permanentLocationExpression").withEnabled("true"))));
+//
+//  private ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+//    .withId(UUID.randomUUID().toString())
+//    .withProfileId(jobProfile.getId())
+//    .withContentType(JOB_PROFILE)
+//    .withContent(jobProfile)
+//    .withChildSnapshotWrappers(Collections.singletonList(
+//      new ProfileSnapshotWrapper()
+//        .withProfileId(actionProfile.getId())
+//        .withContentType(ACTION_PROFILE)
+//        .withContent(actionProfile)
+//        .withChildSnapshotWrappers(Collections.singletonList(
+//          new ProfileSnapshotWrapper()
+//            .withProfileId(mappingProfile.getId())
+//            .withContentType(MAPPING_PROFILE)
+//            .withContent(JsonObject.mapFrom(mappingProfile).getMap())))));
+//
+//  private CreateMarcHoldingsEventHandler createMarcHoldingsEventHandler;
+//
+//  @Before
+//  public void setUp() throws IOException {
+//
+//    MockitoAnnotations.initMocks(this);
+//    MappingManager.clearReaderFactories();
+//    createMarcHoldingsEventHandler = new CreateMarcHoldingsEventHandler(storage);
+//    mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
+//    doAnswer(invocationOnMock -> {
+//      MultipleRecords result = new MultipleRecords<>(new ArrayList<>(), 0);
+//      Consumer<Success<MultipleRecords>> successHandler = invocationOnMock.getArgument(2);
+//      successHandler.accept(new Success<>(result));
+//      return null;
+//    }).when(holdingsRecordsCollection).findByCql(anyString(), any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+//
+//    doAnswer(invocationOnMock -> {
+//      HoldingsRecord holdingsRecord = invocationOnMock.getArgument(0);
+//      Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
+//      successHandler.accept(new Success<>(holdingsRecord));
+//      return null;
+//    }).when(holdingsRecordsCollection).add(any(), any(Consumer.class), any(Consumer.class));
+//  }
+//
+//  @Test
+//  public void shouldProcessEvent() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+//
+//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+//
+//    MappingManager.registerReaderFactory(fakeReaderFactory);
+//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+//
+//    var instanceId = String.valueOf(UUID.randomUUID());
+//
+//    HoldingsRecord holdings = new HoldingsRecord()
+//      .withId(String.valueOf(UUID.randomUUID()))
+//      .withHrid(String.valueOf(UUID.randomUUID()))
+//      .withInstanceId(instanceId)
+//      .withSourceId(String.valueOf(UUID.randomUUID()))
+//      .withHoldingsTypeId(String.valueOf(UUID.randomUUID()))
+//      .withPermanentLocationId(PERMANENT_LOCATION_ID);
+//
+//    var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
+//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
+//    HashMap<String, String> context = new HashMap<>();
+//    context.put("HOLDINGS", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(holdings)).encode());
+//    context.put(MARC_HOLDINGS.value(), Json.encode(record));
+//    context.put("MAPPING_RULES", mappingRules.encode());
+//    context.put("MAPPING_PARAMS", new JsonObject().encode());
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+//      .withContext(context)
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+//
+//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+//    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+//
+//    Assert.assertEquals(DI_SRS_MARC_HOLDING_RECORD_CREATED.value(), actualDataImportEventPayload.getEventType());
+//    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+//    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
+//    Assert.assertEquals(instanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
+//    Assert.assertEquals(PERMANENT_LOCATION_ID, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
+//  }
+//
+//  @Test
+//  public void shouldProcessEventIfInstanceIdIsNotExistsInInstanceInContextButExistsInMarcBibliographicParsedRecords() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+//
+//    MappingManager.registerReaderFactory(fakeReaderFactory);
+//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+//
+//    String expectedInstanceId = UUID.randomUUID().toString();
+//    JsonObject instanceAsJson = new JsonObject().put("id", expectedInstanceId);
+//
+////    var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
+////    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
+//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+//
+//    HashMap<String, String> context = new HashMap<>();
+//    context.put("HOLDINGS", instanceAsJson.encode());
+//    context.put(MARC_HOLDINGS.value(), Json.encode(record));
+//    context.put("MAPPING_RULES", mappingRules.encode());
+//    context.put("MAPPING_PARAMS", new JsonObject().encode());
+//
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+//      .withContext(context)
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+//
+//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+//    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+//
+//    Assert.assertEquals(DI_SRS_MARC_HOLDING_RECORD_CREATED.value(), actualDataImportEventPayload.getEventType());
+//    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+//    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
+//    Assert.assertEquals(expectedInstanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
+//    Assert.assertEquals(PERMANENT_LOCATION_ID, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
+//  }
+//
+//  @Test
+//  public void shouldProcessEventIfInstanceIdIsEmptyInInstanceInContextButExistsInMarcBibliographicParsedRecords() throws InterruptedException, ExecutionException, TimeoutException {
+//    Reader fakeReader = Mockito.mock(Reader.class);
+//
+//    String permanentLocationId = UUID.randomUUID().toString();
+//
+//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
+//
+//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+//
+//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+//
+//    MappingManager.registerReaderFactory(fakeReaderFactory);
+//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+//
+//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+//
+//    HashMap<String, String> context = new HashMap<>();
+//    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(context)
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+//
+//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+//    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+//
+//    Assert.assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
+//    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+//    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
+//    Assert.assertEquals(permanentLocationId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
+//  }
+//
+//
+//  @Test(expected = ExecutionException.class)
+//  public void shouldNotProcessEventIfInstanceIdIsNotExistsInInstanceInContextAndNotExistsInParsedParsedRecords() throws InterruptedException, ExecutionException, TimeoutException {
+//    Reader fakeReader = Mockito.mock(Reader.class);
+//
+//    String permanentLocationId = UUID.randomUUID().toString();
+//
+//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
+//
+//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+//
+//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+//
+//    MappingManager.registerReaderFactory(fakeReaderFactory);
+//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+//
+//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITHOUT_INSTANCE_ID));
+//
+//    HashMap<String, String> context = new HashMap<>();
+//    context.put("INSTANCE", new JsonObject().encode());
+//    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(context)
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+//
+//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+//    future.get(5, TimeUnit.MILLISECONDS);
+//  }
+//
+//
+//  @Test(expected = ExecutionException.class)
+//  public void shouldNotProcessEventIfInstanceIdIsNotExistsInInstanceInContextAndMarcBibliographicNotExists() throws InterruptedException, ExecutionException, TimeoutException {
+//    Reader fakeReader = Mockito.mock(Reader.class);
+//
+//    String permanentLocationId = UUID.randomUUID().toString();
+//
+//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
+//
+//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+//
+//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+//
+//    MappingManager.registerReaderFactory(fakeReaderFactory);
+//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+//
+//    String instanceId = String.valueOf(UUID.randomUUID());
+//    Record record = new Record().withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId));
+//
+//    HashMap<String, String> context = new HashMap<>();
+//    context.put("INSTANCE", new JsonObject().encode());
+//    context.put("InvalidField", JsonObject.mapFrom(record).encode());
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(context)
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+//
+//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+//    future.get(5, TimeUnit.MILLISECONDS);
+//  }
+//
+//  @Test(expected = ExecutionException.class)
+//  public void shouldNotProcessEventIfNoContextMarcBibliographic() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+//    Reader fakeReader = Mockito.mock(Reader.class);
+//
+//    String permanentLocationId = UUID.randomUUID().toString();
+//
+//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
+//
+//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+//
+//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+//
+//    MappingManager.registerReaderFactory(fakeReaderFactory);
+//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+//
+//    String instanceId = String.valueOf(UUID.randomUUID());
+//    Instance instance = new Instance(instanceId, String.valueOf(UUID.randomUUID()),
+//      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
+//    HashMap<String, String> context = new HashMap<>();
+//    context.put("InvalidField", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(context)
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+//
+//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+//    future.get(5, TimeUnit.MILLISECONDS);
+//  }
+//
+//  @Test(expected = ExecutionException.class)
+//  public void shouldNotProcessEventIfContextIsNull() throws InterruptedException, ExecutionException, TimeoutException {
+//    Reader fakeReader = Mockito.mock(Reader.class);
+//
+//    String permanentLocationId = UUID.randomUUID().toString();
+//
+//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
+//
+//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+//
+//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+//
+//    MappingManager.registerReaderFactory(fakeReaderFactory);
+//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(null)
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+//
+//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+//    future.get(5, TimeUnit.MILLISECONDS);
+//  }
+//
+//  @Test(expected = ExecutionException.class)
+//  public void shouldNotProcessEventIfContextIsEmpty() throws InterruptedException, ExecutionException, TimeoutException {
+//    Reader fakeReader = Mockito.mock(Reader.class);
+//
+//    String permanentLocationId = UUID.randomUUID().toString();
+//
+//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
+//
+//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+//
+//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+//
+//    MappingManager.registerReaderFactory(fakeReaderFactory);
+//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(new HashMap<>())
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+//
+//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+//    future.get(5, TimeUnit.MILLISECONDS);
+//  }
+//
+//  @Test(expected = ExecutionException.class)
+//  public void shouldNotProcessEventIfPermanentLocationIdIsNotExistsInContext() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+//    Reader fakeReader = Mockito.mock(Reader.class);
+//
+//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(""));
+//
+//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+//
+//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+//
+//    MappingManager.registerReaderFactory(fakeReaderFactory);
+//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+//
+//    String instanceId = String.valueOf(UUID.randomUUID());
+//    Instance instance = new Instance(instanceId, String.valueOf(UUID.randomUUID()),
+//      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
+//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+//    HashMap<String, String> context = new HashMap<>();
+//    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+//    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(context)
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+//
+//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+//    future.get(5, TimeUnit.MILLISECONDS);
+//  }
+//
+//  @Test(expected = ExecutionException.class)
+//  public void shouldNotProcessEventIfHoldingRecordIsInvalid() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+//    Reader fakeReader = Mockito.mock(Reader.class);
+//
+//    MappingProfile mappingProfile = new MappingProfile()
+//      .withId(UUID.randomUUID().toString())
+//      .withName("Prelim item from MARC")
+//      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+//      .withExistingRecordType(EntityType.HOLDINGS)
+//      .withMappingDetails(new MappingDetail()
+//        .withMappingFields(Lists.newArrayList(
+//          new MappingRule().withPath("permanentLocationId").withValue("permanentLocationExpression"),
+//          new MappingRule().withPath("invalidField").withValue("invalidFieldValue"))));
+//
+//    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+//      .withId(UUID.randomUUID().toString())
+//      .withProfileId(jobProfile.getId())
+//      .withContentType(JOB_PROFILE)
+//      .withContent(jobProfile)
+//      .withChildSnapshotWrappers(Collections.singletonList(
+//        new ProfileSnapshotWrapper()
+//          .withProfileId(actionProfile.getId())
+//          .withContentType(ACTION_PROFILE)
+//          .withContent(actionProfile)
+//          .withChildSnapshotWrappers(Collections.singletonList(
+//            new ProfileSnapshotWrapper()
+//              .withProfileId(mappingProfile.getId())
+//              .withContentType(MAPPING_PROFILE)
+//              .withContent(JsonObject.mapFrom(mappingProfile).getMap())))));
+//
+//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(UUID.randomUUID().toString()), StringValue.of(UUID.randomUUID().toString()));
+//
+//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+//
+//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+//
+//    MappingManager.registerReaderFactory(fakeReaderFactory);
+//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+//
+//    String instanceId = String.valueOf(UUID.randomUUID());
+//    Instance instance = new Instance(instanceId, String.valueOf(UUID.randomUUID()),
+//      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
+//    HashMap<String, String> context = new HashMap<>();
+//    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(context)
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+//
+//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+//    future.get(5, TimeUnit.MILLISECONDS);
+//  }
+//
+//  @Test
+//  public void shouldReturnFailedFutureIfCurrentActionProfileHasNoMappingProfile() {
+//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+//    HashMap<String, String> context = new HashMap<>();
+//    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(context)
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(new ProfileSnapshotWrapper()
+//        .withContent(JsonObject.mapFrom(mappingProfile).getMap())
+//        .withContentType(ACTION_PROFILE));
+//
+//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+//
+//    ExecutionException exception = Assert.assertThrows(ExecutionException.class, future::get);
+//    Assert.assertEquals(ACTION_HAS_NO_MAPPING_MSG, exception.getCause().getMessage());
+//  }
+//
+//  @Test
+//  public void isEligibleShouldReturnTrue() {
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(new HashMap<>())
+//      .withProfileSnapshot(profileSnapshotWrapper)
+//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+//    assertTrue(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
+//  }
+//
+//  @Test
+//  public void isEligibleShouldReturnFalseIfCurrentNodeIsEmpty() {
+//
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(new HashMap<>())
+//      .withProfileSnapshot(profileSnapshotWrapper);
+//    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
+//  }
+//
+//  @Test
+//  public void isEligibleShouldReturnFalseIfCurrentNodeIsNotActionProfile() {
+//
+//    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+//      .withId(UUID.randomUUID().toString())
+//      .withProfileId(jobProfile.getId())
+//      .withContentType(JOB_PROFILE)
+//      .withContent(jobProfile);
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(new HashMap<>())
+//      .withProfileSnapshot(profileSnapshotWrapper);
+//    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
+//  }
+//
+//  @Test
+//  public void isEligibleShouldReturnFalseIfActionIsNotCreate() {
+//    ActionProfile actionProfile = new ActionProfile()
+//      .withId(UUID.randomUUID().toString())
+//      .withName("Create preliminary Item")
+//      .withAction(ActionProfile.Action.DELETE)
+//      .withFolioRecord(HOLDINGS);
+//    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+//      .withId(UUID.randomUUID().toString())
+//      .withProfileId(actionProfile.getId())
+//      .withContentType(JOB_PROFILE)
+//      .withContent(actionProfile);
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(new HashMap<>())
+//      .withProfileSnapshot(profileSnapshotWrapper);
+//    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
+//  }
+//
+//  @Test
+//  public void isEligibleShouldReturnFalseIfRecordIsNotHoldings() {
+//    ActionProfile actionProfile = new ActionProfile()
+//      .withId(UUID.randomUUID().toString())
+//      .withName("Create preliminary Item")
+//      .withAction(ActionProfile.Action.CREATE)
+//      .withFolioRecord(ActionProfile.FolioRecord.INSTANCE);
+//    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+//      .withId(UUID.randomUUID().toString())
+//      .withProfileId(actionProfile.getId())
+//      .withContentType(JOB_PROFILE)
+//      .withContent(actionProfile);
+//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+//      .withContext(new HashMap<>())
+//      .withProfileSnapshot(profileSnapshotWrapper);
+//    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
+//  }
+//}

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandlerTest.java
@@ -1,593 +1,463 @@
-//package org.folio.inventory.dataimport.handlers.actions;
-//
-//import static org.junit.Assert.assertFalse;
-//import static org.junit.Assert.assertTrue;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.Mockito.doAnswer;
-//import static org.mockito.Mockito.when;
-//
-//import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
-//import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
-//import static org.folio.ActionProfile.FolioRecord.MARC_HOLDINGS;
-//import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_CREATED;
-//import static org.folio.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
-//import static org.folio.inventory.dataimport.handlers.actions.AbstractHoldingsEventHandler.ACTION_HAS_NO_MAPPING_MSG;
-//import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
-//import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
-//import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
-//
-//import java.io.IOException;
-//import java.io.UnsupportedEncodingException;
-//import java.util.ArrayList;
-//import java.util.Collections;
-//import java.util.HashMap;
-//import java.util.List;
-//import java.util.UUID;
-//import java.util.concurrent.CompletableFuture;
-//import java.util.concurrent.ExecutionException;
-//import java.util.concurrent.TimeUnit;
-//import java.util.concurrent.TimeoutException;
-//import java.util.function.Consumer;
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import com.google.common.collect.Lists;
-//import io.vertx.core.json.Json;
-//import io.vertx.core.json.JsonObject;
-//import org.junit.Assert;
-//import org.junit.Before;
-//import org.junit.Test;
-//import org.marc4j.MarcJsonReader;
-//import org.mockito.Mock;
-//import org.mockito.Mockito;
-//import org.mockito.MockitoAnnotations;
-//import org.mockito.Spy;
-//
-//import org.folio.ActionProfile;
-//import org.folio.DataImportEventPayload;
-//import org.folio.Holdings;
-//import org.folio.HoldingsRecord;
-//import org.folio.JobProfile;
-//import org.folio.Location;
-//import org.folio.MappingProfile;
-//import org.folio.inventory.TestUtil;
-//import org.folio.inventory.common.api.request.PagingParameters;
-//import org.folio.inventory.common.domain.MultipleRecords;
-//import org.folio.inventory.common.domain.Success;
-//import org.folio.inventory.dataimport.HoldingWriterFactory;
-//import org.folio.inventory.domain.HoldingsRecordCollection;
-//import org.folio.inventory.domain.instances.Instance;
-//import org.folio.inventory.storage.Storage;
-//import org.folio.processing.mapping.MappingManager;
-//import org.folio.processing.mapping.defaultmapper.processor.RuleExecutionContext;
-//import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
-//import org.folio.processing.mapping.mapper.reader.Reader;
-//import org.folio.processing.mapping.mapper.reader.record.marc.MarcBibReaderFactory;
-//import org.folio.processing.mapping.mapper.reader.record.marc.MarcHoldingsReaderFactory;
-//import org.folio.processing.value.StringValue;
-//import org.folio.rest.jaxrs.model.EntityType;
-//import org.folio.rest.jaxrs.model.ExternalIdsHolder;
-//import org.folio.rest.jaxrs.model.MappingDetail;
-//import org.folio.rest.jaxrs.model.MappingRule;
-//import org.folio.rest.jaxrs.model.ParsedRecord;
-//import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
-//import org.folio.rest.jaxrs.model.Record;
-//
-//public class CreateMarcHoldingsEventHandlerTest {
-//
-//  private static final String PARSED_CONTENT_WITH_INSTANCE_ID = "{ \"leader\": \"01314nam  22003851a 4500\", \"fields\":[ {\"001\":\"ybp7406411\"}, {\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } } ] }";
-//  private static final String PARSED_CONTENT_WITHOUT_INSTANCE_ID = "{ \"leader\":\"01314nam  22003851a 4500\", \"fields\":[ { \"001\":\"ybp7406411\" } ] }";
-//  private static final String PARSED_HOLDINGS_RECORD = "src/test/resources/marc/parsed-holdings-record.json";
-////  private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/rules.json";
-//  private static final String PERMANENT_LOCATION_ID = "fe19bae4-da28-472b-be90-d442e2428ead";
-//  private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/marc-holdings-rules.json";
-//
-//  @Mock
-//  private Storage storage;
-//  @Mock
-//  HoldingsRecordCollection holdingsRecordsCollection;
-//  @Spy
-//  private MarcHoldingsReaderFactory fakeReaderFactory = new MarcHoldingsReaderFactory();
-//
-//  private JsonObject mappingRules;
-//
-//  private JobProfile jobProfile = new JobProfile()
-//    .withId(UUID.randomUUID().toString())
-//    .withName("Create MARC Bibs")
-//    .withDataType(JobProfile.DataType.MARC);
-//
-//  private ActionProfile actionProfile = new ActionProfile()
-//    .withId(UUID.randomUUID().toString())
-//    .withName("Create preliminary Item")
-//    .withAction(ActionProfile.Action.CREATE)
-//    .withFolioRecord(HOLDINGS);
-//
-//  private MappingProfile mappingProfile = new MappingProfile()
-//    .withId(UUID.randomUUID().toString())
-//    .withName("Prelim item from MARC")
-//    //TODO ask Pavlo
-//    .withIncomingRecordType(EntityType.HOLDINGS)
-//    .withExistingRecordType(EntityType.HOLDINGS)
-//    .withMappingDetails(new MappingDetail()
-//      .withMappingFields(Collections.singletonList(
-//        new MappingRule().withPath("permanentLocationId").withValue("permanentLocationExpression").withEnabled("true"))));
-//
-//  private ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
-//    .withId(UUID.randomUUID().toString())
-//    .withProfileId(jobProfile.getId())
-//    .withContentType(JOB_PROFILE)
-//    .withContent(jobProfile)
-//    .withChildSnapshotWrappers(Collections.singletonList(
-//      new ProfileSnapshotWrapper()
-//        .withProfileId(actionProfile.getId())
-//        .withContentType(ACTION_PROFILE)
-//        .withContent(actionProfile)
-//        .withChildSnapshotWrappers(Collections.singletonList(
-//          new ProfileSnapshotWrapper()
-//            .withProfileId(mappingProfile.getId())
-//            .withContentType(MAPPING_PROFILE)
-//            .withContent(JsonObject.mapFrom(mappingProfile).getMap())))));
-//
-//  private CreateMarcHoldingsEventHandler createMarcHoldingsEventHandler;
-//
-//  @Before
-//  public void setUp() throws IOException {
-//
-//    MockitoAnnotations.initMocks(this);
-//    MappingManager.clearReaderFactories();
-//    createMarcHoldingsEventHandler = new CreateMarcHoldingsEventHandler(storage);
-//    mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
-//    doAnswer(invocationOnMock -> {
-//      MultipleRecords result = new MultipleRecords<>(new ArrayList<>(), 0);
-//      Consumer<Success<MultipleRecords>> successHandler = invocationOnMock.getArgument(2);
-//      successHandler.accept(new Success<>(result));
-//      return null;
-//    }).when(holdingsRecordsCollection).findByCql(anyString(), any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
-//
-//    doAnswer(invocationOnMock -> {
-//      HoldingsRecord holdingsRecord = invocationOnMock.getArgument(0);
-//      Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
-//      successHandler.accept(new Success<>(holdingsRecord));
-//      return null;
-//    }).when(holdingsRecordsCollection).add(any(), any(Consumer.class), any(Consumer.class));
-//  }
-//
-//  @Test
-//  public void shouldProcessEvent() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-//
-//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-//
-//    MappingManager.registerReaderFactory(fakeReaderFactory);
-//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-//
-//    var instanceId = String.valueOf(UUID.randomUUID());
-//
-//    HoldingsRecord holdings = new HoldingsRecord()
-//      .withId(String.valueOf(UUID.randomUUID()))
-//      .withHrid(String.valueOf(UUID.randomUUID()))
-//      .withInstanceId(instanceId)
-//      .withSourceId(String.valueOf(UUID.randomUUID()))
-//      .withHoldingsTypeId(String.valueOf(UUID.randomUUID()))
-//      .withPermanentLocationId(PERMANENT_LOCATION_ID);
-//
-//    var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
-//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
-//    HashMap<String, String> context = new HashMap<>();
-//    context.put("HOLDINGS", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(holdings)).encode());
-//    context.put(MARC_HOLDINGS.value(), Json.encode(record));
-//    context.put("MAPPING_RULES", mappingRules.encode());
-//    context.put("MAPPING_PARAMS", new JsonObject().encode());
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
-//      .withContext(context)
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-//
-//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
-//    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
-//
-//    Assert.assertEquals(DI_SRS_MARC_HOLDING_RECORD_CREATED.value(), actualDataImportEventPayload.getEventType());
-//    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-//    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
-//    Assert.assertEquals(instanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
-//    Assert.assertEquals(PERMANENT_LOCATION_ID, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
-//  }
-//
-//  @Test
-//  public void shouldProcessEventIfInstanceIdIsNotExistsInInstanceInContextButExistsInMarcBibliographicParsedRecords() throws InterruptedException, ExecutionException, TimeoutException, IOException {
-//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-//
-//    MappingManager.registerReaderFactory(fakeReaderFactory);
-//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-//
-//    String expectedInstanceId = UUID.randomUUID().toString();
-//    JsonObject instanceAsJson = new JsonObject().put("id", expectedInstanceId);
-//
-////    var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
-////    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
-//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
-//
-//    HashMap<String, String> context = new HashMap<>();
-//    context.put("HOLDINGS", instanceAsJson.encode());
-//    context.put(MARC_HOLDINGS.value(), Json.encode(record));
-//    context.put("MAPPING_RULES", mappingRules.encode());
-//    context.put("MAPPING_PARAMS", new JsonObject().encode());
-//
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
-//      .withContext(context)
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-//
-//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
-//    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
-//
-//    Assert.assertEquals(DI_SRS_MARC_HOLDING_RECORD_CREATED.value(), actualDataImportEventPayload.getEventType());
-//    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-//    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
-//    Assert.assertEquals(expectedInstanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
-//    Assert.assertEquals(PERMANENT_LOCATION_ID, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
-//  }
-//
-//  @Test
-//  public void shouldProcessEventIfInstanceIdIsEmptyInInstanceInContextButExistsInMarcBibliographicParsedRecords() throws InterruptedException, ExecutionException, TimeoutException {
-//    Reader fakeReader = Mockito.mock(Reader.class);
-//
-//    String permanentLocationId = UUID.randomUUID().toString();
-//
-//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-//
-//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-//
-//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-//
-//    MappingManager.registerReaderFactory(fakeReaderFactory);
-//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-//
-//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
-//
-//    HashMap<String, String> context = new HashMap<>();
-//    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(context)
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-//
-//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
-//    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
-//
-//    Assert.assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
-//    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-//    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
-//    Assert.assertEquals(permanentLocationId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
-//  }
-//
-//
-//  @Test(expected = ExecutionException.class)
-//  public void shouldNotProcessEventIfInstanceIdIsNotExistsInInstanceInContextAndNotExistsInParsedParsedRecords() throws InterruptedException, ExecutionException, TimeoutException {
-//    Reader fakeReader = Mockito.mock(Reader.class);
-//
-//    String permanentLocationId = UUID.randomUUID().toString();
-//
-//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-//
-//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-//
-//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-//
-//    MappingManager.registerReaderFactory(fakeReaderFactory);
-//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-//
-//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITHOUT_INSTANCE_ID));
-//
-//    HashMap<String, String> context = new HashMap<>();
-//    context.put("INSTANCE", new JsonObject().encode());
-//    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(context)
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-//
-//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
-//    future.get(5, TimeUnit.MILLISECONDS);
-//  }
-//
-//
-//  @Test(expected = ExecutionException.class)
-//  public void shouldNotProcessEventIfInstanceIdIsNotExistsInInstanceInContextAndMarcBibliographicNotExists() throws InterruptedException, ExecutionException, TimeoutException {
-//    Reader fakeReader = Mockito.mock(Reader.class);
-//
-//    String permanentLocationId = UUID.randomUUID().toString();
-//
-//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-//
-//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-//
-//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-//
-//    MappingManager.registerReaderFactory(fakeReaderFactory);
-//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-//
-//    String instanceId = String.valueOf(UUID.randomUUID());
-//    Record record = new Record().withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId));
-//
-//    HashMap<String, String> context = new HashMap<>();
-//    context.put("INSTANCE", new JsonObject().encode());
-//    context.put("InvalidField", JsonObject.mapFrom(record).encode());
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(context)
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-//
-//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
-//    future.get(5, TimeUnit.MILLISECONDS);
-//  }
-//
-//  @Test(expected = ExecutionException.class)
-//  public void shouldNotProcessEventIfNoContextMarcBibliographic() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-//    Reader fakeReader = Mockito.mock(Reader.class);
-//
-//    String permanentLocationId = UUID.randomUUID().toString();
-//
-//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-//
-//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-//
-//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-//
-//    MappingManager.registerReaderFactory(fakeReaderFactory);
-//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-//
-//    String instanceId = String.valueOf(UUID.randomUUID());
-//    Instance instance = new Instance(instanceId, String.valueOf(UUID.randomUUID()),
-//      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
-//    HashMap<String, String> context = new HashMap<>();
-//    context.put("InvalidField", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(context)
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-//
-//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
-//    future.get(5, TimeUnit.MILLISECONDS);
-//  }
-//
-//  @Test(expected = ExecutionException.class)
-//  public void shouldNotProcessEventIfContextIsNull() throws InterruptedException, ExecutionException, TimeoutException {
-//    Reader fakeReader = Mockito.mock(Reader.class);
-//
-//    String permanentLocationId = UUID.randomUUID().toString();
-//
-//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-//
-//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-//
-//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-//
-//    MappingManager.registerReaderFactory(fakeReaderFactory);
-//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(null)
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-//
-//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
-//    future.get(5, TimeUnit.MILLISECONDS);
-//  }
-//
-//  @Test(expected = ExecutionException.class)
-//  public void shouldNotProcessEventIfContextIsEmpty() throws InterruptedException, ExecutionException, TimeoutException {
-//    Reader fakeReader = Mockito.mock(Reader.class);
-//
-//    String permanentLocationId = UUID.randomUUID().toString();
-//
-//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-//
-//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-//
-//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-//
-//    MappingManager.registerReaderFactory(fakeReaderFactory);
-//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(new HashMap<>())
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-//
-//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
-//    future.get(5, TimeUnit.MILLISECONDS);
-//  }
-//
-//  @Test(expected = ExecutionException.class)
-//  public void shouldNotProcessEventIfPermanentLocationIdIsNotExistsInContext() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-//    Reader fakeReader = Mockito.mock(Reader.class);
-//
-//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(""));
-//
-//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-//
-//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-//
-//    MappingManager.registerReaderFactory(fakeReaderFactory);
-//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-//
-//    String instanceId = String.valueOf(UUID.randomUUID());
-//    Instance instance = new Instance(instanceId, String.valueOf(UUID.randomUUID()),
-//      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
-//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
-//    HashMap<String, String> context = new HashMap<>();
-//    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
-//    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(context)
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-//
-//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
-//    future.get(5, TimeUnit.MILLISECONDS);
-//  }
-//
-//  @Test(expected = ExecutionException.class)
-//  public void shouldNotProcessEventIfHoldingRecordIsInvalid() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-//    Reader fakeReader = Mockito.mock(Reader.class);
-//
-//    MappingProfile mappingProfile = new MappingProfile()
-//      .withId(UUID.randomUUID().toString())
-//      .withName("Prelim item from MARC")
-//      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
-//      .withExistingRecordType(EntityType.HOLDINGS)
-//      .withMappingDetails(new MappingDetail()
-//        .withMappingFields(Lists.newArrayList(
-//          new MappingRule().withPath("permanentLocationId").withValue("permanentLocationExpression"),
-//          new MappingRule().withPath("invalidField").withValue("invalidFieldValue"))));
-//
-//    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
-//      .withId(UUID.randomUUID().toString())
-//      .withProfileId(jobProfile.getId())
-//      .withContentType(JOB_PROFILE)
-//      .withContent(jobProfile)
-//      .withChildSnapshotWrappers(Collections.singletonList(
-//        new ProfileSnapshotWrapper()
-//          .withProfileId(actionProfile.getId())
-//          .withContentType(ACTION_PROFILE)
-//          .withContent(actionProfile)
-//          .withChildSnapshotWrappers(Collections.singletonList(
-//            new ProfileSnapshotWrapper()
-//              .withProfileId(mappingProfile.getId())
-//              .withContentType(MAPPING_PROFILE)
-//              .withContent(JsonObject.mapFrom(mappingProfile).getMap())))));
-//
-//    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(UUID.randomUUID().toString()), StringValue.of(UUID.randomUUID().toString()));
-//
-//    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-//
-//    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-//
-//    MappingManager.registerReaderFactory(fakeReaderFactory);
-//    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-//
-//    String instanceId = String.valueOf(UUID.randomUUID());
-//    Instance instance = new Instance(instanceId, String.valueOf(UUID.randomUUID()),
-//      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
-//    HashMap<String, String> context = new HashMap<>();
-//    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(context)
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-//
-//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
-//    future.get(5, TimeUnit.MILLISECONDS);
-//  }
-//
-//  @Test
-//  public void shouldReturnFailedFutureIfCurrentActionProfileHasNoMappingProfile() {
-//    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
-//    HashMap<String, String> context = new HashMap<>();
-//    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(context)
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(new ProfileSnapshotWrapper()
-//        .withContent(JsonObject.mapFrom(mappingProfile).getMap())
-//        .withContentType(ACTION_PROFILE));
-//
-//    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
-//
-//    ExecutionException exception = Assert.assertThrows(ExecutionException.class, future::get);
-//    Assert.assertEquals(ACTION_HAS_NO_MAPPING_MSG, exception.getCause().getMessage());
-//  }
-//
-//  @Test
-//  public void isEligibleShouldReturnTrue() {
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(new HashMap<>())
-//      .withProfileSnapshot(profileSnapshotWrapper)
-//      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-//    assertTrue(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
-//  }
-//
-//  @Test
-//  public void isEligibleShouldReturnFalseIfCurrentNodeIsEmpty() {
-//
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(new HashMap<>())
-//      .withProfileSnapshot(profileSnapshotWrapper);
-//    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
-//  }
-//
-//  @Test
-//  public void isEligibleShouldReturnFalseIfCurrentNodeIsNotActionProfile() {
-//
-//    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
-//      .withId(UUID.randomUUID().toString())
-//      .withProfileId(jobProfile.getId())
-//      .withContentType(JOB_PROFILE)
-//      .withContent(jobProfile);
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(new HashMap<>())
-//      .withProfileSnapshot(profileSnapshotWrapper);
-//    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
-//  }
-//
-//  @Test
-//  public void isEligibleShouldReturnFalseIfActionIsNotCreate() {
-//    ActionProfile actionProfile = new ActionProfile()
-//      .withId(UUID.randomUUID().toString())
-//      .withName("Create preliminary Item")
-//      .withAction(ActionProfile.Action.DELETE)
-//      .withFolioRecord(HOLDINGS);
-//    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
-//      .withId(UUID.randomUUID().toString())
-//      .withProfileId(actionProfile.getId())
-//      .withContentType(JOB_PROFILE)
-//      .withContent(actionProfile);
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(new HashMap<>())
-//      .withProfileSnapshot(profileSnapshotWrapper);
-//    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
-//  }
-//
-//  @Test
-//  public void isEligibleShouldReturnFalseIfRecordIsNotHoldings() {
-//    ActionProfile actionProfile = new ActionProfile()
-//      .withId(UUID.randomUUID().toString())
-//      .withName("Create preliminary Item")
-//      .withAction(ActionProfile.Action.CREATE)
-//      .withFolioRecord(ActionProfile.FolioRecord.INSTANCE);
-//    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
-//      .withId(UUID.randomUUID().toString())
-//      .withProfileId(actionProfile.getId())
-//      .withContentType(JOB_PROFILE)
-//      .withContent(actionProfile);
-//    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-//      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-//      .withContext(new HashMap<>())
-//      .withProfileSnapshot(profileSnapshotWrapper);
-//    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
-//  }
-//}
+package org.folio.inventory.dataimport.handlers.actions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
+import static org.folio.ActionProfile.FolioRecord.ITEM;
+import static org.folio.ActionProfile.FolioRecord.MARC_HOLDINGS;
+import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING;
+import static org.folio.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
+import static org.folio.inventory.dataimport.handlers.actions.CreateHoldingEventHandler.ACTION_HAS_NO_MAPPING_MSG;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.folio.ActionProfile;
+import org.folio.DataImportEventPayload;
+import org.folio.HoldingsRecord;
+import org.folio.JobProfile;
+import org.folio.MappingProfile;
+import org.folio.inventory.TestUtil;
+import org.folio.inventory.common.api.request.PagingParameters;
+import org.folio.inventory.common.domain.MultipleRecords;
+import org.folio.inventory.common.domain.Success;
+import org.folio.inventory.domain.HoldingsRecordCollection;
+import org.folio.inventory.domain.instances.Instance;
+import org.folio.inventory.domain.instances.InstanceCollection;
+import org.folio.inventory.storage.Storage;
+import org.folio.processing.mapping.MappingManager;
+import org.folio.rest.jaxrs.model.EntityType;
+import org.folio.rest.jaxrs.model.MappingDetail;
+import org.folio.rest.jaxrs.model.MappingRule;
+import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.rest.jaxrs.model.Record;
+
+public class CreateMarcHoldingsEventHandlerTest {
+
+  private static final String PARSED_CONTENT_WITHOUT_004_FIELD = "{ \"leader\": \"01314nam  22003851a 4500\", \"fields\":[ {\"001\":\"ybp7406411\"}, {\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } } ] }";
+  private static final String PARSED_HOLDINGS_RECORD = "src/test/resources/marc/parsed-holdings-record.json";
+  private static final String PERMANENT_LOCATION_ID = "fe19bae4-da28-472b-be90-d442e2428ead";
+  private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/marc-holdings-rules.json";
+
+  @Mock
+  private Storage storage;
+  @Mock
+  HoldingsRecordCollection holdingsRecordsCollection;
+  @Mock
+  InstanceCollection instanceRecordCollection;
+  private JsonObject mappingRules;
+  private CreateMarcHoldingsEventHandler createMarcHoldingsEventHandler;
+  private String instanceId;
+
+  private final JobProfile jobProfile = new JobProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Create MARC Bibs")
+    .withDataType(JobProfile.DataType.MARC);
+
+  private final ActionProfile actionProfile = new ActionProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Create preliminary Item")
+    .withAction(ActionProfile.Action.CREATE)
+    .withFolioRecord(HOLDINGS);
+
+  private final MappingProfile mappingProfile = new MappingProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Prelim item from MARC")
+    .withIncomingRecordType(EntityType.MARC_HOLDINGS)
+    .withExistingRecordType(EntityType.HOLDINGS)
+    .withMappingDetails(new MappingDetail()
+      .withMappingFields(Collections.singletonList(
+        new MappingRule().withPath("permanentLocationId").withValue("permanentLocationExpression").withEnabled("true"))));
+
+  private ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+    .withId(UUID.randomUUID().toString())
+    .withProfileId(jobProfile.getId())
+    .withContentType(JOB_PROFILE)
+    .withContent(jobProfile)
+    .withChildSnapshotWrappers(Collections.singletonList(
+      new ProfileSnapshotWrapper()
+        .withProfileId(actionProfile.getId())
+        .withContentType(ACTION_PROFILE)
+        .withContent(actionProfile)
+        .withChildSnapshotWrappers(Collections.singletonList(
+          new ProfileSnapshotWrapper()
+            .withProfileId(mappingProfile.getId())
+            .withContentType(MAPPING_PROFILE)
+            .withContent(JsonObject.mapFrom(mappingProfile).getMap())))));
+
+
+  @Before
+  public void setUp() throws IOException {
+    MockitoAnnotations.initMocks(this);
+    MappingManager.clearReaderFactories();
+    createMarcHoldingsEventHandler = new CreateMarcHoldingsEventHandler(storage);
+    mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
+
+    doAnswer(invocationOnMock -> {
+      instanceId = String.valueOf(UUID.randomUUID());
+      Instance instance = new Instance(instanceId, String.valueOf(UUID.randomUUID()),
+        String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
+      List<Instance> instanceList = Collections.singletonList(instance);
+      MultipleRecords<Instance> result = new MultipleRecords<>(instanceList, 1);
+      Consumer<Success<MultipleRecords<Instance>>> successHandler = invocationOnMock.getArgument(2);
+      successHandler.accept(new Success<>(result));
+      return null;
+    }).when(instanceRecordCollection).findByCql(anyString(), any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    doAnswer(invocationOnMock -> {
+      HoldingsRecord holdingsRecord = invocationOnMock.getArgument(0);
+      Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
+      successHandler.accept(new Success<>(holdingsRecord));
+      return null;
+    }).when(holdingsRecordsCollection).add(any(), any(Consumer.class), any(Consumer.class));
+  }
+
+  @Test
+  public void shouldProcessEvent() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    when(storage.getInstanceCollection(any())).thenReturn(instanceRecordCollection);
+
+    HoldingsRecord holdings = new HoldingsRecord()
+      .withId(String.valueOf(UUID.randomUUID()))
+      .withHrid(String.valueOf(UUID.randomUUID()))
+      .withInstanceId(String.valueOf(UUID.randomUUID()))
+      .withSourceId(String.valueOf(UUID.randomUUID()))
+      .withHoldingsTypeId(String.valueOf(UUID.randomUUID()))
+      .withPermanentLocationId(PERMANENT_LOCATION_ID);
+
+    var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
+    HashMap<String, String> context = new HashMap<>();
+    context.put("HOLDINGS", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(holdings)).encode());
+    context.put(MARC_HOLDINGS.value(), Json.encode(record));
+    context.put("MAPPING_RULES", mappingRules.encode());
+    context.put("MAPPING_PARAMS", new JsonObject().encode());
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+
+    Assert.assertEquals(DI_SRS_MARC_HOLDING_RECORD_CREATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
+    Assert.assertEquals(instanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
+    Assert.assertEquals(PERMANENT_LOCATION_ID, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void shouldThrowExceptionIfContextIsNull() throws ExecutionException, InterruptedException, TimeoutException {
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(null)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+    future.get(5, TimeUnit.MILLISECONDS);
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void shouldThrowExceptionIfFolioRecordIsNotMarcHoldings() throws ExecutionException, InterruptedException, TimeoutException {
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(new HashMap<>())
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+    future.get(5, TimeUnit.MILLISECONDS);
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void shouldThrowExceptionIfChildSnapshotWrappersIsEmpty() throws ExecutionException, InterruptedException, TimeoutException, IOException {
+    var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_HOLDINGS.value(), Json.encode(record));
+
+    profileSnapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(jobProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(jobProfile)
+      .withChildSnapshotWrappers(Collections.emptyList());
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper);
+
+    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+    future.get(5, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void shouldNotProcessEventIfInstanceNotFoundByMarcHoldingsHrid() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+    doAnswer(invocationOnMock -> {
+      MultipleRecords<Instance> result = new MultipleRecords<>(new ArrayList<>(), 1);
+      Consumer<Success<MultipleRecords<Instance>>> successHandler = invocationOnMock.getArgument(2);
+      successHandler.accept(new Success<>(result));
+      return null;
+    }).when(instanceRecordCollection).findByCql(anyString(), any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    when(storage.getInstanceCollection(any())).thenReturn(instanceRecordCollection);
+
+    HoldingsRecord holdings = new HoldingsRecord()
+      .withId(String.valueOf(UUID.randomUUID()))
+      .withHrid(String.valueOf(UUID.randomUUID()))
+      .withInstanceId(String.valueOf(UUID.randomUUID()))
+      .withSourceId(String.valueOf(UUID.randomUUID()))
+      .withHoldingsTypeId(String.valueOf(UUID.randomUUID()))
+      .withPermanentLocationId(PERMANENT_LOCATION_ID);
+
+    var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
+    HashMap<String, String> context = new HashMap<>();
+    context.put("HOLDINGS", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(holdings)).encode());
+    context.put(MARC_HOLDINGS.value(), Json.encode(record));
+    context.put("MAPPING_RULES", mappingRules.encode());
+    context.put("MAPPING_PARAMS", new JsonObject().encode());
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+
+    ExecutionException exception = Assert.assertThrows(ExecutionException.class, future::get);
+    Assert.assertEquals("No instance id found for marc holdings with hrid: in00000000315", exception.getCause().getMessage());
+  }
+
+  @Test
+  public void shouldNotProcessEventIfMarcHoldingDoesNotHave004Field() throws ExecutionException, InterruptedException, TimeoutException, IOException {
+    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    when(storage.getInstanceCollection(any())).thenReturn(instanceRecordCollection);
+
+    HoldingsRecord holdings = new HoldingsRecord()
+      .withId(String.valueOf(UUID.randomUUID()))
+      .withHrid(String.valueOf(UUID.randomUUID()))
+      .withInstanceId(String.valueOf(UUID.randomUUID()))
+      .withSourceId(String.valueOf(UUID.randomUUID()))
+      .withHoldingsTypeId(String.valueOf(UUID.randomUUID()))
+      .withPermanentLocationId(PERMANENT_LOCATION_ID);
+
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITHOUT_004_FIELD));
+    HashMap<String, String> context = new HashMap<>();
+    context.put("HOLDINGS", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(holdings)).encode());
+    context.put(MARC_HOLDINGS.value(), Json.encode(record));
+    context.put("MAPPING_RULES", mappingRules.encode());
+    context.put("MAPPING_PARAMS", new JsonObject().encode());
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+
+    ExecutionException exception = Assert.assertThrows(ExecutionException.class, future::get);
+    Assert.assertEquals("The field 004 for marc holdings must be not null", exception.getCause().getMessage());
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void shouldNotProcessEventIfHoldingRecordIsInvalid() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    MappingProfile mappingProfile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Prelim item from MARC")
+      .withIncomingRecordType(EntityType.MARC_HOLDINGS)
+      .withExistingRecordType(EntityType.HOLDINGS)
+      .withMappingDetails(new MappingDetail()
+        .withMappingFields(Lists.newArrayList(
+          new MappingRule().withPath("permanentLocationId").withValue("permanentLocationExpression"),
+          new MappingRule().withPath("invalidField").withValue("invalidFieldValue"))));
+
+    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(jobProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(jobProfile)
+      .withChildSnapshotWrappers(Collections.singletonList(
+        new ProfileSnapshotWrapper()
+          .withProfileId(actionProfile.getId())
+          .withContentType(ACTION_PROFILE)
+          .withContent(actionProfile)
+          .withChildSnapshotWrappers(Collections.singletonList(
+            new ProfileSnapshotWrapper()
+              .withProfileId(mappingProfile.getId())
+              .withContentType(MAPPING_PROFILE)
+              .withContent(JsonObject.mapFrom(mappingProfile).getMap())))));
+
+
+    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+
+    HoldingsRecord holdings = new HoldingsRecord()
+      .withId(String.valueOf(UUID.randomUUID()))
+      .withHrid(String.valueOf(UUID.randomUUID()))
+      .withInstanceId(String.valueOf(UUID.randomUUID()))
+      .withSourceId(String.valueOf(UUID.randomUUID()))
+      .withHoldingsTypeId(String.valueOf(UUID.randomUUID()))
+      .withPermanentLocationId(PERMANENT_LOCATION_ID);
+
+    var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
+    HashMap<String, String> context = new HashMap<>();
+    context.put("HOLDINGS", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(holdings)).encode());
+    context.put(MARC_HOLDINGS.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+    future.get(5, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void shouldReturnFailedFutureIfCurrentActionProfileHasNoMappingProfile() throws IOException {
+    var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_HOLDINGS.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(new ProfileSnapshotWrapper()
+        .withContent(JsonObject.mapFrom(mappingProfile).getMap())
+        .withContentType(ACTION_PROFILE));
+
+    CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
+
+    ExecutionException exception = Assert.assertThrows(ExecutionException.class, future::get);
+    Assert.assertEquals(ACTION_HAS_NO_MAPPING_MSG, exception.getCause().getMessage());
+  }
+
+  @Test
+  public void isEligibleShouldReturnTrue() throws IOException {
+    var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_HOLDINGS.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+    assertTrue(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
+  }
+
+  @Test
+  public void isEligibleShouldReturnFalseIfCurrentNodeIsEmpty() {
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(new HashMap<>())
+      .withProfileSnapshot(profileSnapshotWrapper);
+    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
+  }
+
+  @Test
+  public void isEligibleShouldReturnFalseIfCurrentNodeIsNotActionProfile() {
+    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(jobProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(jobProfile);
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(new HashMap<>())
+      .withProfileSnapshot(profileSnapshotWrapper);
+    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
+  }
+
+  @Test
+  public void isEligibleShouldReturnFalseIfActionIsNotCreate() {
+    ActionProfile actionProfile = new ActionProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create preliminary Item")
+      .withAction(ActionProfile.Action.DELETE)
+      .withFolioRecord(HOLDINGS);
+    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(actionProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(actionProfile);
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(new HashMap<>())
+      .withProfileSnapshot(profileSnapshotWrapper);
+    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
+  }
+
+  @Test
+  public void isEligibleShouldReturnFalseIfRecordIsNotHoldings() {
+    ActionProfile actionProfile = new ActionProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create preliminary Item")
+      .withAction(ActionProfile.Action.CREATE)
+      .withFolioRecord(ITEM);
+    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(actionProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(actionProfile);
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withContext(new HashMap<>())
+      .withProfileSnapshot(profileSnapshotWrapper);
+    assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
+  }
+
+
+  @Test
+  public void isPostProcessingNeededShouldReturnTrue() {
+    assertTrue(createMarcHoldingsEventHandler.isPostProcessingNeeded());
+  }
+
+  @Test
+  public void shouldReturnPostProcessingInitializationEventType() {
+    assertEquals(DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING.value(), createMarcHoldingsEventHandler.getPostProcessingInitializationEventType());
+  }
+}

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandlerTest.java
@@ -12,6 +12,7 @@ import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
 import static org.folio.ActionProfile.FolioRecord.ITEM;
 import static org.folio.ActionProfile.FolioRecord.MARC_HOLDINGS;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING;
+import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_CREATED;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
 import static org.folio.inventory.dataimport.handlers.actions.CreateHoldingEventHandler.ACTION_HAS_NO_MAPPING_MSG;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
@@ -172,7 +173,7 @@ public class CreateMarcHoldingsEventHandlerTest {
     CompletableFuture<DataImportEventPayload> future = createMarcHoldingsEventHandler.handle(dataImportEventPayload);
     DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
 
-    Assert.assertEquals(DI_SRS_MARC_HOLDING_RECORD_CREATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
     Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
     Assert.assertEquals(instanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
@@ -298,7 +299,6 @@ public class CreateMarcHoldingsEventHandlerTest {
     Assert.assertEquals("Can`t create Holding entity: 'permanentLocationId' is empty", exception.getCause().getMessage());
   }
 
-
   @Test
   public void shouldProcessEventIfInstanceFoundButTotalRecordsIsNotEqualOne() throws InterruptedException, ExecutionException, TimeoutException, IOException {
     doAnswer(invocationOnMock -> {
@@ -340,7 +340,7 @@ public class CreateMarcHoldingsEventHandlerTest {
 
     DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
 
-    Assert.assertEquals(DI_SRS_MARC_HOLDING_RECORD_CREATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
     Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
     Assert.assertNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
@@ -368,7 +368,7 @@ public class CreateMarcHoldingsEventHandlerTest {
     context.put("MAPPING_PARAMS", new JsonObject().encode());
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
       .withContext(context)
       .withProfileSnapshot(profileSnapshotWrapper)
       .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
@@ -425,7 +425,7 @@ public class CreateMarcHoldingsEventHandlerTest {
     context.put(MARC_HOLDINGS.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
       .withContext(context)
       .withProfileSnapshot(profileSnapshotWrapper)
       .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
@@ -442,7 +442,7 @@ public class CreateMarcHoldingsEventHandlerTest {
     context.put(MARC_HOLDINGS.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
       .withContext(context)
       .withProfileSnapshot(profileSnapshotWrapper)
       .withCurrentNode(new ProfileSnapshotWrapper()
@@ -463,7 +463,7 @@ public class CreateMarcHoldingsEventHandlerTest {
     context.put(MARC_HOLDINGS.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
       .withContext(context)
       .withProfileSnapshot(profileSnapshotWrapper)
       .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
@@ -473,7 +473,7 @@ public class CreateMarcHoldingsEventHandlerTest {
   @Test
   public void isEligibleShouldReturnFalseIfCurrentNodeIsEmpty() {
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper);
     assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
@@ -487,7 +487,7 @@ public class CreateMarcHoldingsEventHandlerTest {
       .withContentType(JOB_PROFILE)
       .withContent(jobProfile);
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper);
     assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
@@ -506,7 +506,7 @@ public class CreateMarcHoldingsEventHandlerTest {
       .withContentType(JOB_PROFILE)
       .withContent(actionProfile);
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper);
     assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));
@@ -525,7 +525,7 @@ public class CreateMarcHoldingsEventHandlerTest {
       .withContentType(JOB_PROFILE)
       .withContent(actionProfile);
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withEventType(DI_SRS_MARC_HOLDING_RECORD_CREATED.value())
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper);
     assertFalse(createMarcHoldingsEventHandler.isEligible(dataImportEventPayload));

--- a/src/test/resources/handlers/marc-holdings-rules.json
+++ b/src/test/resources/handlers/marc-holdings-rules.json
@@ -1,0 +1,6654 @@
+{
+  "001": [
+    {
+      "target": "hrid",
+      "description": "The human readable ID",
+      "subfield": [],
+      "rules": []
+    },
+    {
+      "target": "modeOfIssuanceId",
+      "description": "",
+      "subfield": [],
+      "rules": [
+        {
+          "description": "Issuance mode based on 7 leader`s byte",
+          "conditions": [
+            {
+              "type": "set_issuance_mode_id",
+              "LDR": true
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "008": [
+    {
+      "target": "instanceTypeId",
+      "description": "Default Unspecified Instance type in case when no 336 field present",
+      "subfield": [],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "set_instance_type_id",
+              "parameter": {
+                "unspecifiedInstanceTypeCode": "zzz"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "source",
+      "description": "Source of instance record",
+      "subfield": [],
+      "rules": [
+        {
+          "conditions": [],
+          "value": "MARC21"
+        }
+      ]
+    },
+    {
+      "target": "languages",
+      "description": "Language code",
+      "subfield": [],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "char_select",
+              "parameter": {
+                "from": 35,
+                "to": 38
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "010": [
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for LCCN",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "LCCN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "LCCN",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "020": [
+    {
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Valid ISBN",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "ISBN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Valid ISBN",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "c",
+            "q"
+          ],
+          "requiredSubfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Invalid ISBN",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Invalid ISBN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Invalid ISBN",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "z",
+            "q",
+            "c"
+          ],
+          "requiredSubfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "022": [
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for ISSN",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "ISSN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "ISSN",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Invalid ISSN",
+          "subfield": [
+            "y",
+            "z",
+            "m"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Invalid ISSN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Invalid ISSN",
+          "subfield": [
+            "y",
+            "z",
+            "m"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Linking ISSN",
+          "subfield": [
+            "l"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Linking ISSN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Linking ISSN",
+          "subfield": [
+            "l"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "024": [
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Other Standard Identifier",
+          "subfield": [
+            "a",
+            "c",
+            "d",
+            "q",
+            "z",
+            "2"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Other standard identifier"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Other Standard Identifier",
+          "subfield": [
+            "a",
+            "c",
+            "d",
+            "q",
+            "z",
+            "2"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "028": [
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Publisher Number",
+          "subfield": [
+            "a",
+            "b",
+            "q"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Publisher or distributor number"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Publisher Number",
+          "subfield": [
+            "a",
+            "b",
+            "q"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "035": [
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for System Control Number",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_value",
+                  "parameter": {
+                    "names": [
+                      "System control number",
+                      "OCLC"
+                    ],
+                    "oclc_regex": "(\\(OCoLC\\)|ocm|ocn|on).*"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "System Control Number",
+          "subfield": [
+            "a"
+          ]
+        }
+      ]
+    }
+  ],
+  "041": [
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "languages",
+          "description": "Language code",
+          "subfield": [
+            "a"
+          ],
+          "subFieldSplit": {
+            "type": "split_every",
+            "value": "3"
+          }
+        }
+      ]
+    }
+  ],
+  "050": [
+    {
+      "entity": [
+        {
+          "target": "classifications.classificationTypeId",
+          "description": "Type for LC classification",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_classification_type_id",
+                  "parameter": {
+                    "name": "LC"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "classifications.classificationNumber",
+          "description": "LC classification",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b"
+          ]
+        }
+      ]
+    }
+  ],
+  "060": [
+    {
+      "entity": [
+        {
+          "target": "classifications.classificationTypeId",
+          "description": "Type for NLM classification",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_classification_type_id",
+                  "parameter": {
+                    "name": "NLM"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "classifications.classificationNumber",
+          "description": "NLM classification",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b"
+          ]
+        }
+      ]
+    }
+  ],
+  "074": [
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for GPO Item Number",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "GPO item number"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "GPO Item Number",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Cancelled GPO Item Number",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Cancelled GPO item number"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Cancelled GPO Item Number",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "080": [
+    {
+      "entity": [
+        {
+          "target": "classifications.classificationTypeId",
+          "description": "Type for UDC classification",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_classification_type_id",
+                  "parameter": {
+                    "name": "UDC"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "classifications.classificationNumber",
+          "description": "UDC classification",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b"
+          ]
+        }
+      ]
+    }
+  ],
+  "082": [
+    {
+      "entity": [
+        {
+          "target": "classifications.classificationTypeId",
+          "description": "Type for Dewey classification",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_classification_type_id",
+                  "parameter": {
+                    "name": "Dewey"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "classifications.classificationNumber",
+          "description": "Dewey classification",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_substring",
+                  "parameter": {
+                    "substring": "/"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "086": [
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "classifications.classificationTypeId",
+          "description": "Type for gov doc classification",
+          "subfield": [
+            "a",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_classification_type_id",
+                  "parameter": {
+                    "name": "GDC"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "classifications.classificationNumber",
+          "description": "Gov doc classification",
+          "subfield": [
+            "a",
+            "z"
+          ]
+        }
+      ]
+    }
+  ],
+  "090": [
+    {
+      "entity": [
+        {
+          "target": "classifications.classificationTypeId",
+          "description": "Type for LC classification",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_classification_type_id",
+                  "parameter": {
+                    "name": "LC"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "classifications.classificationNumber",
+          "description": "LC classification",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "a",
+            "b"
+          ]
+        }
+      ]
+    }
+  ],
+  "100": [
+    {
+      "entity": [
+        {
+          "target": "contributors.contributorNameTypeId",
+          "description": "Type for Personal Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Personal name"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeId",
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "4"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeText",
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "e"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.primary",
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "true"
+            }
+          ]
+        },
+        {
+          "target": "contributors.name",
+          "description": "Personal Name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "j",
+            "k",
+            "l",
+            "n",
+            "p",
+            "q",
+            "t",
+            "u"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "110": [
+    {
+      "entity": [
+        {
+          "target": "contributors.contributorNameTypeId",
+          "description": "Type for Corporate Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Corporate name"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeText",
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "e"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeId",
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "4"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.primary",
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "true"
+            }
+          ]
+        },
+        {
+          "target": "contributors.name",
+          "description": "Corporate Name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "k",
+            "l",
+            "n",
+            "p",
+            "t",
+            "u"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "111": [
+    {
+      "entity": [
+        {
+          "target": "contributors.contributorNameTypeId",
+          "description": "Type for Meeting Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Meeting name"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeId",
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "4"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeText",
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "j"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.primary",
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "true"
+            }
+          ]
+        },
+        {
+          "target": "contributors.name",
+          "description": "Meeting Name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "k",
+            "l",
+            "n",
+            "p",
+            "t",
+            "u"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "130": [
+    {
+      "entity": [
+        {
+          "target": "alternativeTitles.alternativeTitleTypeId",
+          "description": "Alternative Title id",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "d",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "o",
+            "r",
+            "s",
+            "t"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_alternative_title_type_id",
+                  "parameter": {
+                    "name": "Uniform title"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "alternativeTitles.alternativeTitle",
+          "description": "Alternative Title",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "d",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "o",
+            "r",
+            "s",
+            "t"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "240": [
+    {
+      "entity": [
+        {
+          "target": "alternativeTitles.alternativeTitleTypeId",
+          "description": "Alternative Title id",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "d",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "o",
+            "r",
+            "s"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_alternative_title_type_id",
+                  "parameter": {
+                    "name": "Uniform title"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "alternativeTitles.alternativeTitle",
+          "description": "Alternative Title",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "d",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "o",
+            "r",
+            "s"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "245": [
+    {
+      "target": "title",
+      "description": "Resource Title",
+      "applyRulesOnConcatenatedData": true,
+      "subfield": [
+        "a",
+        "n",
+        "p",
+        "b",
+        "c",
+        "f",
+        "g",
+        "h",
+        "k",
+        "s"
+      ]
+    },
+    {
+      "target": "indexTitle",
+      "description": "Index title",
+      "applyRulesOnConcatenatedData": true,
+      "subfield": [
+        "a",
+        "n",
+        "p",
+        "b"
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_prefix_by_indicator, capitalize"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "246": [
+    {
+      "entity": [
+        {
+          "target": "alternativeTitles.alternativeTitleTypeId",
+          "description": "Alternative Title id",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "b",
+            "f",
+            "g",
+            "h",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_alternative_title_type_id",
+                  "parameter": {
+                    "name": "Variant title"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "alternativeTitles.alternativeTitle",
+          "description": "Alternative Title",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "b",
+            "f",
+            "g",
+            "h",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "247": [
+    {
+      "entity": [
+        {
+          "target": "alternativeTitles.alternativeTitleTypeId",
+          "description": "Alternative Title id",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "b",
+            "f",
+            "g",
+            "h",
+            "x"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_alternative_title_type_id",
+                  "parameter": {
+                    "name": "Former title"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "alternativeTitles.alternativeTitle",
+          "description": "Former title",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "b",
+            "f",
+            "g",
+            "h",
+            "x"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "250": [
+    {
+      "target": "editions",
+      "description": "Edition",
+      "subfield": [
+        "a",
+        "b"
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "255": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Cartographic Mathematical Data"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Cartographic Mathematical Data",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "260": [
+    {
+      "target": "publication.place",
+      "description": "Place of publication",
+      "subfield": [
+        "a"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "a"
+          ]
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "publication.publisher",
+      "subfield": [
+        "b"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "b"
+          ]
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "publication.dateOfPublication",
+      "subfield": [
+        "c"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "c"
+          ]
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim, trim_period"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "264": [
+    {
+      "target": "publication.place",
+      "description": "Place of publication",
+      "subfield": [
+        "a"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "a"
+          ]
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "publication.publisher",
+      "description": "Publisher of publication",
+      "subfield": [
+        "b"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "b"
+          ]
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "publication.dateOfPublication",
+      "description": "Date of publication",
+      "subfield": [
+        "c"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "c"
+          ]
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim, trim_period"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "publication.role",
+      "description": "Role of publication, defined by 2nd indicator",
+      "applyRulesOnConcatenatedData": true,
+      "subfield": [
+        "a",
+        "b",
+        "c"
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "set_publisher_role"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "300": [
+    {
+      "target": "physicalDescriptions",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "e",
+        "f",
+        "g",
+        "3"
+      ]
+    }
+  ],
+  "310": [
+    {
+      "target": "publicationFrequency",
+      "description": "Publication frequency",
+      "applyRulesOnConcatenatedData": true,
+      "subfield": [
+        "a",
+        "b"
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "321": [
+    {
+      "target": "publicationFrequency",
+      "description": "Publication frequency",
+      "applyRulesOnConcatenatedData": true,
+      "subfield": [
+        "a",
+        "b"
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "336": [
+    {
+      "target": "instanceTypeId",
+      "description": "Instance type ID",
+      "ignoreSubsequentFields": true,
+      "ignoreSubsequentSubfields": true,
+      "subfield": [
+        "b"
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "set_instance_type_id",
+              "parameter": {
+                "unspecifiedInstanceTypeCode": "zzz"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "338": [
+    {
+      "target": "instanceFormatIds",
+      "description": "Instance Format ID",
+      "ignoreSubsequentSubfields": true,
+      "subfield": [
+        "b"
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "set_instance_format_id"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "362": [
+    {
+      "target": "publicationRange",
+      "description": "Publication range",
+      "applyRulesOnConcatenatedData": true,
+      "subfield": [
+        "a",
+        "z"
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "500": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "General note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "General Note",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "501": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "With note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "With Note",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "502": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "o"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Dissertation note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Dissertation Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "o"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "o"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "504": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Bibliography note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Bibliography, etc. Note",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "505": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "g",
+            "r",
+            "t",
+            "u"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Formatted Contents Note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Formatted Contents Note",
+          "subfield": [
+            "a",
+            "g",
+            "r",
+            "t",
+            "u"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "g",
+            "r",
+            "t",
+            "u"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "506": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "u",
+            "2",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Restrictions on Access note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Restrictions on Access Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "u",
+            "2",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "u",
+            "2",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "507": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Scale note for graphic material"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Scale Note for Graphic Material",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "508": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Creation / Production Credits note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Creation/Production Credits Note",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "510": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "x",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Citation / References note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Citation/References Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "x",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "x",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "511": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Participant or Performer note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Participant or Performer Note",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "513": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Type of report and period covered note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Type of Report and Period Covered Note",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "514": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "m",
+            "u",
+            "z"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Data quality note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Data Quality Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "m",
+            "u",
+            "z"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "m",
+            "u",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "515": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Numbering peculiarities note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Numbering Peculiarities Note",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "516": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Type of computer file or data note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Type of Computer File or Data Note",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "518": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "d",
+            "o",
+            "p",
+            "2",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Date / time and place of an event note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Date/Time and Place of an Event Note",
+          "subfield": [
+            "a",
+            "d",
+            "o",
+            "p",
+            "2",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "d",
+            "o",
+            "p",
+            "2",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "520": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "2",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Summary"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Summary, Etc.",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "2",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "2",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "521": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Target Audience note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Target Audience Note",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "522": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Geographic Coverage note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Geographic Coverage Note",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "524": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "2",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Preferred Citation of Described Materials note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Preferred Citation of Described Materials Note",
+          "subfield": [
+            "a",
+            "2",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "2",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "525": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Supplement note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Supplement Note",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "526": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "5",
+            "x",
+            "z"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Study Program Information note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Study Program Information Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "5",
+            "x",
+            "z"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "5",
+            "x",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "530": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Additional Physical Form Available note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Additional Physical Form Available Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "532": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Accessibility note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Accessibility note",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "533": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "m",
+            "n",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Reproduction note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Reproduction Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "m",
+            "n",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "m",
+            "n",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "534": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "e",
+            "f",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "t",
+            "x",
+            "z",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Original Version note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Original Version Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "e",
+            "f",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "t",
+            "x",
+            "z",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "e",
+            "f",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "t",
+            "x",
+            "z",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "535": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Location of Originals / Duplicates note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Location of Originals/Duplicates Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "536": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Funding Information Note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Funding Information Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "538": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "System Details note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "System Details Note",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "540": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Terms Governing Use and Reproduction note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Terms Governing Use and Reproduction Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "541": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "n",
+            "o",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Immediate Source of Acquisition note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Immediate Source of Acquisition Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "n",
+            "o",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "n",
+            "o",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "542": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "q",
+            "r",
+            "s",
+            "u",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Information related to Copyright Status"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Information Relating to Copyright Status",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "q",
+            "r",
+            "s",
+            "u",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "q",
+            "r",
+            "s",
+            "u",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "544": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "n",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Location of Other Archival Materials note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Location of Other Archival Materials Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "n",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "n",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "545": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "u"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Biographical or Historical Data"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Biographical or Historical Data",
+          "subfield": [
+            "a",
+            "b",
+            "u"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "u"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "546": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Language note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Language Note",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "547": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Former Title Complexity note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Former Title Complexity Note",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "550": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Issuing Body note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Issuing Body Note",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "552": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "u",
+            "z"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Entity and Attribute Information note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Entity and Attribute Information Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "u",
+            "z"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "u",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "555": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Cumulative Index / Finding Aides notes"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Cumulative Index/Finding Aids Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "556": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "z"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Information About Documentation note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Information About Documentation Note",
+          "subfield": [
+            "a",
+            "z"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "561": [
+    {
+      "target": "notes.instanceNoteTypeId",
+      "description": "Instance note type id",
+      "subfield": [
+        "a",
+        "u",
+        "3",
+        "5"
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "set_note_type_id",
+              "parameter": {
+                "name": "Ownership and Custodial History note"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "entity": [
+        {
+          "target": "notes.note",
+          "description": "Ownership and Custodial History",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "562": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Copy and Version Identification note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Copy and Version Identification Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "563": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Binding Information note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Binding Information",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "565": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Case File Characteristics note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Case File Characteristics Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "567": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "2"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Methodology note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Methodology Note",
+          "subfield": [
+            "a",
+            "b",
+            "2"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "2"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "580": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Linking Entry Complexity note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Linking Entry Complexity Note",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "581": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "z",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Publications About Described Materials note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Publications About Described Materials Note",
+          "subfield": [
+            "a",
+            "z",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "z",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "583": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "n",
+            "o",
+            "u",
+            "x",
+            "z",
+            "2",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Action note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Action Note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "n",
+            "o",
+            "u",
+            "x",
+            "z",
+            "2",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "n",
+            "o",
+            "u",
+            "x",
+            "z",
+            "2",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "584": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "b",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Accumulation and Frequency of Use note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Accumulation and Frequency of Use Note",
+          "subfield": [
+            "a",
+            "b",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "b",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "585": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Exhibitions note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Exhibitions Note",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "586": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Awards note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Awards Note",
+          "subfield": [
+            "a",
+            "3"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "588": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Source of Description note"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Source of Description Note",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "590": [
+    {
+      "entity": [
+        {
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Local notes"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.note",
+          "description": "Local notes",
+          "subfield": [
+            "a"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "notes.staffOnly",
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "600": [
+    {
+      "target": "subjects",
+      "description": "Subject Headings",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "j",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "q",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ",
+          "subfields": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "j",
+            "q",
+            "t",
+            "f",
+            "g",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": [
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": []
+        }
+      ]
+    }
+  ],
+  "610": [
+    {
+      "target": "subjects",
+      "description": "Subject Headings",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ",
+          "subfields": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "t",
+            "f",
+            "g",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "s"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": [
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": []
+        }
+      ]
+    }
+  ],
+  "611": [
+    {
+      "target": "subjects",
+      "description": "Subject Headings",
+      "subfield": [
+        "a",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "j",
+        "k",
+        "l",
+        "n",
+        "p",
+        "q",
+        "s",
+        "t",
+        "u",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ",
+          "subfields": [
+            "a",
+            "c",
+            "d",
+            "e",
+            "q",
+            "t",
+            "f",
+            "g",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": [
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": []
+        }
+      ]
+    }
+  ],
+  "630": [
+    {
+      "target": "subjects",
+      "description": "Subject Headings",
+      "subfield": [
+        "a",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "r",
+        "s",
+        "t",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ",
+          "subfields": [
+            "a",
+            "d",
+            "f",
+            "g",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": [
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": []
+        }
+      ]
+    }
+  ],
+  "647": [
+    {
+      "target": "subjects",
+      "description": "Subject Headings",
+      "subfield": [
+        "x",
+        "y",
+        "z",
+        "v"
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": "--",
+          "subfields": [
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": []
+        }
+      ]
+    }
+  ],
+  "648": [
+    {
+      "target": "subjects",
+      "description": "Subject Headings",
+      "subfield": [
+        "a",
+        "x",
+        "y",
+        "z",
+        "v"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": "--",
+          "subfields": [
+            "a",
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        }
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "650": [
+    {
+      "target": "subjects",
+      "description": "Subject Headings",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "g",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": "--",
+          "subfields": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "g",
+            "v",
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "651": [
+    {
+      "target": "subjects",
+      "description": "Subject Headings",
+      "subfield": [
+        "a",
+        "e",
+        "g",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": "--",
+          "subfields": [
+            "a",
+            "e",
+            "g",
+            "v",
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "655": [
+    {
+      "target": "subjects",
+      "description": "Subject Headings",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": "--",
+          "subfields": [
+            "a",
+            "e",
+            "g",
+            "v",
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "700": [
+    {
+      "entity": [
+        {
+          "target": "contributors.contributorNameTypeId",
+          "description": "Type for Personal Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Personal name"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeId",
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "4"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeText",
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "e"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.primary",
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        },
+        {
+          "target": "contributors.name",
+          "description": "Personal Name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "j",
+            "k",
+            "l",
+            "n",
+            "p",
+            "q",
+            "t",
+            "u"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "710": [
+    {
+      "entity": [
+        {
+          "target": "contributors.contributorNameTypeId",
+          "description": "Type for Corporate Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Corporate name"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeId",
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "4"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeText",
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "e"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.primary",
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        },
+        {
+          "target": "contributors.name",
+          "description": "Corporate Name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "k",
+            "l",
+            "n",
+            "p",
+            "t",
+            "u"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "711": [
+    {
+      "entity": [
+        {
+          "target": "contributors.contributorNameTypeId",
+          "description": "Type for Meeting Name",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Meeting name"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeId",
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "4"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.contributorTypeText",
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "j"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "contributors.primary",
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [],
+              "value": "false"
+            }
+          ]
+        },
+        {
+          "target": "contributors.name",
+          "description": "Meeting Name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "k",
+            "l",
+            "n",
+            "p",
+            "t",
+            "u"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "780": [
+    {
+      "entity": [
+        {
+          "target": "precedingTitles.title",
+          "description": "The primary title (or label) associated with the resource",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "t"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "precedingTitles.isbnId",
+          "description": "Type for Valid ISBN",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "ISBN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "precedingTitles.isbnValue",
+          "description": "Value for Valid ISBN",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "precedingTitles.issnId",
+          "description": "Type for Valid ISSN",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "x"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "ISSN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "precedingTitles.issnValue",
+          "description": "Value for Valid ISSN",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "x"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "785": [
+    {
+      "entity": [
+        {
+          "target": "succeedingTitles.title",
+          "description": "The primary title (or label) associated with the resource",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "t"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "succeedingTitles.isbnId",
+          "description": "Type for Valid ISBN",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "ISBN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "succeedingTitles.isbnValue",
+          "description": "Value for Valid ISBN",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "succeedingTitles.issnId",
+          "description": "Type for Valid ISSN",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "x"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "ISSN"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "succeedingTitles.issnValue",
+          "description": "Value for Valid ISSN",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "x"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "800": [
+    {
+      "target": "series",
+      "description": "Series Statement",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "j",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "q",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "w",
+        "x",
+        "3",
+        "5"
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "810": [
+    {
+      "target": "series",
+      "description": "Series Statement",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "w",
+        "x",
+        "3",
+        "5"
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "811": [
+    {
+      "target": "series",
+      "description": "Series Statement",
+      "subfield": [
+        "a",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "j",
+        "k",
+        "l",
+        "n",
+        "p",
+        "q",
+        "s",
+        "t",
+        "u",
+        "v",
+        "w",
+        "x",
+        "3",
+        "5"
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "830": [
+    {
+      "target": "series",
+      "description": "Series Statement",
+      "subfield": [
+        "a",
+        "d",
+        "f",
+        "g",
+        "h",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "r",
+        "s",
+        "t",
+        "v",
+        "w",
+        "x",
+        "3",
+        "5"
+      ],
+      "applyRulesOnConcatenatedData": true,
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "852": [
+    {
+      "entity": [
+        {
+          "target": "callNumberTypeId",
+          "description": "Call number type, defined by 1st indicator",
+          "subfield": [
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_call_number_type_id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "permanentLocationId",
+          "description": "The permanent shelving location",
+          "subfield": [
+            "b"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_permanent_location_id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "callNumber",
+          "applyRulesOnConcatenatedData": true,
+          "description": "Call Number identifier",
+          "subfield": [
+            "h",
+            "i"
+          ],
+          "subFieldDelimiter": [
+            {
+              "value": " ",
+              "subfields": [
+                "h",
+                "i"
+              ]
+            }
+          ]
+        },
+        {
+          "target": "callNumberPrefix",
+          "description": "Prefix of the call number",
+          "subfield": [
+            "k"
+          ]
+        },
+        {
+          "target": "shelvingTitle",
+          "description": "Shelving form of title",
+          "subfield": [
+            "l"
+          ]
+        },
+        {
+          "target": "callNumberSuffix",
+          "description": "Suffix of the call number",
+          "subfield": [
+            "m"
+          ]
+        },
+        {
+          "target": "copyNumber",
+          "description": "Range of numbers for copies that have the same location",
+          "subfield": [
+            "t"
+          ]
+        }
+      ]
+    }
+  ],
+  "856": [
+    {
+      "entity": [
+        {
+          "target": "electronicAccess.relationshipId",
+          "applyRulesOnConcatenatedData": true,
+          "description": "Relationship between the electronic resource at the location identified and the item described in the record as a whole",
+          "subfield": [
+            "3",
+            "y",
+            "u",
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_electronic_access_relations_id"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "electronicAccess.uri",
+          "description": "URI",
+          "subfield": [
+            "u"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "electronicAccess.linkText",
+          "description": "Link text",
+          "subfield": [
+            "y"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "electronicAccess.materialsSpecification",
+          "description": "Materials Specified",
+          "subfield": [
+            "3"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "electronicAccess.publicNote",
+          "description": "URL public note",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/marc/parsed-holdings-record.json
+++ b/src/test/resources/marc/parsed-holdings-record.json
@@ -1,0 +1,953 @@
+{
+  "leader": "01240uvs a2200397   4500",
+  "fields": [
+    {
+      "001": "366832"
+    },
+    {
+      "004": "in00000000315"
+    },
+    {
+      "005": "20141106221425.0"
+    },
+    {
+      "008": "750907c19509999enkqr p       0   a0eng d"
+    },
+    {
+      "010": {
+        "subfields": [
+          {
+            "a": "   58020553 "
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "022": {
+        "subfields": [
+          {
+            "a": "0022-0469"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "035": {
+        "subfields": [
+          {
+            "a": "(CStRLIN)NYCX1604275S"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "035": {
+        "subfields": [
+          {
+            "a": "(NIC)notisABP6388"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "035": {
+        "subfields": [
+          {
+            "a": "366832"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "035": {
+        "subfields": [
+          {
+            "a": "(OCoLC)1604275"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "040": {
+        "subfields": [
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "NIC"
+          },
+          {
+            "d": "CStRLIN"
+          },
+          {
+            "d": "NIC"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "050": {
+        "subfields": [
+          {
+            "a": "BR140"
+          },
+          {
+            "b": ".J6"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "082": {
+        "subfields": [
+          {
+            "a": "270.05"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "222": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "245": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history."
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "260": {
+        "subfields": [
+          {
+            "a": "London,"
+          },
+          {
+            "b": "Cambridge University Press [etc.]"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "265": {
+        "subfields": [
+          {
+            "a": "32 East 57th St., New York, 10022"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "300": {
+        "subfields": [
+          {
+            "a": "v."
+          },
+          {
+            "b": "25 cm."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "310": {
+        "subfields": [
+          {
+            "a": "Quarterly,"
+          },
+          {
+            "b": "1970-"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "321": {
+        "subfields": [
+          {
+            "a": "Semiannual,"
+          },
+          {
+            "b": "1950-69"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "362": {
+        "subfields": [
+          {
+            "a": "v. 1-   Apr. 1950-"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "561": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "562": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "583": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "f": "note$f"
+          },
+          {
+            "h": "note$h"
+          },
+          {
+            "i": "note$i"
+          },
+          {
+            "j": "note$j"
+          },
+          {
+            "k": "note$k"
+          },
+          {
+            "l": "note$l"
+          },
+          {
+            "n": "note$n"
+          },
+          {
+            "o": "note$o"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "x": "note$x"
+          },
+          {
+            "z": "note$z"
+          },
+          {
+            "2": "note$2"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "570": {
+        "subfields": [
+          {
+            "a": "Editor:   C. W. Dugmore."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "650": {
+        "subfields": [
+          {
+            "a": "Church history"
+          },
+          {
+            "x": "Periodicals."
+          }
+        ],
+        "ind1": " ",
+        "ind2": "0"
+      }
+    },
+    {
+      "650": {
+        "subfields": [
+          {
+            "a": "Church history"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst00860740"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "655": {
+        "subfields": [
+          {
+            "a": "Periodicals"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst01411641"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "700": {
+        "subfields": [
+          {
+            "a": "Dugmore, C. W."
+          },
+          {
+            "q": "(Clifford William),"
+          },
+          {
+            "e": "ed."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "582": {
+        "subfields": [
+          {
+            "k": "callNumberPrefix"
+          },
+          {
+            "h": "callNumber1"
+          },
+          {
+            "i": "callNumber2"
+          },
+          {
+            "m": "callNumberSuffix"
+          },
+          {
+            "t": "copyNumber"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "856": {
+        "subfields": [
+          {
+            "u": "uri"
+          },
+          {
+            "y": "linkText"
+          },
+          {
+            "3": "materialsSpecification"
+          },
+          {
+            "z": "publicNote"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "863": {
+        "subfields": [
+          {
+            "8": "1"
+          },
+          {
+            "a": "1-49"
+          },
+          {
+            "i": "1950-1998"
+          }
+        ],
+        "ind1": "4",
+        "ind2": "0"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "a": "holdingsStatements.statement"
+          },
+          {
+            "z": "holdingsStatements.note"
+          },
+          {
+            "x": "holdingsStatements.staffNote"
+          }
+        ],
+        "ind1": "4",
+        "ind2": "0"
+      }
+    },
+    {
+      "867": {
+        "subfields": [
+          {
+            "a": "holdingsStatementsForSupplements.statement"
+          },
+          {
+            "z": "holdingsStatementsForSupplements.note"
+          },
+          {
+            "x": "holdingsStatementsForSupplements.staffNote"
+          }
+        ],
+        "ind1": "4",
+        "ind2": "0"
+      }
+    },
+    {
+      "868": {
+        "subfields": [
+          {
+            "a": "holdingsStatementsForIndexes.statement"
+          },
+          {
+            "z": "holdingsStatementsForIndexes.note"
+          },
+          {
+            "x": "holdingsStatementsForIndexes.staffNote"
+          }
+        ],
+        "ind1": "4",
+        "ind2": "0"
+      }
+    },
+    {
+      "902": {
+        "subfields": [
+          {
+            "a": "pfnd"
+          },
+          {
+            "b": "Lintz"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "905": {
+        "subfields": [
+          {
+            "a": "19890510120000.0"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "948": {
+        "subfields": [
+          {
+            "a": "20141106"
+          },
+          {
+            "b": "m"
+          },
+          {
+            "d": "batch"
+          },
+          {
+            "e": "lts"
+          },
+          {
+            "x": "addfast"
+          }
+        ],
+        "ind1": "2",
+        "ind2": " "
+      }
+    },
+    {
+      "950": {
+        "subfields": [
+          {
+            "l": "OLIN"
+          },
+          {
+            "a": "BR140"
+          },
+          {
+            "b": ".J86"
+          },
+          {
+            "h": "01/01/01 N"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "852": {
+        "subfields": [
+          {
+            "b": "0f45d01d-db73-4c4f-89b0-82c5b56533e6"
+          },
+          {
+            "t": "3"
+          },
+          {
+            "h": "M3"
+          },
+          {
+            "i": ".M93 1955"
+          },
+          {
+            "m": "+"
+          },
+          {
+            "x": "Rec'd in Music Lib ; Earlier vols. were pd by Mrs. Bueding; ck in Kritische Berichte on H1185407 and its check-in; Each v. to be plated \"From the library of Dr. Ernest Bueding\"; *** Ser.1 wkg.2/1; Ser.1 wkg.1/3,5 : PA; ***Ser.1 Wkg.1 Bd.4 & Bd.6 do not exist.; ***Ser.10 Wkg.32 OP--we have it in c.1 & c.2 sets;"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.1:grp.1:abt.1:v.1-6; ser.1:grp.1:abt.2:v.1-2;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.1:grp.2:v.1-2; ser.1:grp.3; ser.1:grp.4:v.1-4;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.2:grp.5:v.1-20;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.2:grp.6:v.1-2; ser.2:grp.7:v.1-4;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.3:grp.8-10;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.4:grp.11:v.1-10; ser.4:grp.12:v.1-6;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.4:grp.13:abt.1:v.1; ser.4:grp.13:abt.2;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.5:grp.14:v.1-6; ser.5:grp.15:v.1-8; ser.6:grp.16;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.7:grp.17:v.1-2; ser.7:grp.18;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.8:grp.19:abt.1-2; ser.8:grp.20:abt.1:v.1-3;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.8:grp.20:abt.2; ser.8:grp.21;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.8:grp.22:abt.1-2; ser.8:grp.23:v.1-2;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.9:grp.24:abt.1-2; ser.9:grp.25:v.1-2;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.9:v.26; ser.9:grp.27:v.1-2;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.10:grp.28:abt.1:v.1-4; ser.10:grp.28:abt.2;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.10:grp.28:abt.3/5:v.1; ser.10:grp.28:abt.3/5:v.1a;10:grp.28:abt.3/5:v.2-3"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.10:grp.29:v.1-3; ser.10:grp.30:v.1-2,4;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.10:grp.31:v.1-3;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.10:grp.33:abt.1-2; ser.10:grp.34;"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "866": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "(1955-2010)"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "867": {
+        "subfields": [
+          {
+            "8": "0"
+          },
+          {
+            "a": "ser.10:grp.31:vorabdruck"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "999": {
+        "ind1": "f",
+        "ind2": "f",
+        "subfields": [
+          {
+            "s": "b90cb1bc-601f-45d7-b99e-b11efd281dcd",
+            "i": "957985c6-97e3-4038-b0e7-343ecd0b8120"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
We need to make mod-inventory to generate Holdings from incoming SRS Marc Holdings

## Approach
- created handler for populating instance id and storing holdings in the mod-inventory-storage
- throws DI_INVENTORY_HOLDINGS_CREATED_READY_FOR_POST_PROCESSING, prepare event payload for post-processing
- generated Holdings using the corresponding Processor from data-import-processing-core

## Learning
https://issues.folio.org/browse/MODINV-483

