### PR TITLE
Added missing permission to `/inventory/instances/{id}` to `modulePer…

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -358,7 +358,8 @@
             "inventory-storage.instances.item.get",
             "inventory-storage.preceding-succeeding-titles.collection.get",
             "inventory-storage.instance-relationships.collection.get",
-            "inventory-storage.bound-with-parts.collection.get"
+            "inventory-storage.bound-with-parts.collection.get",
+            "inventory-storage.holdings.collection.get"
           ]
         }, {
           "methods": ["POST"],


### PR DESCRIPTION
Resolves [MODINV-492](https://issues.folio.org/browse/MODINV-492) by adding `inventory-storage.holdings.collection.get` to the `modulePersions` of `/inventory/instances/{id}`.