### PR TITLE
Include config API tests in suite MODINV-498

### DIFF
--- a/src/test/java/api/ApiTestSuite.java
+++ b/src/test/java/api/ApiTestSuite.java
@@ -68,7 +68,8 @@ import support.fakes.FakeOkapi;
   MarkItemUnknownApiTests.class,
   HoldingsApiMoveExamples.class,
   BoundWithTests.class,
-  TenantApiTest.class
+  TenantApiTest.class,
+  InventoryConfigApiTest.class
 })
 public class ApiTestSuite {
   public static final int INVENTORY_VERTICLE_TEST_PORT = 9603;

--- a/src/test/java/api/InventoryConfigApiTest.java
+++ b/src/test/java/api/InventoryConfigApiTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(JUnitParamsRunner.class)
 public class InventoryConfigApiTest extends ApiTests {
   private static final InventoryConfiguration config = new InventoryConfigurationImpl();
 

--- a/src/test/java/api/InventoryConfigApiTest.java
+++ b/src/test/java/api/InventoryConfigApiTest.java
@@ -5,6 +5,8 @@ import api.support.ApiTests;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
+import lombok.SneakyThrows;
+
 import org.folio.inventory.config.InventoryConfiguration;
 import org.folio.inventory.config.InventoryConfigurationImpl;
 import org.folio.inventory.support.http.client.Response;
@@ -23,8 +25,9 @@ import static org.junit.Assert.assertTrue;
 public class InventoryConfigApiTest extends ApiTests {
   private static final InventoryConfiguration config = new InventoryConfigurationImpl();
 
+  @SneakyThrows
   @Test
-  public void shouldReturnInstanceBlockedFieldsConfig() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+  public void shouldReturnInstanceBlockedFieldsConfig() {
     final var getCompleted = okapiClient.get(ApiRoot.instanceBlockedFieldsConfig());
 
     Response getResponse = getCompleted.toCompletableFuture().get(5, SECONDS);
@@ -37,8 +40,9 @@ public class InventoryConfigApiTest extends ApiTests {
     }
   }
 
+  @SneakyThrows
   @Test
-  public void shouldReturnHoldingsBlockedFieldsConfig() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+  public void shouldReturnHoldingsBlockedFieldsConfig() {
     final var getCompleted = okapiClient.get(ApiRoot.holdingsBlockedFieldsConfig());
 
     Response getResponse = getCompleted.toCompletableFuture().get(5, SECONDS);


### PR DESCRIPTION
## Purpose

The `InventoryConfigApiTest`s rely on state / preparation from the `ApiTestSuite`. This means they need to run within that suite to be reliably executed. Running outside the suite can lead to failures depending upon the combination / order of tests executed. 