### PR TITLE
MODINV-599: Update Log4j to 2.16.0 (Kiwi R3 2021).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 18.0.5 2021-12-15
+## 18.0.5 IN-PROGRESS
 
 * Update Log4j to 2.16.0. (CVE-2021-44228) (MODINV-599)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 18.0.5 2021-12-15
+
+* Update Log4j to 2.16.0. (CVE-2021-44228) (MODINV-599)
+
 ## 18.0.4 2021-11-16
 
 * Fixed put for mappingParams into dataImportEventPayload BF (MODINV-571)

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODINV-599](https://issues.folio.org/browse/MODINV-599) for 18.0 version (Used by Kiwi).

Use 2.16.0 rather than 2.15.0, it contains additional changes related to the CVE and is also the version RMB is set to use as of [Release 33.1.3](https://github.com/folio-org/raml-module-builder/pull/1002).