### PR TITLE
MODINV-504 - Updated authority schema according to the new mapping rules

### DIFF
--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -3,10 +3,14 @@
   "description": "An authority record",
   "type": "object",
   "properties": {
-    "uuid": {
+    "id": {
       "type": "string",
       "description": "Authority UUID",
       "$ref": "uuid.json"
+    },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
     },
     "personalName": {
       "type": "string",

--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "An authority record",
+  "type": "object",
+  "properties": {
+    "uuid": {
+      "type": "string",
+      "description": "Authority UUID, comes from 999 field",
+      "$ref": "uuid.json"
+    },
+    "hPersonalName": {
+      "type": "string",
+      "description": "HEADING PERSONAL NAME, comes from 100 field"
+    },
+    "sftPersonalName": {
+      "type": "array",
+      "description": "SEE FROM TRACING PERSONAL NAME, comes from 400 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftPersonalName": {
+      "type": "array",
+      "description": "SEE ALSO FROM TRACING PERSONAL NAME, comes from 500 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hCorporateName": {
+      "type": "string",
+      "description": "HEADING CORPORATE NAME, comes from 110 field"
+    },
+    "sftCorporateName": {
+      "type": "array",
+      "description": "SEE FROM TRACING CORPORATE NAME, comes from 410 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftCorporateName": {
+      "type": "array",
+      "description": "SEE ALSO FROM TRACING CORPORATE NAME, comes from 510 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hMeetingName": {
+      "type": "array",
+      "description": "HEADING MEETING NAME, comes from 111 field"
+    },
+    "sftMeetingName": {
+      "type": "array",
+      "description": "SEE FROM TRACING MEETING NAME, comes from 411 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftMeetingName": {
+      "type": "array",
+      "description": "SEE ALSO FROM TRACING MEETING NAME, comes from 511 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hUniformTitle": {
+      "type": "string",
+      "description": "HEADING UNIFORM TITLE, comes from 130 field"
+    },
+    "sftUniformTitle": {
+      "type": "array",
+      "description": "SEE FROM TRACING UNIFORM TITLE, comes from 430 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftUniformTitle": {
+      "type": "array",
+      "description": "SEE ALSO FROM TRACING UNIFORM TITLE, comes from 530 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hTopicalTerm": {
+      "type": "string",
+      "description": "HEADING TOPICAL TERM, comes from 150 field"
+    },
+    "sftTopicalTerm": {
+      "type": "array",
+      "description": "SEE FROM TRACING TOPICAL TERM, comes from 450 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftTopicalTerm": {
+      "type": "array",
+      "description": "SEE ALSO FROM TRACING TOPICAL TERM, comes from 550 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "cSubjectHeadings": {
+      "type": "string",
+      "description": "CHILDREN'S SUBJECT HEADINGS"
+    },
+    "hGeographicName": {
+      "type": "string",
+      "description": "HEADING GEOGRAPHIC NAME, comes from 151 field"
+    },
+    "sftGeographicTerm": {
+      "type": "array",
+      "description": "SEE FROM TRACING GEOGRAPHIC NAME, comes from 451 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftGeographicTerm": {
+      "type": "array",
+      "description": "SEE ALSO FROM TRACING GEOGRAPHIC NAME, comes from 551 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hGenreTerm": {
+      "type": "string",
+      "description": "HEADING GENRE/FORM TERM, comes from 155 field"
+    },
+    "sftGenreTerm": {
+      "type": "array",
+      "description": "SEE FROM TRACING GENRE/FORM TERM, comes from 455 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftGenreTerm": {
+      "type": "array",
+      "description": "SEE AlSO FROM TRACING GENRE/FORM TERM, comes from 555 field",
+      "items": {
+        "type": "string"
+      }
+    },
+    "identifiers": {
+      "type": "object",
+      "description": "Identifiers",
+      "properties": {
+        "controlNumber": {
+          "type": "string",
+          "description": "CONTROL NUMBER, comes from 001 field"
+        },
+        "lcControlNumber": {
+          "type": "string",
+          "description": "LIBRARY OF CONGRESS CONTROL NUMBER, comes from 010 field"
+        },
+        "oStandardIdentifier": {
+          "type": "array",
+          "description": "OTHER STANDARD IDENTIFIER, comes from 024 field",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sControlNumber": {
+          "type": "array",
+          "description": "SYSTEM CONTROL NUMBER, comes from 035 field",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "notes": {
+      "type": "array",
+      "description": "NONPUBLIC GENERAL NOTE, comes from 667 field",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -181,39 +181,50 @@
       }
     },
     "identifiers": {
-      "type": "object",
-      "description": "Identifiers",
-      "properties": {
-        "controlNumber": {
-          "type": "string",
-          "description": "Control number identifier"
-        },
-        "lcControlNumber": {
-          "type": "string",
-          "description": "Library of Congress control number identifier"
-        },
-        "oStandardIdentifier": {
-          "type": "array",
-          "description": "Other standard identifier",
-          "items": {
-            "type": "string"
+      "type": "array",
+      "description": "An extensible set of name-value pairs of identifiers associated with the resource",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "Resource identifier value"
+          },
+          "identifierTypeId": {
+            "type": "string",
+            "description": "Resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers)",
+            "$ref": "uuid.json"
           }
         },
-        "sControlNumber": {
-          "type": "array",
-          "description": "System control number",
-          "items": {
-            "type": "string"
-          }
-        }
+        "additionalProperties": false,
+        "required": [
+          "value",
+          "identifierTypeId"
+        ]
       }
     },
     "notes": {
       "type": "array",
-      "description": "Nonpublic general note",
+      "description": "Bibliographic notes (e.g. general notes, specialized notes), and administrative notes",
       "items": {
-        "type": "string"
+        "type": "object",
+        "properties": {
+          "noteTypeId": {
+            "description": "ID of the type of note",
+            "$ref": "uuid.json"
+          },
+          "note": {
+            "type": "string",
+            "description": "Text content of the note"
+          }
+        }
       }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Creater, updater, creation date, last updated date",
+      "$ref": "./raml-util/schemas/metadata.schema"
     }
   }
 }

--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -9,151 +9,115 @@
       "$ref": "uuid.json"
     },
     "personalName": {
-      "type": "object",
-      "description": "Personal name",
-      "properties": {
-        "hPersonalName": {
-          "type": "string",
-          "description": "Heading personal name"
-        },
-        "sftPersonalName": {
-          "type": "array",
-          "description": "See from tracing personal name",
-          "items": {
-            "type": "string"
-          }
-        },
-        "saftPersonalName": {
-          "type": "array",
-          "description": "See also from tracing personal name",
-          "items": {
-            "type": "string"
-          }
-        }
+      "type": "string",
+      "description": "Heading personal name"
+    },
+    "sftPersonalName": {
+      "type": "array",
+      "description": "See from tracing personal name",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftPersonalName": {
+      "type": "array",
+      "description": "See also from tracing personal name",
+      "items": {
+        "type": "string"
       }
     },
     "corporateName": {
-      "type": "object",
-      "description": "Corporate name",
-      "properties": {
-        "hCorporateName": {
-          "type": "string",
-          "description": "Heading corporate name"
-        },
-        "sftCorporateName": {
-          "type": "array",
-          "description": "See from tracing corporate name",
-          "items": {
-            "type": "string"
-          }
-        },
-        "saftCorporateName": {
-          "type": "array",
-          "description": "See also from tracing corporate name",
-          "items": {
-            "type": "string"
-          }
-        }
+      "type": "string",
+      "description": "Heading corporate name"
+    },
+    "sftCorporateName": {
+      "type": "array",
+      "description": "See from tracing corporate name",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftCorporateName": {
+      "type": "array",
+      "description": "See also from tracing corporate name",
+      "items": {
+        "type": "string"
       }
     },
     "meetingName": {
-      "type": "object",
-      "description": "Meeting name",
-      "properties": {
-        "hMeetingName": {
-          "type": "array",
-          "description": "Heading meeting name"
-        },
-        "sftMeetingName": {
-          "type": "array",
-          "description": "See from tracing meeting name",
-          "items": {
-            "type": "string"
-          }
-        },
-        "saftMeetingName": {
-          "type": "array",
-          "description": "See also from tracing meeting name",
-          "items": {
-            "type": "string"
-          }
-        }
+      "type": "array",
+      "description": "Heading meeting name"
+    },
+    "sftMeetingName": {
+      "type": "array",
+      "description": "See from tracing meeting name",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftMeetingName": {
+      "type": "array",
+      "description": "See also from tracing meeting name",
+      "items": {
+        "type": "string"
       }
     },
     "uniformTitle": {
-      "type": "object",
-      "description": "Uniform title",
-      "properties": {
-        "hUniformTitle": {
-          "type": "string",
-          "description": "Heading uniform title"
-        },
-        "sftUniformTitle": {
-          "type": "array",
-          "description": "See from tracing uniform title",
-          "items": {
-            "type": "string"
-          }
-        },
-        "saftUniformTitle": {
-          "type": "array",
-          "description": "See also from tracing uniform title",
-          "items": {
-            "type": "string"
-          }
-        }
+      "type": "string",
+      "description": "Heading uniform title"
+    },
+    "sftUniformTitle": {
+      "type": "array",
+      "description": "See from tracing uniform title",
+      "items": {
+        "type": "string"
       }
     },
-    "subject": {
-      "type": "object",
-      "description": "Subject",
-      "properties": {
-        "hTopicalTerm": {
-          "type": "string",
-          "description": "Heading topical term"
-        },
-        "sftTopicalTerm": {
-          "type": "array",
-          "description": "See from tracing topical term",
-          "items": {
-            "type": "string"
-          }
-        },
-        "saftTopicalTerm": {
-          "type": "array",
-          "description": "See also from tracing topical term",
-          "items": {
-            "type": "string"
-          }
-        }
+    "saftUniformTitle": {
+      "type": "array",
+      "description": "See also from tracing uniform title",
+      "items": {
+        "type": "string"
+      }
+    },
+    "topicalTerm": {
+      "type": "string",
+      "description": "Heading topical term"
+    },
+    "sftTopicalTerm": {
+      "type": "array",
+      "description": "See from tracing topical term",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftTopicalTerm": {
+      "type": "array",
+      "description": "See also from tracing topical term",
+      "items": {
+        "type": "string"
       }
     },
     "subjectHeadings": {
       "type": "string",
       "description": "Children's subject headings"
     },
-    "geographicPlace": {
-      "type": "object",
-      "description": "Geographic place",
-      "properties": {
-        "hGeographicName": {
-          "type": "string",
-          "description": "Heading geographic name"
-        },
-        "sftGeographicTerm": {
-          "type": "array",
-          "description": "See from tracing geographic name",
-          "items": {
-            "type": "string"
-          }
-        },
-        "saftGeographicTerm": {
-          "type": "array",
-          "description": "See also from tracing geographic name",
-          "items": {
-            "type": "string"
-          }
-        }
+    "geographicName": {
+      "type": "string",
+      "description": "Heading geographic name"
+    },
+    "sftGeographicTerm": {
+      "type": "array",
+      "description": "See from tracing geographic name",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftGeographicTerm": {
+      "type": "array",
+      "description": "See also from tracing geographic name",
+      "items": {
+        "type": "string"
       }
     },
     "genre": {

--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -183,7 +183,6 @@
     "identifiers": {
       "type": "array",
       "description": "An extensible set of name-value pairs of identifiers associated with the resource",
-      "minItems": 0,
       "items": {
         "type": "object",
         "properties": {
@@ -193,7 +192,7 @@
           },
           "identifierTypeId": {
             "type": "string",
-            "description": "Resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers)",
+            "description": "Resource identifier type (e.g. Control number, LCCN, Other standard identifier, System control number)",
             "$ref": "uuid.json"
           }
         },
@@ -205,7 +204,7 @@
     },
     "notes": {
       "type": "array",
-      "description": "Bibliographic notes (e.g. general notes, specialized notes), and administrative notes",
+      "description": "Notes (e.g. nonpublic general note)",
       "items": {
         "type": "object",
         "properties": {

--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -197,7 +197,6 @@
             "$ref": "uuid.json"
           }
         },
-        "additionalProperties": false,
         "required": [
           "value",
           "identifierTypeId"
@@ -218,7 +217,11 @@
             "type": "string",
             "description": "Text content of the note"
           }
-        }
+        },
+        "required": [
+          "note",
+          "noteTypeId"
+        ]
       }
     },
     "metadata": {

--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -104,9 +104,9 @@
         }
       }
     },
-    "topicalTerm": {
+    "subject": {
       "type": "object",
-      "description": "Topical term",
+      "description": "Subject",
       "properties": {
         "hTopicalTerm": {
           "type": "string",
@@ -132,9 +132,9 @@
       "type": "string",
       "description": "Children's subject headings"
     },
-    "geographicName": {
+    "geographicPlace": {
       "type": "object",
-      "description": "Geographic name",
+      "description": "Geographic place",
       "properties": {
         "hGeographicName": {
           "type": "string",
@@ -156,7 +156,7 @@
         }
       }
     },
-    "genreTerm": {
+    "genre": {
       "type": "object",
       "description": "Genre/form term",
       "properties": {

--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -5,137 +5,179 @@
   "properties": {
     "uuid": {
       "type": "string",
-      "description": "Authority UUID, comes from 999 field",
+      "description": "Authority UUID",
       "$ref": "uuid.json"
     },
-    "hPersonalName": {
+    "personalName": {
+      "type": "object",
+      "description": "Personal name",
+      "properties": {
+        "hPersonalName": {
+          "type": "string",
+          "description": "Heading personal name"
+        },
+        "sftPersonalName": {
+          "type": "array",
+          "description": "See from tracing personal name",
+          "items": {
+            "type": "string"
+          }
+        },
+        "saftPersonalName": {
+          "type": "array",
+          "description": "See also from tracing personal name",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "corporateName": {
+      "type": "object",
+      "description": "Corporate name",
+      "properties": {
+        "hCorporateName": {
+          "type": "string",
+          "description": "Heading corporate name"
+        },
+        "sftCorporateName": {
+          "type": "array",
+          "description": "See from tracing corporate name",
+          "items": {
+            "type": "string"
+          }
+        },
+        "saftCorporateName": {
+          "type": "array",
+          "description": "See also from tracing corporate name",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "meetingName": {
+      "type": "object",
+      "description": "Meeting name",
+      "properties": {
+        "hMeetingName": {
+          "type": "array",
+          "description": "Heading meeting name"
+        },
+        "sftMeetingName": {
+          "type": "array",
+          "description": "See from tracing meeting name",
+          "items": {
+            "type": "string"
+          }
+        },
+        "saftMeetingName": {
+          "type": "array",
+          "description": "See also from tracing meeting name",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "uniformTitle": {
+      "type": "object",
+      "description": "Uniform title",
+      "properties": {
+        "hUniformTitle": {
+          "type": "string",
+          "description": "Heading uniform title"
+        },
+        "sftUniformTitle": {
+          "type": "array",
+          "description": "See from tracing uniform title",
+          "items": {
+            "type": "string"
+          }
+        },
+        "saftUniformTitle": {
+          "type": "array",
+          "description": "See also from tracing uniform title",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "topicalTerm": {
+      "type": "object",
+      "description": "Topical term",
+      "properties": {
+        "hTopicalTerm": {
+          "type": "string",
+          "description": "Heading topical term"
+        },
+        "sftTopicalTerm": {
+          "type": "array",
+          "description": "See from tracing topical term",
+          "items": {
+            "type": "string"
+          }
+        },
+        "saftTopicalTerm": {
+          "type": "array",
+          "description": "See also from tracing topical term",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "subjectHeadings": {
       "type": "string",
-      "description": "HEADING PERSONAL NAME, comes from 100 field"
+      "description": "Children's subject headings"
     },
-    "sftPersonalName": {
-      "type": "array",
-      "description": "SEE FROM TRACING PERSONAL NAME, comes from 400 field",
-      "items": {
-        "type": "string"
+    "geographicName": {
+      "type": "object",
+      "description": "Geographic name",
+      "properties": {
+        "hGeographicName": {
+          "type": "string",
+          "description": "Heading geographic name"
+        },
+        "sftGeographicTerm": {
+          "type": "array",
+          "description": "See from tracing geographic name",
+          "items": {
+            "type": "string"
+          }
+        },
+        "saftGeographicTerm": {
+          "type": "array",
+          "description": "See also from tracing geographic name",
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
-    "saftPersonalName": {
-      "type": "array",
-      "description": "SEE ALSO FROM TRACING PERSONAL NAME, comes from 500 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "hCorporateName": {
-      "type": "string",
-      "description": "HEADING CORPORATE NAME, comes from 110 field"
-    },
-    "sftCorporateName": {
-      "type": "array",
-      "description": "SEE FROM TRACING CORPORATE NAME, comes from 410 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "saftCorporateName": {
-      "type": "array",
-      "description": "SEE ALSO FROM TRACING CORPORATE NAME, comes from 510 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "hMeetingName": {
-      "type": "array",
-      "description": "HEADING MEETING NAME, comes from 111 field"
-    },
-    "sftMeetingName": {
-      "type": "array",
-      "description": "SEE FROM TRACING MEETING NAME, comes from 411 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "saftMeetingName": {
-      "type": "array",
-      "description": "SEE ALSO FROM TRACING MEETING NAME, comes from 511 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "hUniformTitle": {
-      "type": "string",
-      "description": "HEADING UNIFORM TITLE, comes from 130 field"
-    },
-    "sftUniformTitle": {
-      "type": "array",
-      "description": "SEE FROM TRACING UNIFORM TITLE, comes from 430 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "saftUniformTitle": {
-      "type": "array",
-      "description": "SEE ALSO FROM TRACING UNIFORM TITLE, comes from 530 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "hTopicalTerm": {
-      "type": "string",
-      "description": "HEADING TOPICAL TERM, comes from 150 field"
-    },
-    "sftTopicalTerm": {
-      "type": "array",
-      "description": "SEE FROM TRACING TOPICAL TERM, comes from 450 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "saftTopicalTerm": {
-      "type": "array",
-      "description": "SEE ALSO FROM TRACING TOPICAL TERM, comes from 550 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "cSubjectHeadings": {
-      "type": "string",
-      "description": "CHILDREN'S SUBJECT HEADINGS"
-    },
-    "hGeographicName": {
-      "type": "string",
-      "description": "HEADING GEOGRAPHIC NAME, comes from 151 field"
-    },
-    "sftGeographicTerm": {
-      "type": "array",
-      "description": "SEE FROM TRACING GEOGRAPHIC NAME, comes from 451 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "saftGeographicTerm": {
-      "type": "array",
-      "description": "SEE ALSO FROM TRACING GEOGRAPHIC NAME, comes from 551 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "hGenreTerm": {
-      "type": "string",
-      "description": "HEADING GENRE/FORM TERM, comes from 155 field"
-    },
-    "sftGenreTerm": {
-      "type": "array",
-      "description": "SEE FROM TRACING GENRE/FORM TERM, comes from 455 field",
-      "items": {
-        "type": "string"
-      }
-    },
-    "saftGenreTerm": {
-      "type": "array",
-      "description": "SEE AlSO FROM TRACING GENRE/FORM TERM, comes from 555 field",
-      "items": {
-        "type": "string"
+    "genreTerm": {
+      "type": "object",
+      "description": "Genre/form term",
+      "properties": {
+        "hGenreTerm": {
+          "type": "string",
+          "description": "Heading genre/form term"
+        },
+        "sftGenreTerm": {
+          "type": "array",
+          "description": "See from tracing genre/form term",
+          "items": {
+            "type": "string"
+          }
+        },
+        "saftGenreTerm": {
+          "type": "array",
+          "description": "See also from tracing genre/form term",
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
     "identifiers": {
@@ -144,22 +186,22 @@
       "properties": {
         "controlNumber": {
           "type": "string",
-          "description": "CONTROL NUMBER, comes from 001 field"
+          "description": "Control number identifier"
         },
         "lcControlNumber": {
           "type": "string",
-          "description": "LIBRARY OF CONGRESS CONTROL NUMBER, comes from 010 field"
+          "description": "Library of Congress control number identifier"
         },
         "oStandardIdentifier": {
           "type": "array",
-          "description": "OTHER STANDARD IDENTIFIER, comes from 024 field",
+          "description": "Other standard identifier",
           "items": {
             "type": "string"
           }
         },
         "sControlNumber": {
           "type": "array",
-          "description": "SYSTEM CONTROL NUMBER, comes from 035 field",
+          "description": "System control number",
           "items": {
             "type": "string"
           }
@@ -168,7 +210,7 @@
     },
     "notes": {
       "type": "array",
-      "description": "NONPUBLIC GENERAL NOTE, comes from 667 field",
+      "description": "Nonpublic general note",
       "items": {
         "type": "string"
       }

--- a/ramls/samples/authority.sample
+++ b/ramls/samples/authority.sample
@@ -1,85 +1,71 @@
 {
    "uuid":"5f671674-229a-48e9-804e-d2814cddd321",
-   "personalName":{
-      "hPersonalName":"Twain, Mark, 1835-1910",
-      "sftPersonalName":[
-         "Tuėĭn, Mark, 1835-1910",
-         "Tuwayn, Mārk, 1835-1910",
-         "Tʻu-wen, Ma-kʻo, 1835-1910",
-         "Твен, Марк, 1835-1910"
-      ],
-      "saftPersonalName":[
-         "nnn, Clemens, Samuel Langhorne, 1835-1910",
-         "nnn, Snodgrass, Quintus Curtius, 1835-1910"
-      ]
-   },
-   "corporateName":{
-      "hCorporateName":"International Business Machines Corporation",
-      "sftCorporateName":[
-         "Oklahoma. Council on Juvenile Delinquency",
-         "Oklahoma. Oklahoma Council on Juvenile Delinquency"
-      ],
-      "saftCorporateName":[
-         "Oklahoma Council on Juvenile Delinquency Planning",
-         "Oklahoma Council on Juvenile Justice"
-      ]
-   },
-   "meetingName":{
-      "hMeetingName":"Olympic Winter Games (21st : 2010 : Vancouver, B.C.)",
-      "sftMeetingName":[
-         "Vancouver Winter Games (2010 : Vancouver, B.C.)"
-      ],
-      "saftMeetingName":[
+   "personalName":"Twain, Mark, 1835-1910",
+   "sftPersonalName":[
+      "Tuėĭn, Mark, 1835-1910",
+      "Tuwayn, Mārk, 1835-1910",
+      "Tʻu-wen, Ma-kʻo, 1835-1910",
+      "Твен, Марк, 1835-1910"
+   ],
+   "saftPersonalName":[
+      "nnn, Clemens, Samuel Langhorne, 1835-1910",
+      "nnn, Snodgrass, Quintus Curtius, 1835-1910"
+   ],
+   "corporateName":"International Business Machines Corporation",
+   "sftCorporateName":[
+      "Oklahoma. Council on Juvenile Delinquency",
+      "Oklahoma. Oklahoma Council on Juvenile Delinquency"
+   ],
+   "saftCorporateName":[
+      "Oklahoma Council on Juvenile Delinquency Planning",
+      "Oklahoma Council on Juvenile Justice"
+   ],
+   "meetingName":"Olympic Winter Games (21st : 2010 : Vancouver, B.C.)",
+   "sftMeetingName":[
+      "Vancouver Winter Games (2010 : Vancouver, B.C.)"
+   ],
+   "saftMeetingName":[
 
-      ]
-   },
-   "uniformTitle":{
-      "hUniformTitle":"Monograph (Institute of Applied Social and Economic Research)",
-      "sftUniformTitle":[
-         "Monographs (Institute of Applied Social and Economic Research)",
-         "Monograph series (Institute of Applied Social and Economic Research)",
-         "IASER monograph"
-      ],
-      "saftUniformTitle":[
-         "Continues (work): New Guinea research bulletin",
-         "Continued by (work): Monograph (National Research Institute (Papua New Guinea))"
-      ]
-   },
-   "subject":{
-      "hTopicalTerm":"Optical disks",
-      "sftTopicalTerm":[
-         "Discs, Optical",
-         "Optical discs",
-         "Laser discs",
-         "Laser disks",
-         "Laserdiscs",
-         "Laserdisks"
-      ],
-      "saftTopicalTerm":[
-         "Optical storage devices"
-      ]
-   },
+   ],
+   "uniformTitle":"Monograph (Institute of Applied Social and Economic Research)",
+   "sftUniformTitle":[
+      "Monographs (Institute of Applied Social and Economic Research)",
+      "Monograph series (Institute of Applied Social and Economic Research)",
+      "IASER monograph"
+   ],
+   "saftUniformTitle":[
+      "Continues (work): New Guinea research bulletin",
+      "Continued by (work): Monograph (National Research Institute (Papua New Guinea))"
+   ],
+   "topicalTerm":"Optical disks",
+   "sftTopicalTerm":[
+      "Discs, Optical",
+      "Optical discs",
+      "Laser discs",
+      "Laser disks",
+      "Laserdiscs",
+      "Laserdisks"
+   ],
+   "saftTopicalTerm":[
+      "Optical storage devices"
+   ],
    "subjectHeadings":"z",
-   "geographicPlace":{
-      "hGeographicName":"Great Lakes",
-      "sftGeographicName":[
-         "Great Lakes",
-         "Lakes Great",
-         "Regions of the United States"
-      ],
-      "saftGeographicName":[
-         "Superior, Michigan, Huron, Erie, and Ontario"
-      ]
-   },
-   "genre":{
-      "hGenreTerm":"Panoramas",
-      "sftGenreTerm":[
-         "Panoramic views"
-      ],
-      "saftGenreTerm":[
+   "geographicName":"Great Lakes",
+   "sftGeographicName":[
+      "Great Lakes",
+      "Lakes Great",
+      "Regions of the United States"
+   ],
+   "saftGeographicName":[
+      "Superior, Michigan, Huron, Erie, and Ontario"
+   ],
+   "genreTerm":"Panoramas",
+   "sftGenreTerm":[
+      "Panoramic views"
+   ],
+   "saftGenreTerm":[
 
-      ]
-   },
+   ],
    "identifiers":[
       {
          "identifierTypeId":"11bf5f7c-30e1-4308-8170-1fbb5b817cf2",

--- a/ramls/samples/authority.sample
+++ b/ramls/samples/authority.sample
@@ -1,0 +1,121 @@
+{
+   "uuid":"5f671674-229a-48e9-804e-d2814cddd321",
+   "personalName":{
+      "hPersonalName":"Twain, Mark, 1835-1910",
+      "sftPersonalName":[
+         "Tuėĭn, Mark, 1835-1910",
+         "Tuwayn, Mārk, 1835-1910",
+         "Tʻu-wen, Ma-kʻo, 1835-1910",
+         "Твен, Марк, 1835-1910"
+      ],
+      "saftPersonalName":[
+         "nnn, Clemens, Samuel Langhorne, 1835-1910",
+         "nnn, Snodgrass, Quintus Curtius, 1835-1910"
+      ]
+   },
+   "corporateName":{
+      "hCorporateName":"International Business Machines Corporation",
+      "sftCorporateName":[
+         "Oklahoma. Council on Juvenile Delinquency",
+         "Oklahoma. Oklahoma Council on Juvenile Delinquency"
+      ],
+      "saftCorporateName":[
+         "Oklahoma Council on Juvenile Delinquency Planning",
+         "Oklahoma Council on Juvenile Justice"
+      ]
+   },
+   "meetingName":{
+      "hMeetingName":"Olympic Winter Games (21st : 2010 : Vancouver, B.C.)",
+      "sftMeetingName":[
+         "Vancouver Winter Games (2010 : Vancouver, B.C.)"
+      ],
+      "saftMeetingName":[
+
+      ]
+   },
+   "uniformTitle":{
+      "hUniformTitle":"Monograph (Institute of Applied Social and Economic Research)",
+      "sftUniformTitle":[
+         "Monographs (Institute of Applied Social and Economic Research)",
+         "Monograph series (Institute of Applied Social and Economic Research)",
+         "IASER monograph"
+      ],
+      "saftUniformTitle":[
+         "Continues (work): New Guinea research bulletin",
+         "Continued by (work): Monograph (National Research Institute (Papua New Guinea))"
+      ]
+   },
+   "subject":{
+      "hTopicalTerm":"Optical disks",
+      "sftTopicalTerm":[
+         "Discs, Optical",
+         "Optical discs",
+         "Laser discs",
+         "Laser disks",
+         "Laserdiscs",
+         "Laserdisks"
+      ],
+      "saftTopicalTerm":[
+         "Optical storage devices"
+      ]
+   },
+   "subjectHeadings":"z",
+   "geographicPlace":{
+      "hGeographicName":"Great Lakes",
+      "sftGeographicName":[
+         "Great Lakes",
+         "Lakes Great",
+         "Regions of the United States"
+      ],
+      "saftGeographicName":[
+         "Superior, Michigan, Huron, Erie, and Ontario"
+      ]
+   },
+   "genre":{
+      "hGenreTerm":"Panoramas",
+      "sftGenreTerm":[
+         "Panoramic views"
+      ],
+      "saftGenreTerm":[
+
+      ]
+   },
+   "identifiers":[
+      {
+         "identifierTypeId":"11bf5f7c-30e1-4308-8170-1fbb5b817cf2",
+         "value":"955335"
+      },
+      {
+         "identifierTypeId":"a6b2e7a4-d8fc-46b4-ac86-7bee3557f9c6",
+         "value":"79021164"
+      },
+      {
+         "identifierTypeId":"e32dd8fe-6582-4161-a56c-9dfe4415517e",
+         "value":"0000000121491740"
+      },
+      {
+         "identifierTypeId":"bc3e4c14-2412-49d4-9132-386f3aab243e",
+         "value":"(OCoLC)oca00254964"
+      }
+   ],
+   "notes":[
+      {
+         "noteTypeId":"d95deec9-6bf5-47c2-b784-96e1ce6ed975",
+         "value":"Machine-derived non-Latin script reference project."
+      },
+      {
+         "noteTypeId":"d95deec9-6bf5-47c2-b784-96e1ce6ed975",
+         "value":"Non-Latin script references not evaluated."
+      },
+      {
+         "noteTypeId":"d95deec9-6bf5-47c2-b784-96e1ce6ed975",
+         "value":"Pseudonym not established: Jean François Alden"
+      }
+   ],
+   "metadata":{
+      "createdDate":"2020-10-09T16:47:22.072+0000",
+      "updatedDate":"2020-10-09T16:47:49.703+0000",
+      "createdByUserId":"39720b69-3141-5eb8-95c8-d3bf17eb99d2",
+      "updatedByUserId":"39720b69-3141-5eb8-95c8-d3bf17eb99d2"
+   }
+}

--- a/ramls/samples/authority.sample
+++ b/ramls/samples/authority.sample
@@ -1,5 +1,6 @@
 {
-   "uuid":"5f671674-229a-48e9-804e-d2814cddd321",
+   "id":"5f671674-229a-48e9-804e-d2814cddd321",
+   "_version": 0,
    "personalName":"Twain, Mark, 1835-1910",
    "sftPersonalName":[
       "Tuėĭn, Mark, 1835-1910",


### PR DESCRIPTION
**_Purpose_**
The purpose is to update the schema accordingly to the mapping rules created in https://github.com/folio-org/mod-source-record-manager/pull/505/files
There is a need to simplify the schema to do not have complex objects (object with multiple fields) because the mapping processor can't seem to handle such mapping