### PR TITLE
MODINV-641: Can't provide instanceId to build hotlink for Item when trying to update Item and match by Item's field

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -184,6 +184,9 @@ public class UpdateItemEventHandler implements EventHandler {
           LOG.warn(format("Error retrieving Holdings for the hotlink by id %s cause %s, status code %s", updatedItem.getHoldingId(), failure.getReason(), failure.getStatusCode()));
           promise.complete(dataImportEventPayload);
         });
+    } else {
+      LOG.info("Holdings already exists in payload with for the hotlink");
+      promise.complete(dataImportEventPayload);
     }
     return promise.future();
   }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -172,7 +172,7 @@ public class UpdateItemEventHandler implements EventHandler {
 
   private Future<DataImportEventPayload> addHoldingToPayloadIfNeeded(DataImportEventPayload dataImportEventPayload, Context context, Item updatedItem) {
     Promise<DataImportEventPayload> promise = Promise.promise();
-    if (dataImportEventPayload.getContext().get(HOLDINGS.value()) == null || StringUtils.isBlank(dataImportEventPayload.getContext().get(HOLDINGS.value()))) {
+    if (StringUtils.isBlank(dataImportEventPayload.getContext().get(HOLDINGS.value()))) {
       HoldingsRecordCollection holdingsRecordCollection = storage.getHoldingsRecordCollection(context);
       holdingsRecordCollection.findById(updatedItem.getHoldingId(),
         success -> {
@@ -185,7 +185,7 @@ public class UpdateItemEventHandler implements EventHandler {
           promise.complete(dataImportEventPayload);
         });
     } else {
-      LOG.info("Holdings already exists in payload with for the hotlink");
+      LOG.debug("Holdings already exists in payload with for the hotlink with id {}", updatedItem.getHoldingId());
       promise.complete(dataImportEventPayload);
     }
     return promise.future();

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -181,7 +181,7 @@ public class UpdateItemEventHandler implements EventHandler {
           promise.complete(dataImportEventPayload);
         },
         failure -> {
-          LOG.warn(format("Error retrieving Holdings for the hotlink by id %s cause %s, status code %s", updatedItem.getHoldingId(), failure.getReason(), failure.getStatusCode()));
+          LOG.warn("Error retrieving Holdings for the hotlink by id {} cause {}, status code {}", updatedItem.getHoldingId(), failure.getReason(), failure.getStatusCode());
           promise.complete(dataImportEventPayload);
         });
     } else {


### PR DESCRIPTION
**Overview**: The main issue of this ticket is that in cases when there is an update just only for Item-entity -> there is no information about an instance in UI. That's why hotlinks for "UPDATED" Item don't work.
**Approach**: 
If there is no data about Holding in the context at the ItemUpdateHandler, then the new code will go and retrieve a Holding by id (it exists in Item-entity). After that, this Holding(with instanceId) will be added to the payload for the build of all needed data for UI in the next steps of data-import.