### PR TITLE
MODINV-601: Update Log4j to 2.16.0 (Juniper R2 2021).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 17.0.8 IN-PROGRESS
+
+* Update Log4j to 2.16.0. (CVE-2021-44228) (MODINV-601)
+
 ## 17.0.7 2021-11-15
 
 * Prevent sending a requests with an empty barcode (MODINV-572)

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODINV-601](https://issues.folio.org/browse/MODINV-601).