### PR TITLE
MODINV-599: Update Log4j to 2.16.0.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * added Marc Authority handler for entities created via MARC Authority Data Import (MODINV-501)
 * added support for new administrative notes field (MODINV-580, MODINV-581, MODINV-582)
+* Update Log4j to 2.16.0. (CVE-2021-44228) (MODINV-599)
 
 ## 18.1.0 2021-10-18
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODINV-599](https://issues.folio.org/browse/MODINV-599).

Use 2.16.0 rather than 2.15.0, it contains additional changes related to the CVE and is also the version RMB is set to use as of [Release 33.1.3](https://github.com/folio-org/raml-module-builder/pull/1002).