### PR TITLE
MODINV-571 Fixed put for mappingParams into dataImportEventPayload

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Fixed incorrect optimistic locking behavior for instance update when uploading file via data import (MODINV-546)
 * Fixed holdings record created via MARC Bib Data Import shows incorrect source (MODINV-549)
+* Fixed put for mappingParams into dataImportEventPayload
 
 ## 18.0.0 2021-10-06
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Fixed incorrect optimistic locking behavior for instance update when uploading file via data import (MODINV-546)
 * Fixed holdings record created via MARC Bib Data Import shows incorrect source (MODINV-549)
-* Fixed put for mappingParams into dataImportEventPayload
+* Fixed put for mappingParams into dataImportEventPayload (MODINV-571)
 
 ## 18.0.0 2021-10-06
 

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
@@ -59,7 +59,7 @@ public abstract class AbstractMatchEventHandler implements EventHandler {
 
   private CompletableFuture<Boolean> doMatching(DataImportEventPayload dataImportEventPayload, MappingMetadataDto mappingMetadataDto,
                                                 MatchingParametersRelations matchingParametersRelations) {
-    dataImportEventPayload.getContext().put(MAPPING_PARAMS, Json.encode(mappingMetadataDto));
+    dataImportEventPayload.getContext().put(MAPPING_PARAMS, mappingMetadataDto.getMappingParams());
     dataImportEventPayload.getContext().put(MATCHING_RELATIONS,
       Json.encode(matchingParametersRelations.getMatchingRelations()));
 


### PR DESCRIPTION
## Purpose
Cannot match HOLDINGS via locations.

## Approach
Fixed put for mappingParams into dataImportEventPayload context

## Learning
[MODINV-571](https://issues.folio.org/browse/MODINV-571)