### PR TITLE
MODINV-549 Holdings record created via MARC Bib Data Import shows incorrect source

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 18.1.0 2021-10-18
 
 * Fixed incorrect optimistic locking behavior for instance update when uploading file via data import (MODINV-546)
+* Fixed holdings record created via MARC Bib Data Import shows incorrect source (MODINV-549)
 
 ## 18.0.0 2021-10-06
 

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
@@ -48,6 +48,7 @@ public class CreateHoldingEventHandler implements EventHandler {
   private static final String PAYLOAD_DATA_HAS_NO_INSTANCE_ID_ERROR_MSG = "Failed to extract instanceId from instance entity or parsed record";
   private static final String MAPPING_METADATA_NOT_FOUND_MSG = "MappingMetadata snapshot was not found by jobExecutionId '%s'";
   static final String ACTION_HAS_NO_MAPPING_MSG = "Action profile to create a Holding entity requires a mapping profile";
+  private static final String FOLIO_SOURCE_ID = "f32d531e-df79-46b3-8932-cdd35f7a2264";
 
   private final Storage storage;
   private final MappingMetadataCache mappingMetadataCache;
@@ -86,6 +87,7 @@ public class CreateHoldingEventHandler implements EventHandler {
             holdingAsJson = holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD);
           }
           holdingAsJson.put("id", UUID.randomUUID().toString());
+          holdingAsJson.put("sourceId", FOLIO_SOURCE_ID);
           fillInstanceIdIfNeeded(dataImportEventPayload, holdingAsJson);
           checkIfPermanentLocationIdExists(holdingAsJson);
           return Json.decodeValue(dataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord.class);

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
@@ -71,6 +71,7 @@ public class CreateHoldingEventHandlerTest {
 
   private static final String PARSED_CONTENT_WITH_INSTANCE_ID = "{ \"leader\": \"01314nam  22003851a 4500\", \"fields\":[ {\"001\":\"ybp7406411\"}, {\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } } ] }";
   private static final String PARSED_CONTENT_WITHOUT_INSTANCE_ID = "{ \"leader\":\"01314nam  22003851a 4500\", \"fields\":[ { \"001\":\"ybp7406411\" } ] }";
+  private static final String FOLIO_SOURCE_ID = "f32d531e-df79-46b3-8932-cdd35f7a2264";
 
   @Mock
   private Storage storage;
@@ -182,6 +183,7 @@ public class CreateHoldingEventHandlerTest {
     Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
     Assert.assertEquals(instanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
     Assert.assertEquals(permanentLocationId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
+    Assert.assertEquals(FOLIO_SOURCE_ID, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("sourceId"));
   }
 
   @Test
@@ -223,6 +225,7 @@ public class CreateHoldingEventHandlerTest {
     Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
     Assert.assertEquals(expectedInstanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
     Assert.assertEquals(permanentLocationId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
+    Assert.assertEquals(FOLIO_SOURCE_ID, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("sourceId"));
   }
 
   @Test
@@ -259,6 +262,7 @@ public class CreateHoldingEventHandlerTest {
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
     Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
     Assert.assertEquals(permanentLocationId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
+    Assert.assertEquals(FOLIO_SOURCE_ID, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("sourceId"));
   }
 
 


### PR DESCRIPTION
## Purpose
When a holdings is created from a MARC Bib Data Import, it shows source = MARC instead of source = FOLIO

## Approach
- Added FOLIO sourceid to holding when it is created using CreateHoldingEventHandler 

##Learning
https://issues.folio.org/browse/MODINV-549