### PR TITLE
MODINV-576 Uncomment line to set source field for MARC Authority

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateMarcAuthorityEventHandler.java
@@ -4,7 +4,9 @@ import static java.lang.String.format;
 import static org.folio.ActionProfile.FolioRecord.AUTHORITY;
 import static org.folio.ActionProfile.FolioRecord.MARC_AUTHORITY;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED;
+import static org.folio.inventory.dataimport.handlers.actions.AbstractInstanceEventHandler.MARC_FORMAT;
 import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.constructContext;
+import static org.folio.inventory.domain.instances.Instance.SOURCE_KEY;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 
 import java.util.HashMap;
@@ -141,8 +143,7 @@ public class CreateMarcAuthorityEventHandler implements EventHandler {
     if (authorityAsJson.getJsonObject(AUTHORITY_PATH) != null) {
       authorityAsJson = authorityAsJson.getJsonObject(AUTHORITY_PATH);
     }
-    //Uncomment when MODINVSTOR-825 ready
-//    authorityAsJson.put(SOURCE_KEY, MARC_FORMAT);
+    authorityAsJson.put(SOURCE_KEY, MARC_FORMAT);
 
     return authorityAsJson;
   }


### PR DESCRIPTION
Uncomment line which sets the source for MARC Authority record when [MODINVSTOR-825](https://issues.folio.org/browse/MODINVSTOR-825) ready