### PR TITLE
MODINV-583 Authority: Update metadata in schema

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 18.x.x 2021-xx-xx
 
 * added Marc Authority handler for entities created via MARC Authority Data Import (MODINV-501)
+* Authority: Update metadata in schema (MODINV-583)
 
 ## 18.1.0 2021-10-18
 

--- a/pom.xml
+++ b/pom.xml
@@ -369,6 +369,7 @@
               <sourcePaths>
                 <path>${basedir}/ramls/holdings-record.json</path>
                 <path>${basedir}/ramls/mappingMetadataDto.json</path>
+                <path>${basedir}/ramls/authority.json</path>
               </sourcePaths>
               <targetPackage>org.folio</targetPackage>
               <generateBuilders>true</generateBuilders>

--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -245,10 +245,25 @@
         ]
       }
     },
-    "metadata": {
-      "type": "object",
-      "description": "Creater, updater, creation date, last updated date",
-      "$ref": "./raml-util/schemas/metadata.schema"
+    "createdBy": {
+      "description": "ID of the user who created the record (when available)",
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "createdDate": {
+      "description": "Date and time when the record was created",
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedBy": {
+      "description": "ID of the user who last updated the record (when available)",
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    },
+    "updatedDate": {
+      "description": "Date and time when the record was last updated",
+      "type": "string",
+      "format": "date-time"
     }
   }
 }

--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -246,9 +246,8 @@
       }
     },
     "createdBy": {
-      "description": "ID of the user who created the record (when available)",
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "description": "Who created the record (when available)",
+      "type": "string"
     },
     "createdDate": {
       "description": "Date and time when the record was created",
@@ -256,9 +255,8 @@
       "format": "date-time"
     },
     "updatedBy": {
-      "description": "ID of the user who last updated the record (when available)",
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "description": "Who last updated the record (when available)",
+      "type": "string"
     },
     "updatedDate": {
       "description": "Date and time when the record was last updated",

--- a/ramls/samples/authority.sample
+++ b/ramls/samples/authority.sample
@@ -127,10 +127,8 @@
          "value":"Pseudonym not established: Jean François Alden"
       }
    ],
-   "metadata":{
-      "createdDate":"2020-10-09T16:47:22.072+0000",
-      "updatedDate":"2020-10-09T16:47:49.703+0000",
-      "createdByUserId":"39720b69-3141-5eb8-95c8-d3bf17eb99d2",
-      "updatedByUserId":"39720b69-3141-5eb8-95c8-d3bf17eb99d2"
-   }
+   "createdDate":"2020-10-09T16:47:22.072+0000",
+   "updatedDate":"2020-10-09T16:47:49.703+0000",
+   "createdBy":"39720b69-3141-5eb8-95c8-d3bf17eb99d2",
+   "updatedBy":"39720b69-3141-5eb8-95c8-d3bf17eb99d2"
 }


### PR DESCRIPTION
MODINV-583 Authority: Update metadata in schema
https://issues.folio.org/browse/MODINV-583

### Purpose
Now the schema has a reference to metadata that is not convenient for mapping processor.

### Approach
- drop the reference to metadata in schema and add 4 new single properties - createdBy, createdDate, updatedBy, updatedDate
- update sample file
- add schema building to pom.xml