### PR TITLE
MODINV-628 Send post-processing event from create/update Authority handlers

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/AbstractAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/AbstractAuthorityEventHandler.java
@@ -103,7 +103,7 @@ public abstract class AbstractAuthorityEventHandler implements EventHandler {
 
   @Override
   public boolean isPostProcessingNeeded() {
-    return false;
+    return true;
   }
 
   protected abstract Future<Authority> processAuthority(Authority authority, AuthorityRecordCollection authorityCollection, DataImportEventPayload payload);

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandler.java
@@ -3,6 +3,7 @@ package org.folio.inventory.dataimport.handlers.actions;
 import static org.folio.ActionProfile.FolioRecord.AUTHORITY;
 import static org.folio.ActionProfile.FolioRecord.MARC_AUTHORITY;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 
 import io.vertx.core.Future;
@@ -77,6 +78,11 @@ public class CreateAuthorityEventHandler extends AbstractAuthorityEventHandler {
   @Override
   protected ProfileSnapshotWrapper.ContentType profileContentType() {
     return ACTION_PROFILE;
+  }
+
+  @Override
+  public String getPostProcessingInitializationEventType() {
+    return DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING.value();
   }
 
   private void createRelationship(Promise<Authority> promise, Authority authority, DataImportEventPayload payload) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandler.java
@@ -6,6 +6,7 @@ import static org.folio.ActionProfile.Action.UPDATE;
 import static org.folio.ActionProfile.FolioRecord.AUTHORITY;
 import static org.folio.ActionProfile.FolioRecord.MARC_AUTHORITY;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_AUTHORITY_UPDATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 
 import io.vertx.core.Future;
@@ -58,6 +59,11 @@ public class UpdateAuthorityEventHandler extends AbstractAuthorityEventHandler {
   @Override
   protected ProfileSnapshotWrapper.ContentType profileContentType() {
     return MAPPING_PROFILE;
+  }
+
+  @Override
+  public String getPostProcessingInitializationEventType() {
+    return DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING.value();
   }
 
   private Future<Authority> updateAuthority(Authority authority, AuthorityRecordCollection authorityRecordCollection) {

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandlerTest.java
@@ -2,6 +2,7 @@ package org.folio.inventory.dataimport.handlers.actions;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static java.util.concurrent.CompletableFuture.completedStage;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -346,5 +347,10 @@ public class CreateAuthorityEventHandlerTest {
   @Test
   public void isPostProcessingNeededShouldReturnFalse() {
     assertFalse(createMarcAuthoritiesEventHandler.isPostProcessingNeeded());
+  }
+
+  @Test
+  public void shouldReturnPostProcessingInitializationEventType() {
+    assertEquals(DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING.value(), createMarcAuthoritiesEventHandler.getPostProcessingInitializationEventType());
   }
 }

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandlerTest.java
@@ -345,8 +345,8 @@ public class CreateAuthorityEventHandlerTest {
   }
 
   @Test
-  public void isPostProcessingNeededShouldReturnFalse() {
-    assertFalse(createMarcAuthoritiesEventHandler.isPostProcessingNeeded());
+  public void isPostProcessingNeededShouldReturnTrue() {
+    assertTrue(createMarcAuthoritiesEventHandler.isPostProcessingNeeded());
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandlerTest.java
@@ -294,8 +294,8 @@ public class UpdateAuthorityEventHandlerTest {
   }
 
   @Test
-  public void isPostProcessingNeededShouldReturnFalse() {
-    assertFalse(eventHandler.isPostProcessingNeeded());
+  public void isPostProcessingNeededShouldReturnTrue() {
+    assertTrue(eventHandler.isPostProcessingNeeded());
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandlerTest.java
@@ -1,6 +1,7 @@
 package org.folio.inventory.dataimport.handlers.actions;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -295,5 +296,10 @@ public class UpdateAuthorityEventHandlerTest {
   @Test
   public void isPostProcessingNeededShouldReturnFalse() {
     assertFalse(eventHandler.isPostProcessingNeeded());
+  }
+
+  @Test
+  public void shouldReturnPostProcessingInitializationEventType() {
+    assertEquals(DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING.value(), eventHandler.getPostProcessingInitializationEventType());
   }
 }


### PR DESCRIPTION
### Purpose
Create/update Authority handlers should send post-processing events:
DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING
DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING

### Learning
[MODINV-628](https://issues.folio.org/browse/MODINV-628)