### PR TITLE
Include server error failure tests in suite MODINV-501

### DIFF
--- a/src/test/java/org/folio/inventory/storage/external/failure/ExternalStorageFailureSuite.java
+++ b/src/test/java/org/folio/inventory/storage/external/failure/ExternalStorageFailureSuite.java
@@ -22,7 +22,8 @@ import io.vertx.core.Vertx;
   ExternalItemCollectionBadRequestExamples.class,
   ExternalInstanceCollectionServerErrorExamples.class,
   ExternalInstanceCollectionBadRequestExamples.class,
-  ExternalAuthorityCollectionBadRequestExamples.class
+  ExternalAuthorityCollectionBadRequestExamples.class,
+  ExternalAuthorityCollectionServerErrorExamples.class
 })
 public class ExternalStorageFailureSuite {
   private static final VertxAssistant vertxAssistant = new VertxAssistant();


### PR DESCRIPTION
*Purpose*

The `ExternalAuthorityCollectionServerErrorExamples` rely on state / preparation from the `ExternalStorageFailureSuite`. This means they need to run within that suite to be reliably executed. Running outside the suite can lead to failures depending upon the combination / order of tests executed. 