### PR TITLE
MODINV-603 - Remove Kafka cache by handling Constraint Violation Exceptions for DataImportKafkaHandler

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -52,7 +52,6 @@ import org.folio.inventory.services.ItemIdStorageService;
 import org.folio.inventory.storage.Storage;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.KafkaHeaderUtils;
-import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.EventManager;
 import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
@@ -71,15 +70,14 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
   private static final String CHUNK_ID_HEADER = "chunkId";
   private static final String PROFILE_SNAPSHOT_ID_KEY = "JOB_PROFILE_SNAPSHOT_ID";
 
-  private KafkaInternalCache kafkaInternalCache;
   private Vertx vertx;
   private ProfileSnapshotCache profileSnapshotCache;
   private MappingMetadataCache mappingMetadataCache;
 
-  public DataImportKafkaHandler(Vertx vertx, Storage storage, HttpClient client, KafkaInternalCache kafkaInternalCache,
-                                ProfileSnapshotCache profileSnapshotCache, MappingMetadataCache mappingMetadataCache) {
+  public DataImportKafkaHandler(Vertx vertx, Storage storage, HttpClient client,
+                                ProfileSnapshotCache profileSnapshotCache,
+                                MappingMetadataCache mappingMetadataCache) {
     this.vertx = vertx;
-    this.kafkaInternalCache = kafkaInternalCache;
     this.profileSnapshotCache = profileSnapshotCache;
     this.mappingMetadataCache = mappingMetadataCache;
     registerDataImportProcessingHandlers(storage, client);
@@ -90,40 +88,36 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     try {
       Promise<String> promise = Promise.promise();
       Event event = Json.decodeValue(record.value(), Event.class);
-      if (!kafkaInternalCache.containsByKey(event.getId())) {
-        kafkaInternalCache.putToCache(event.getId());
-        DataImportEventPayload eventPayload = Json.decodeValue(event.getEventPayload(), DataImportEventPayload.class);
-        Map<String, String> headersMap = KafkaHeaderUtils.kafkaHeadersToMap(record.headers());
-        String recordId = headersMap.get(RECORD_ID_HEADER);
-        String chunkId = headersMap.get(CHUNK_ID_HEADER);
-        String jobExecutionId = eventPayload.getJobExecutionId();
-        LOGGER.info("Data import event payload has been received with event type: {}, recordId: {} by jobExecution: {} and chunkId: {}", eventPayload.getEventType(), recordId, jobExecutionId, chunkId);
-        eventPayload.getContext().put(RECORD_ID_HEADER, recordId);
-        eventPayload.getContext().put(CHUNK_ID_HEADER, chunkId);
+      DataImportEventPayload eventPayload = Json.decodeValue(event.getEventPayload(), DataImportEventPayload.class);
+      Map<String, String> headersMap = KafkaHeaderUtils.kafkaHeadersToMap(record.headers());
+      String recordId = headersMap.get(RECORD_ID_HEADER);
+      String chunkId = headersMap.get(CHUNK_ID_HEADER);
+      String jobExecutionId = eventPayload.getJobExecutionId();
+      LOGGER.info("Data import event payload has been received with event type: {}, recordId: {} by jobExecution: {} and chunkId: {}", eventPayload.getEventType(), recordId, jobExecutionId, chunkId);
+      eventPayload.getContext().put(RECORD_ID_HEADER, recordId);
+      eventPayload.getContext().put(CHUNK_ID_HEADER, chunkId);
 
-        Context context = EventHandlingUtil.constructContext(eventPayload.getTenant(), eventPayload.getToken(), eventPayload.getOkapiUrl());
-        String jobProfileSnapshotId = eventPayload.getContext().get(PROFILE_SNAPSHOT_ID_KEY);
-        profileSnapshotCache.get(jobProfileSnapshotId, context)
-          .toCompletionStage()
-          .thenCompose(snapshotOptional -> snapshotOptional
-            .map(profileSnapshot -> EventManager.handleEvent(eventPayload, profileSnapshot))
-            .orElse(CompletableFuture.failedFuture(new EventProcessingException(format("Job profile snapshot with id '%s' does not exist", jobProfileSnapshotId)))))
-          .whenComplete((processedPayload, throwable) -> {
-            if (throwable != null) {
-              promise.fail(throwable);
-            } else if (DI_ERROR.value().equals(processedPayload.getEventType())) {
-              promise.fail("Failed to process data import event payload");
-            } else {
-              promise.complete(record.key());
-            }
-          });
-        return promise.future();
-      }
+      Context context = EventHandlingUtil.constructContext(eventPayload.getTenant(), eventPayload.getToken(), eventPayload.getOkapiUrl());
+      String jobProfileSnapshotId = eventPayload.getContext().get(PROFILE_SNAPSHOT_ID_KEY);
+      profileSnapshotCache.get(jobProfileSnapshotId, context)
+        .toCompletionStage()
+        .thenCompose(snapshotOptional -> snapshotOptional
+          .map(profileSnapshot -> EventManager.handleEvent(eventPayload, profileSnapshot))
+          .orElse(CompletableFuture.failedFuture(new EventProcessingException(format("Job profile snapshot with id '%s' does not exist", jobProfileSnapshotId)))))
+        .whenComplete((processedPayload, throwable) -> {
+          if (throwable != null) {
+            promise.fail(throwable);
+          } else if (DI_ERROR.value().equals(processedPayload.getEventType())) {
+            promise.fail("Failed to process data import event payload");
+          } else {
+            promise.complete(record.key());
+          }
+        });
+      return promise.future();
     } catch (Exception e) {
       LOGGER.error(format("Failed to process data import kafka record from topic %s", record.topic()), e);
       return Future.failedFuture(e);
     }
-    return Future.succeededFuture();
   }
 
   private void registerDataImportProcessingHandlers(Storage storage, HttpClient client) {

--- a/src/test/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandlerTest.java
@@ -26,7 +26,6 @@ import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.cache.ProfileSnapshotCache;
 import org.folio.inventory.storage.Storage;
 import org.folio.kafka.KafkaConfig;
-import org.folio.kafka.cache.KafkaInternalCache;
 import org.folio.processing.events.EventManager;
 import org.folio.processing.events.services.handler.EventHandler;
 import org.folio.rest.jaxrs.model.Event;
@@ -37,10 +36,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -70,15 +67,11 @@ public class DataImportKafkaHandlerTest {
   private static final String RECORD_ID_HEADER = "recordId";
   private static final String CHUNK_ID_HEADER = "chunkId";
 
-
   @ClassRule
   public static EmbeddedKafkaCluster cluster = provisionWith(useDefaults());
 
   @Mock
   private Storage mockedStorage;
-
-  @Mock
-  private KafkaInternalCache kafkaInternalCache;
 
   @Mock
   private KafkaConsumerRecord<String, String> kafkaRecord;
@@ -141,7 +134,7 @@ public class DataImportKafkaHandlerTest {
       .build();
 
     HttpClient client = vertx.createHttpClient();
-    dataImportKafkaHandler = new DataImportKafkaHandler(vertx, mockedStorage, client, kafkaInternalCache,
+    dataImportKafkaHandler = new DataImportKafkaHandler(vertx, mockedStorage, client,
       new ProfileSnapshotCache(vertx,
       vertx.createHttpClient(new HttpClientOptions().setConnectTimeout(3000)), 3600),
       new MappingMetadataCache(vertx,
@@ -171,8 +164,6 @@ public class DataImportKafkaHandlerTest {
     when(mockedEventHandler.handle(any(DataImportEventPayload.class)))
       .thenReturn(CompletableFuture.completedFuture(new DataImportEventPayload()));
     EventManager.registerEventHandler(mockedEventHandler);
-
-    Mockito.when(kafkaInternalCache.containsByKey("01")).thenReturn(false);
 
     // when
     Future<String> future = dataImportKafkaHandler.handle(kafkaRecord);
@@ -205,48 +196,12 @@ public class DataImportKafkaHandlerTest {
       .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
     EventManager.registerEventHandler(mockedEventHandler);
 
-    Mockito.when(kafkaInternalCache.containsByKey("01")).thenReturn(false);
-
     // when
     Future<String> future = dataImportKafkaHandler.handle(kafkaRecord);
 
     // then
     future.onComplete(ar -> {
       context.assertTrue(ar.failed());
-      async.complete();
-    });
-  }
-
-  @Test
-  public void shouldNotHandleIfCacheAlreadyContainsThisEvent(TestContext context) {
-    // given
-    Async async = context.async();
-    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withTenant(TENANT_ID)
-      .withOkapiUrl(mockServer.baseUrl())
-      .withToken("test-token")
-      .withContext(new HashMap<>(Map.of("JOB_PROFILE_SNAPSHOT_ID", profileSnapshotWrapper.getId())));
-
-    Event event = new Event().withId("01").withEventPayload(Json.encode(dataImportEventPayload));
-    String expectedKafkaRecordKey = "test_key";
-    when(kafkaRecord.key()).thenReturn(expectedKafkaRecordKey);
-    when(kafkaRecord.value()).thenReturn(Json.encode(event));
-
-    EventHandler mockedEventHandler = mock(EventHandler.class);
-    when(mockedEventHandler.isEligible(any(DataImportEventPayload.class))).thenReturn(true);
-    when(mockedEventHandler.handle(any(DataImportEventPayload.class)))
-      .thenReturn(CompletableFuture.completedFuture(new DataImportEventPayload()));
-    EventManager.registerEventHandler(mockedEventHandler);
-
-    Mockito.when(kafkaInternalCache.containsByKey("01")).thenReturn(true);
-
-    // when
-    Future<String> future = dataImportKafkaHandler.handle(kafkaRecord);
-
-    // then
-    future.onComplete(ar -> {
-      context.assertTrue(ar.succeeded());
-      context.assertNotEquals(expectedKafkaRecordKey, ar.result());
       async.complete();
     });
   }


### PR DESCRIPTION
## Purpose
to remove Kafka cache from DataImportKafkaHandler since events deduplication relies on uniqueness constraint of entities IDs  during entities creation

## Approach
* remove Kafka cache from DataImportKafkaHandler


## Learning
[MODINV-603](https://issues.folio.org/browse/MODINV-603)
