### PR TITLE
MODINV-564 Import of MARC Holdings might create more Holdings than were in the file (kiwi bugfix)

### DIFF
--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcHoldingsEventHandlerTest.java
@@ -185,6 +185,7 @@ public class CreateMarcHoldingsEventHandlerTest {
 
     var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
+    record.setId("a0eb738a-c631-48cb-b36e-41cdcc83e2a4");
     HashMap<String, String> context = new HashMap<>();
     context.put("HOLDINGS", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(holdings)).encode());
     context.put(MARC_HOLDINGS.value(), Json.encode(record));
@@ -349,6 +350,7 @@ public class CreateMarcHoldingsEventHandlerTest {
 
     var parsedHoldingsRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_HOLDINGS_RECORD));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedHoldingsRecord.encode()));
+    record.setId("a0eb738a-c631-48cb-b36e-41cdcc83e2a4");
     HashMap<String, String> context = new HashMap<>();
     context.put("HOLDINGS", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(holdings)).encode());
     context.put(MARC_HOLDINGS.value(), Json.encode(record));


### PR DESCRIPTION
## Purpose
Inventory created more holdings records than were in the file because it generates a unique id for each request

## Approach
In our distributed system, we can use the unique id already created by another module, since these entities are in the 1-2-1 relationship

## Learning
https://issues.folio.org/browse/MODINV-564