### PR TITLE
MODINV-599: Update Log4j to 2.16.0 (Iris).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,12 @@
+## 16.3.5 2021-12-15
+
+* Update Log4j to 2.16.0. (CVE-2021-44228) (MODINV-599)
+
 ## 16.3.4 2021-07-15
 * Includes fix of editing an instance field not controlled by MARC (MODINV-432)
 * Includes fix of Instances duplication when imported via data-import (MODINV-455)
 * Includes fix of Inventory instance record not updating although quickMARC/SRS updates (MODINV-451, MODINV-445)
 * Includes upgrade to data-import-processing-core v3.0.4
-
 
 ## 16.3.3 2021-06-18
 * Includes fix of Instance tags deletion when the instance is updated by an imported MARC record (MODINV-419)

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODINV-599](https://issues.folio.org/browse/MODINV-599) for 16.3 version (Used by Iris).

Use 2.16.0 rather than 2.15.0, it contains additional changes related to the CVE and is also the version RMB is set to use as of [Release 33.1.3](https://github.com/folio-org/raml-module-builder/pull/1002).