### PR TITLE
MODINV-634: PostgreSQL JDBC 42.3.2 Security update (CVE-2022-21724)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
     <vertx.version>4.2.1</vertx.version>
     <jsonschema2pojo_output_dir>${project.build.directory}/generated-sources/jsonschema2pojo</jsonschema2pojo_output_dir>
     <lombok.version>1.18.16</lombok.version>
-    <postgres.version>42.2.23</postgres.version>
+    <postgres.version>42.3.2</postgres.version>
     <liquibase.version>4.6.2</liquibase.version>
   </properties>
 


### PR DESCRIPTION
mod-inventory requires org.postgresql:postgresql for liquibase.

The version org.postgresql:postgresql:42.2.23 has a remote code execution vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2022-21724

https://jdbc.postgresql.org/download.html#current advises to switch to 42.3.*.

42.3.2 fixes the vulnerability.