### PR TITLE
Update data-import-processing-core to v3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-source-record-storage-client</artifactId>
-      <version>5.2.0-SNAPSHOT</version>
+      <version>5.2.0</version>
       <type>jar</type>
       <exclusions>
         <!-- This is provided by JDK >= 9 causing a compile error (Eclipse doesn't suppress this compile error):


### PR DESCRIPTION
data-import-processing-core v3.2.0 was released, the development version 3.2.0-SNAPSHOT is no longer relevant and will be deleted from nexus repository