### PR TITLE
Fix timeunits for setting Idle timeout

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -854,7 +854,7 @@
         "value": "okapi_modules"
       },
       {
-        "name": "DB_QUERYTIMEOUT",
+        "name": "DB_IDLETIMEOUT",
         "value": "60000"
       },
       {

--- a/src/main/java/org/folio/inventory/common/dao/PostgresConnectionOptions.java
+++ b/src/main/java/org/folio/inventory/common/dao/PostgresConnectionOptions.java
@@ -11,6 +11,7 @@ import static java.lang.String.format;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Utility class to get connection properties used to connect to Postgres DB.
@@ -28,7 +29,7 @@ public class PostgresConnectionOptions {
   public static final String DB_PASSWORD = "DB_PASSWORD";
   public static final String DB_MAXPOOLSIZE = "DB_MAXPOOLSIZE";
   public static final String DB_SERVER_PEM = "DB_SERVER_PEM";
-  public static final String DB_QUERYTIMEOUT = "DB_QUERYTIMEOUT";
+  public static final String DB_IDLETIMEOUT = "DB_IDLETIMEOUT";
 
   private static Map<String, String> systemProperties = System.getenv();
 
@@ -69,7 +70,9 @@ public class PostgresConnectionOptions {
       pgConnectionOptions.setEnabledSecureTransportProtocols(Collections.singleton("TLSv1.3"));
       pgConnectionOptions.setOpenSslEngineOptions(new OpenSSLEngineOptions());
     }
-    pgConnectionOptions.setIdleTimeout(Integer.parseInt(getSystemProperty(DB_QUERYTIMEOUT) != null ? getSystemProperty(DB_QUERYTIMEOUT) : DEFAULT_IDLE_TIMEOUT));
+    pgConnectionOptions.setIdleTimeout(Integer.parseInt(
+      StringUtils.isNotBlank(getSystemProperty(DB_IDLETIMEOUT)) ? getSystemProperty(DB_IDLETIMEOUT) : DEFAULT_IDLE_TIMEOUT));
+    pgConnectionOptions.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
     if (StringUtils.isNotBlank(tenantId)) {
       pgConnectionOptions.addProperty(DEFAULT_SCHEMA_PROPERTY, convertToPsqlStandard(tenantId));
     }

--- a/src/test/java/org/folio/inventory/dao/PostgresClientFactoryTest.java
+++ b/src/test/java/org/folio/inventory/dao/PostgresClientFactoryTest.java
@@ -27,7 +27,7 @@ import static org.folio.inventory.common.dao.PostgresConnectionOptions.DB_USERNA
 import static org.folio.inventory.common.dao.PostgresConnectionOptions.DB_PASSWORD;
 import static org.folio.inventory.common.dao.PostgresConnectionOptions.DB_MAXPOOLSIZE;
 import static org.folio.inventory.common.dao.PostgresConnectionOptions.DB_SERVER_PEM;
-import static org.folio.inventory.common.dao.PostgresConnectionOptions.DB_QUERYTIMEOUT;
+import static org.folio.inventory.common.dao.PostgresConnectionOptions.DB_IDLETIMEOUT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -113,7 +113,7 @@ public class PostgresClientFactoryTest {
     optionsMap.put(DB_DATABASE, "test");
     optionsMap.put(DB_MAXPOOLSIZE, String.valueOf(MAX_POOL_SIZE));
     optionsMap.put(DB_SERVER_PEM, SERVER_PEM);
-    optionsMap.put(DB_QUERYTIMEOUT, String.valueOf(60000));
+    optionsMap.put(DB_IDLETIMEOUT, String.valueOf(60000));
 
     PostgresConnectionOptions.setSystemProperties(optionsMap);
     PgConnectOptions pgConnectOpts = PostgresConnectionOptions.getConnectionOptions(TENANT_ID);


### PR DESCRIPTION
Idle timeout time units defaults - seconds, and this PR fixes setting of idle timeout for mod-inventory DB that is equals to 60 sec now.
It can prevent potential issues when closed connection remains in pool