### PR TITLE
MODINV-504 - updated 'genre' field

### DIFF
--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -124,28 +124,22 @@
         "type": "string"
       }
     },
-    "genre": {
-      "type": "object",
-      "description": "Genre/form term",
-      "properties": {
-        "hGenreTerm": {
-          "type": "string",
-          "description": "Heading genre/form term"
-        },
-        "sftGenreTerm": {
-          "type": "array",
-          "description": "See from tracing genre/form term",
-          "items": {
-            "type": "string"
-          }
-        },
-        "saftGenreTerm": {
-          "type": "array",
-          "description": "See also from tracing genre/form term",
-          "items": {
-            "type": "string"
-          }
-        }
+    "hGenreTerm": {
+      "type": "string",
+      "description": "Heading genre/form term"
+    },
+    "sftGenreTerm": {
+      "type": "array",
+      "description": "See from tracing genre/form term",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftGenreTerm": {
+      "type": "array",
+      "description": "See also from tracing genre/form term",
+      "items": {
+        "type": "string"
       }
     },
     "identifiers": {


### PR DESCRIPTION
**_Purpose_**
This update is missing in a previous PR https://github.com/folio-org/mod-inventory/pull/407
This 'genre' field needs to be updated similarly to other fields. 
The related sample file is already updated.