### PR TITLE
MODINV-614 Remove Kafka cache for QuickMarcKafkaHandler

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * added Marc Authority handler for entities created via MARC Authority Data Import (MODINV-501)
 * added support for new administrative notes field (MODINV-580, MODINV-581, MODINV-582)
 * Update Log4j to 2.16.0. (CVE-2021-44228) (MODINV-599)
+* Remove Kafka cache for QuickMarcKafkaHandler (MODINV-614) (MODINV-599)
 
 ## 18.1.0 2021-10-18
 

--- a/src/main/java/org/folio/inventory/dataimport/consumers/QuickMarcKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/QuickMarcKafkaHandler.java
@@ -93,9 +93,10 @@ public class QuickMarcKafkaHandler implements AsyncRecordHandler<String, String>
       .compose(eventPayload -> processPayload(eventPayload, context)
         .compose(recordType -> sendEvent(eventPayload, getReplyEventType(recordType), params))
         .recover(throwable -> sendErrorEvent(params, eventPayload, throwable))
-        .map(ar -> record.key()),
-        th -> Future.failedFuture(th.getMessage())
-      );
+        .map(ar -> record.key()), th -> {
+        LOGGER.error("Update record state was failed while handle event, {}", th.getMessage());
+        return Future.failedFuture(th.getMessage());
+      });
   }
 
   private QMEventTypes getReplyEventType(Record.RecordType recordType) {

--- a/src/main/java/org/folio/inventory/dataimport/consumers/QuickMarcKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/QuickMarcKafkaHandler.java
@@ -1,7 +1,6 @@
 package org.folio.inventory.dataimport.consumers;
 
 import static io.vertx.kafka.client.producer.KafkaProducer.createShared;
-import static java.lang.String.format;
 
 import static org.folio.inventory.dataimport.handlers.QMEventTypes.QM_ERROR;
 import static org.folio.inventory.dataimport.handlers.QMEventTypes.QM_INVENTORY_AUTHORITY_UPDATED;
@@ -43,7 +42,6 @@ import org.folio.inventory.dataimport.util.ConsumerWrapperUtil;
 import org.folio.inventory.storage.Storage;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.KafkaConfig;
-import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.rest.jaxrs.model.Event;
@@ -67,17 +65,14 @@ public class QuickMarcKafkaHandler implements AsyncRecordHandler<String, String>
   private final PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper;
   private final int maxDistributionNumber;
   private final KafkaConfig kafkaConfig;
-  private final KafkaInternalCache kafkaInternalCache;
   private final Vertx vertx;
   private final Map<QMEventTypes, KafkaProducer<String, String>> producerMap = new HashMap<>();
 
   public QuickMarcKafkaHandler(Vertx vertx, Storage storage, int maxDistributionNumber, KafkaConfig kafkaConfig,
-                               KafkaInternalCache kafkaInternalCache,
                                PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper) {
     this.vertx = vertx;
     this.maxDistributionNumber = maxDistributionNumber;
     this.kafkaConfig = kafkaConfig;
-    this.kafkaInternalCache = kafkaInternalCache;
     this.instanceUpdateDelegate = new InstanceUpdateDelegate(storage);
     this.holdingsUpdateDelegate = new HoldingsUpdateDelegate(storage);
     this.authorityUpdateDelegate = new AuthorityUpdateDelegate(storage);
@@ -93,18 +88,14 @@ public class QuickMarcKafkaHandler implements AsyncRecordHandler<String, String>
     var params = new OkapiConnectionParams(kafkaHeadersToMap(record.headers()), vertx);
     var context = constructContext(params.getTenantId(), params.getToken(), params.getOkapiUrl());
     Event event = Json.decodeValue(record.value(), Event.class);
-    if (!kafkaInternalCache.containsByKey(event.getId())) {
-      LOGGER.info(format("Quick marc event payload has been received with event type: %s", event.getEventType()));
-      kafkaInternalCache.putToCache(event.getId());
-      return getEventPayload(event)
-        .compose(eventPayload -> processPayload(eventPayload, context)
-          .compose(recordType -> sendEvent(eventPayload, getReplyEventType(recordType), params))
-          .recover(throwable -> sendErrorEvent(params, eventPayload, throwable))
-          .map(ar -> record.key()),
-          th -> Future.failedFuture(th.getMessage())
-        );
-    }
-    return Future.succeededFuture();
+    LOGGER.info("Quick marc event payload has been received with event type: {}", event.getEventType());
+    return getEventPayload(event)
+      .compose(eventPayload -> processPayload(eventPayload, context)
+        .compose(recordType -> sendEvent(eventPayload, getReplyEventType(recordType), params))
+        .recover(throwable -> sendErrorEvent(params, eventPayload, throwable))
+        .map(ar -> record.key()),
+        th -> Future.failedFuture(th.getMessage())
+      );
   }
 
   private QMEventTypes getReplyEventType(Record.RecordType recordType) {


### PR DESCRIPTION
## Purpose
Kafka Cache is used in QuickMarcKafkaHandler in mod-inventory. Just remove Kafka cache (consumer receiving QM_COMPLETED supports deduplication).

## Learning
[MODINV-614](https://issues.folio.org/browse/MODINV-614)