### PR TITLE
MODINV-643. Upgrade Vertx versions that contain fixes for the connection pool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testcontainers.version>1.15.3</testcontainers.version>
-    <vertx.version>4.2.1</vertx.version>
+    <vertx.version>4.2.4</vertx.version>
     <jsonschema2pojo_output_dir>${project.build.directory}/generated-sources/jsonschema2pojo</jsonschema2pojo_output_dir>
     <lombok.version>1.18.16</lombok.version>
     <postgres.version>42.3.2</postgres.version>


### PR DESCRIPTION
New 2.4.2 version of Vertx recenly released.

https://github.com/vert-x3/wiki/wiki/4.2.4-Release-Notes#vertx

It contains fixes related to the connection pool and other issues.

So expected version in module pom:
Vertx - 2.4.2