### PR TITLE
MODINV-620 Remove zipping/unzipping of Kafka events for quickMarc update flow

### DIFF
--- a/src/test/java/org/folio/inventory/eventhandlers/UpdateAuthorityQuickMarcEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/UpdateAuthorityQuickMarcEventHandlerTest.java
@@ -30,8 +30,6 @@ import org.folio.inventory.dataimport.handlers.actions.AuthorityUpdateDelegate;
 import org.folio.inventory.dataimport.handlers.quickmarc.UpdateAuthorityQuickMarcEventHandler;
 import org.folio.inventory.domain.AuthorityRecordCollection;
 import org.folio.inventory.storage.Storage;
-import org.folio.inventory.support.http.client.OkapiHttpClient;
-import org.folio.processing.events.utils.ZIPArchiver;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UpdateAuthorityQuickMarcEventHandlerTest {
@@ -48,8 +46,6 @@ public class UpdateAuthorityQuickMarcEventHandlerTest {
   private Context context;
   @Mock
   private AuthorityRecordCollection authorityRecordCollection;
-  @Mock
-  private OkapiHttpClient okapiHttpClient;
 
   private UpdateAuthorityQuickMarcEventHandler updateAuthorityQuickMarcEventHandler;
   private AuthorityUpdateDelegate authorityUpdateDelegate;
@@ -113,11 +109,10 @@ public class UpdateAuthorityQuickMarcEventHandlerTest {
   }
 
   @Test
-  public void shouldCompleteExceptionally() throws IOException {
-
+  public void shouldCompleteExceptionally_whenRecordIsEmpty() {
     HashMap<String, String> eventPayload = new HashMap<>();
     eventPayload.put("RECORD_TYPE", "MARC_AUTHORITY");
-    eventPayload.put("MARC_AUTHORITY", ZIPArchiver.zip(record.encode()));
+    eventPayload.put("MARC_AUTHORITY", "");
     eventPayload.put("MAPPING_RULES", mappingRules.encode());
     eventPayload.put("MAPPING_PARAMS", new JsonObject().encode());
 

--- a/src/test/java/org/folio/inventory/eventhandlers/UpdateHoldingsQuickMarcEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/UpdateHoldingsQuickMarcEventHandlerTest.java
@@ -36,8 +36,6 @@ import org.folio.inventory.dataimport.handlers.actions.HoldingsUpdateDelegate;
 import org.folio.inventory.dataimport.handlers.quickmarc.UpdateHoldingsQuickMarcEventHandler;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.storage.Storage;
-import org.folio.inventory.support.http.client.OkapiHttpClient;
-import org.folio.processing.events.utils.ZIPArchiver;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UpdateHoldingsQuickMarcEventHandlerTest {
@@ -54,8 +52,6 @@ public class UpdateHoldingsQuickMarcEventHandlerTest {
   private Context context;
   @Mock
   private HoldingsRecordCollection holdingsRecordCollection;
-  @Mock
-  private OkapiHttpClient okapiHttpClient;
 
   private UpdateHoldingsQuickMarcEventHandler updateHoldingsQuickMarcEventHandler;
   private HoldingsUpdateDelegate holdingsUpdateDelegate;
@@ -93,7 +89,6 @@ public class UpdateHoldingsQuickMarcEventHandlerTest {
 
   @Test
   public void shouldProcessEvent() {
-
     List<HoldingsType> holdings = new ArrayList<>();
     holdings.add(new HoldingsType().withName("testingnote$a").withId("fe19bae4-da28-472b-be90-d442e2428eadx"));
     MappingParameters mappingParameters = new MappingParameters();
@@ -127,11 +122,10 @@ public class UpdateHoldingsQuickMarcEventHandlerTest {
   }
 
   @Test
-  public void shouldCompleteExceptionally() throws IOException {
-
+  public void shouldCompleteExceptionally_whenRecordIsEmpty() {
     HashMap<String, String> eventPayload = new HashMap<>();
     eventPayload.put("RECORD_TYPE", "MARC_HOLDING");
-    eventPayload.put("MARC_HOLDING", ZIPArchiver.zip(record.encode()));
+    eventPayload.put("MARC_HOLDING", "");
     eventPayload.put("MAPPING_RULES", mappingRules.encode());
     eventPayload.put("MAPPING_PARAMS", new JsonObject().encode());
 

--- a/src/test/java/org/folio/inventory/eventhandlers/UpdateInstanceQuickMarcEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/UpdateInstanceQuickMarcEventHandlerTest.java
@@ -36,7 +36,6 @@ import org.folio.inventory.domain.instances.InstanceCollection;
 import org.folio.inventory.storage.Storage;
 import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.inventory.support.http.client.Response;
-import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.jaxrs.model.Record;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -164,11 +163,10 @@ public class UpdateInstanceQuickMarcEventHandlerTest {
   }
 
   @Test
-  public void shouldCompleteExceptionally() throws IOException {
-
+  public void shouldCompleteExceptionally_whenRecordIsEmpty() {
     HashMap<String, String> eventPayload = new HashMap<>();
     eventPayload.put("RECORD_TYPE", "MARC_BIB");
-    eventPayload.put("MARC_BIB", ZIPArchiver.zip(record.encode()));
+    eventPayload.put("MARC_BIB", "");
     eventPayload.put("MAPPING_RULES", mappingRules.encode());
     eventPayload.put("MAPPING_PARAMS", new JsonObject().encode());
 
@@ -180,7 +178,6 @@ public class UpdateInstanceQuickMarcEventHandlerTest {
 
   @Test
   public void shouldSendError() {
-
     doAnswer(invocationOnMock -> {
       Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
       failureHandler.accept(new Failure("Internal Server Error", 500));

--- a/src/test/java/org/folio/inventory/quickmarc/consumers/QuickMarcKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/quickmarc/consumers/QuickMarcKafkaHandlerTest.java
@@ -60,7 +60,6 @@ import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.inventory.support.http.client.Response;
 import org.folio.kafka.KafkaConfig;
 import org.folio.okapi.common.XOkapiHeaders;
-import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.ParsedRecordDto;
@@ -201,8 +200,7 @@ public class QuickMarcKafkaHandlerTest {
   }
 
   @Test
-  public void shouldSendInstanceUpdatedEvent(TestContext context) throws IOException,
-    InterruptedException {
+  public void shouldSendInstanceUpdatedEvent(TestContext context) throws InterruptedException {
     // given
     Async async = context.async();
     Map<String, String> payload = new HashMap<>();
@@ -214,7 +212,7 @@ public class QuickMarcKafkaHandlerTest {
       .withRecordType(ParsedRecordDto.RecordType.MARC_BIB)
       .withRelatedRecordVersion("1")));
 
-    Event event = new Event().withId("01").withEventPayload(ZIPArchiver.zip(Json.encode(payload)));
+    Event event = new Event().withId("01").withEventPayload(Json.encode(payload));
     String expectedKafkaRecordKey = "test_key";
     when(kafkaRecord.key()).thenReturn(expectedKafkaRecordKey);
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
@@ -236,8 +234,7 @@ public class QuickMarcKafkaHandlerTest {
   }
 
   @Test
-  public void shouldSendHoldingsUpdatedEvent(TestContext context) throws IOException,
-    InterruptedException {
+  public void shouldSendHoldingsUpdatedEvent(TestContext context) throws InterruptedException {
 
     List<HoldingsType> holdings = new ArrayList<>();
     holdings.add(new HoldingsType().withName("testingnote$a"));
@@ -254,7 +251,7 @@ public class QuickMarcKafkaHandlerTest {
       .withRecordType(ParsedRecordDto.RecordType.MARC_HOLDING)
       .withRelatedRecordVersion("1")));
 
-    Event event = new Event().withId("01").withEventPayload(ZIPArchiver.zip(Json.encode(payload)));
+    Event event = new Event().withId("01").withEventPayload(Json.encode(payload));
     String expectedKafkaRecordKey = "test_key";
     when(kafkaRecord.key()).thenReturn(expectedKafkaRecordKey);
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
@@ -276,8 +273,7 @@ public class QuickMarcKafkaHandlerTest {
   }
 
   @Test
-  public void shouldSendAuthorityUpdatedEvent(TestContext context) throws IOException,
-    InterruptedException {
+  public void shouldSendAuthorityUpdatedEvent(TestContext context) throws InterruptedException {
     // given
     Async async = context.async();
     Map<String, String> payload = new HashMap<>();
@@ -289,7 +285,7 @@ public class QuickMarcKafkaHandlerTest {
       .withRecordType(ParsedRecordDto.RecordType.MARC_AUTHORITY)
       .withRelatedRecordVersion("1")));
 
-    Event event = new Event().withId("01").withEventPayload(ZIPArchiver.zip(Json.encode(payload)));
+    Event event = new Event().withId("01").withEventPayload(Json.encode(payload));
     String expectedKafkaRecordKey = "test_key";
     when(kafkaRecord.key()).thenReturn(expectedKafkaRecordKey);
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
@@ -317,8 +313,7 @@ public class QuickMarcKafkaHandlerTest {
   }
 
   @Test
-  public void shouldSendErrorEventWhenRecordIsNotExistInStorage(TestContext context) throws IOException,
-    InterruptedException {
+  public void shouldSendErrorEventWhenRecordIsNotExistInStorage(TestContext context) throws InterruptedException {
     // given
     Async async = context.async();
     Map<String, String> payload = new HashMap<>();
@@ -330,7 +325,7 @@ public class QuickMarcKafkaHandlerTest {
       .withRecordType(ParsedRecordDto.RecordType.MARC_AUTHORITY)
       .withRelatedRecordVersion("1")));
 
-    Event event = new Event().withId("01").withEventPayload(ZIPArchiver.zip(Json.encode(payload)));
+    Event event = new Event().withId("01").withEventPayload(Json.encode(payload));
     String expectedKafkaRecordKey = "test_key";
     when(kafkaRecord.key()).thenReturn(expectedKafkaRecordKey);
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
@@ -358,8 +353,7 @@ public class QuickMarcKafkaHandlerTest {
   }
 
   @Test
-  public void shouldSendErrorEventWhenFailedToFetchRecordFromStorage(TestContext context) throws IOException,
-    InterruptedException {
+  public void shouldSendErrorEventWhenFailedToFetchRecordFromStorage(TestContext context) throws InterruptedException {
     // given
     Async async = context.async();
     Map<String, String> payload = new HashMap<>();
@@ -371,7 +365,7 @@ public class QuickMarcKafkaHandlerTest {
       .withRecordType(ParsedRecordDto.RecordType.MARC_AUTHORITY)
       .withRelatedRecordVersion("1")));
 
-    Event event = new Event().withId("01").withEventPayload(ZIPArchiver.zip(Json.encode(payload)));
+    Event event = new Event().withId("01").withEventPayload(Json.encode(payload));
     String expectedKafkaRecordKey = "test_key";
     when(kafkaRecord.key()).thenReturn(expectedKafkaRecordKey);
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
@@ -399,8 +393,7 @@ public class QuickMarcKafkaHandlerTest {
   }
 
   @Test
-  public void shouldSendErrorEventWhenPayloadHasNoMarcRecord(TestContext context)
-    throws IOException, InterruptedException {
+  public void shouldSendErrorEventWhenPayloadHasNoMarcRecord(TestContext context) throws InterruptedException {
     // given
     Async async = context.async();
     Map<String, String> payload = new HashMap<>();
@@ -408,7 +401,7 @@ public class QuickMarcKafkaHandlerTest {
     payload.put("MAPPING_RULES", bibMappingRules.encode());
     payload.put("MAPPING_PARAMS", new JsonObject().encode());
 
-    Event event = new Event().withId("01").withEventPayload(ZIPArchiver.zip(Json.encode(payload)));
+    Event event = new Event().withId("01").withEventPayload(Json.encode(payload));
     when(kafkaRecord.value()).thenReturn(Json.encode(event));
     String expectedKafkaRecordKey = "test_key";
     when(kafkaRecord.key()).thenReturn(expectedKafkaRecordKey);


### PR DESCRIPTION
Purpose/Overview:
The custom zipping/unzipping approach that we are currently using for quick-marc flow is not needed. We should rely on Kafka's zipping approach.

### Learning
[MODINV-620](https://issues.folio.org/browse/MODINV-620)