### PR TITLE
MODINV-635 Create processor for Delete Authority record

### DIFF
--- a/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
@@ -23,6 +23,7 @@ import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_NOT_MATCHED;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
+import static org.folio.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_DELETED;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_ENV;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_HOST;
 import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_MAX_REQUEST_SIZE;
@@ -79,6 +80,7 @@ public class DataImportConsumerVerticle extends AbstractVerticle {
     DI_INVENTORY_ITEM_MATCHED,
     DI_INVENTORY_ITEM_NOT_MATCHED,
     DI_SRS_MARC_AUTHORITY_RECORD_CREATED,
+    DI_SRS_MARC_AUTHORITY_RECORD_DELETED,
     DI_SRS_MARC_AUTHORITY_RECORD_MODIFIED_READY_FOR_POST_PROCESSING,
     DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED,
     DI_SRS_MARC_BIB_RECORD_CREATED,

--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -148,7 +148,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     EventManager.registerEventHandler(new CreateMarcHoldingsEventHandler(storage, mappingMetadataCache, new HoldingsIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx)))));
     EventManager.registerEventHandler(new CreateAuthorityEventHandler(storage, mappingMetadataCache, new AuthorityIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx)))));
     EventManager.registerEventHandler(new UpdateAuthorityEventHandler(storage, mappingMetadataCache));
-    EventManager.registerEventHandler(new DeleteAuthorityEventHandler(storage, mappingMetadataCache));
+    EventManager.registerEventHandler(new DeleteAuthorityEventHandler(storage));
     EventManager.registerEventHandler(new UpdateItemEventHandler(storage, mappingMetadataCache));
     EventManager.registerEventHandler(new UpdateHoldingEventHandler(storage, mappingMetadataCache));
     EventManager.registerEventHandler(new ReplaceInstanceEventHandler(storage, precedingSucceedingTitlesHelper, mappingMetadataCache));

--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -37,6 +37,7 @@ import org.folio.inventory.dataimport.handlers.actions.ReplaceInstanceEventHandl
 import org.folio.inventory.dataimport.handlers.actions.UpdateHoldingEventHandler;
 import org.folio.inventory.dataimport.handlers.actions.UpdateItemEventHandler;
 import org.folio.inventory.dataimport.handlers.actions.UpdateAuthorityEventHandler;
+import org.folio.inventory.dataimport.handlers.actions.DeleteAuthorityEventHandler;
 import org.folio.inventory.dataimport.handlers.matching.MatchAuthorityEventHandler;
 import org.folio.inventory.dataimport.handlers.matching.MatchHoldingEventHandler;
 import org.folio.inventory.dataimport.handlers.matching.MatchInstanceEventHandler;
@@ -147,6 +148,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     EventManager.registerEventHandler(new CreateMarcHoldingsEventHandler(storage, mappingMetadataCache, new HoldingsIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx)))));
     EventManager.registerEventHandler(new CreateAuthorityEventHandler(storage, mappingMetadataCache, new AuthorityIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx)))));
     EventManager.registerEventHandler(new UpdateAuthorityEventHandler(storage, mappingMetadataCache));
+    EventManager.registerEventHandler(new DeleteAuthorityEventHandler(storage, mappingMetadataCache));
     EventManager.registerEventHandler(new UpdateItemEventHandler(storage, mappingMetadataCache));
     EventManager.registerEventHandler(new UpdateHoldingEventHandler(storage, mappingMetadataCache));
     EventManager.registerEventHandler(new ReplaceInstanceEventHandler(storage, precedingSucceedingTitlesHelper, mappingMetadataCache));

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandler.java
@@ -79,6 +79,7 @@ public class DeleteAuthorityEventHandler implements EventHandler {
     return false;
   }
 
+  /* Validates the event payload */
   private boolean isExpectedPayload(DataImportEventPayload payload) {
     return payload != null
       && payload.getContext() != null
@@ -86,6 +87,7 @@ public class DeleteAuthorityEventHandler implements EventHandler {
       && StringUtils.isNotBlank(payload.getContext().get(AUTHORITY_RECORD_ID));
   }
 
+  /* Deletes authority by id from storage */
   private Future<Authority> deleteAuthorityRecord(String id, AuthorityRecordCollection authorityCollection) {
     Promise<Authority> promise = Promise.promise();
     authorityCollection.delete(id, success -> promise.complete(),
@@ -95,6 +97,7 @@ public class DeleteAuthorityEventHandler implements EventHandler {
     return promise.future();
   }
 
+  /* Completes the given future with the given payload, writing a message in a log */
   private Handler<Authority> successHandler(DataImportEventPayload payload,
                                             CompletableFuture<DataImportEventPayload> future) {
     return authority -> {
@@ -103,6 +106,7 @@ public class DeleteAuthorityEventHandler implements EventHandler {
     };
   }
 
+  /* Completes exceptionally the given future with the given exception, writing a message in a log */
   private Handler<Throwable> failureHandler(DataImportEventPayload payload,
                                             CompletableFuture<DataImportEventPayload> future) {
     return e -> {
@@ -111,6 +115,7 @@ public class DeleteAuthorityEventHandler implements EventHandler {
     };
   }
 
+  /* Creates message for logging */
   private String constructMsg(String message, DataImportEventPayload payload) {
     if (payload == null) {
       return message;
@@ -124,6 +129,7 @@ public class DeleteAuthorityEventHandler implements EventHandler {
     }
   }
 
+  /* Gets data from header */
   private String getDataIdHeader(DataImportEventPayload payload, String key) {
     return payload.getContext() == null ? "-" : payload.getContext().get(key);
   }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandler.java
@@ -28,7 +28,7 @@ import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTI
 public class DeleteAuthorityEventHandler implements EventHandler {
   private static final Logger LOGGER = LogManager.getLogger(DeleteAuthorityEventHandler.class);
 
-  private static final String MARC_AUTHORITY_ID = "MARC_AUTHORITY_ID";
+  private static final String AUTHORITY_RECORD_ID = "AUTHORITY_RECORD_ID";
   private static final String UNEXPECTED_PAYLOAD_MSG = "Unexpected payload";
   private static final String ERROR_DELETING_AUTHORITY_MSG_TEMPLATE = "Failed deleting Authority. Cause: %s, status: '%s'";
   private static final String DELETE_FAILED_MSG_PATTERN = "Action DELETE for AUTHORITY record failed.";
@@ -53,7 +53,7 @@ public class DeleteAuthorityEventHandler implements EventHandler {
 
       var context = constructContext(payload.getTenant(), payload.getToken(), payload.getOkapiUrl());
       AuthorityRecordCollection authorityRecordCollection = storage.getAuthorityRecordCollection(context);
-      String id = payload.getContext().get(MARC_AUTHORITY_ID);
+      String id = payload.getContext().get(AUTHORITY_RECORD_ID);
 
       deleteAuthorityRecord(id, authorityRecordCollection)
         .onSuccess(successHandler(payload, future))
@@ -83,7 +83,7 @@ public class DeleteAuthorityEventHandler implements EventHandler {
     return payload != null
       && payload.getContext() != null
       && !payload.getContext().isEmpty()
-      && StringUtils.isNotBlank(payload.getContext().get(MARC_AUTHORITY_ID));
+      && StringUtils.isNotBlank(payload.getContext().get(AUTHORITY_RECORD_ID));
   }
 
   private Future<Authority> deleteAuthorityRecord(String id, AuthorityRecordCollection authorityCollection) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandler.java
@@ -1,0 +1,67 @@
+package org.folio.inventory.dataimport.handlers.actions;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import org.folio.ActionProfile;
+import org.folio.Authority;
+import org.folio.DataImportEventPayload;
+import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.dataimport.exceptions.DataImportException;
+import org.folio.inventory.domain.AuthorityRecordCollection;
+import org.folio.inventory.storage.Storage;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+
+import static java.lang.String.format;
+import static org.folio.ActionProfile.FolioRecord.AUTHORITY;
+import static org.folio.ActionProfile.FolioRecord.MARC_AUTHORITY;
+import static org.folio.ActionProfile.Action.DELETE;
+import static org.folio.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_DELETED;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
+
+public class DeleteAuthorityEventHandler extends AbstractAuthorityEventHandler {
+  protected static final String ERROR_DELETING_AUTHORITY_MSG_TEMPLATE = "Failed deleting Authority. Cause: %s, status: '%s'";
+
+  public DeleteAuthorityEventHandler(Storage storage, MappingMetadataCache mappingMetadataCache) {
+    super(storage, mappingMetadataCache);
+  }
+
+  @Override
+  protected Future<Authority> processAuthority(Authority authority, AuthorityRecordCollection authorityCollection, DataImportEventPayload payload) {
+    return deleteAuthority(authority, authorityCollection);
+  }
+
+  @Override
+  protected String nextEventType() {
+    return DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value();
+  }
+
+  @Override
+  protected ActionProfile.Action profileAction() {
+    return DELETE;
+  }
+
+  @Override
+  protected ActionProfile.FolioRecord sourceRecordType() {
+    return MARC_AUTHORITY;
+  }
+
+  @Override
+  protected ActionProfile.FolioRecord targetRecordType() {
+    return AUTHORITY;
+  }
+
+  @Override
+  protected ProfileSnapshotWrapper.ContentType profileContentType() {
+    return MAPPING_PROFILE;
+  }
+
+  private Future<Authority> deleteAuthority(Authority authority, AuthorityRecordCollection authorityCollection) {
+    Promise<Authority> promise = Promise.promise();
+    authorityCollection.delete(authority.getId(), success -> promise.complete(authority),
+      failure -> promise.fail(new DataImportException(format(ERROR_DELETING_AUTHORITY_MSG_TEMPLATE, failure.getReason(),
+        failure.getStatusCode()))
+      ));
+    return promise.future();
+  }
+
+}

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandler.java
@@ -1,67 +1,131 @@
 package org.folio.inventory.dataimport.handlers.actions;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.ActionProfile;
 import org.folio.Authority;
 import org.folio.DataImportEventPayload;
-import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.exceptions.DataImportException;
 import org.folio.inventory.domain.AuthorityRecordCollection;
 import org.folio.inventory.storage.Storage;
+import org.folio.processing.events.services.handler.EventHandler;
+import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 
+import java.util.concurrent.CompletableFuture;
+
+import static io.vertx.core.json.JsonObject.mapFrom;
 import static java.lang.String.format;
-import static org.folio.ActionProfile.FolioRecord.AUTHORITY;
-import static org.folio.ActionProfile.FolioRecord.MARC_AUTHORITY;
 import static org.folio.ActionProfile.Action.DELETE;
-import static org.folio.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_DELETED;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
+import static org.folio.ActionProfile.FolioRecord.MARC_AUTHORITY;
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.constructContext;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 
-public class DeleteAuthorityEventHandler extends AbstractAuthorityEventHandler {
-  protected static final String ERROR_DELETING_AUTHORITY_MSG_TEMPLATE = "Failed deleting Authority. Cause: %s, status: '%s'";
+public class DeleteAuthorityEventHandler implements EventHandler {
+  private static final Logger LOGGER = LogManager.getLogger(DeleteAuthorityEventHandler.class);
 
-  public DeleteAuthorityEventHandler(Storage storage, MappingMetadataCache mappingMetadataCache) {
-    super(storage, mappingMetadataCache);
+  private static final String MARC_AUTHORITY_ID = "MARC_AUTHORITY_ID";
+  private static final String UNEXPECTED_PAYLOAD_MSG = "Unexpected payload";
+  private static final String ERROR_DELETING_AUTHORITY_MSG_TEMPLATE = "Failed deleting Authority. Cause: %s, status: '%s'";
+  private static final String DELETE_FAILED_MSG_PATTERN = "Action DELETE for AUTHORITY record failed.";
+  private static final String DELETE_SUCCEED_MSG_PATTERN = "Action DELETE for AUTHORITY record succeed.";
+  private static final String META_INFO_MSG_PATTERN = "JobExecutionId: '%s', RecordId: '%s', ChunkId: '%s'";
+  private static final String RECORD_ID_HEADER = "recordId";
+  private static final String CHUNK_ID_HEADER = "chunkId";
+
+  private final Storage storage;
+
+  public DeleteAuthorityEventHandler(Storage storage) {
+    this.storage = storage;
   }
 
   @Override
-  protected Future<Authority> processAuthority(Authority authority, AuthorityRecordCollection authorityCollection, DataImportEventPayload payload) {
-    return deleteAuthority(authority, authorityCollection);
+  public CompletableFuture<DataImportEventPayload> handle(DataImportEventPayload payload) {
+    CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
+    try {
+      if (!isExpectedPayload(payload)) {
+        throw new EventProcessingException(UNEXPECTED_PAYLOAD_MSG);
+      }
+
+      var context = constructContext(payload.getTenant(), payload.getToken(), payload.getOkapiUrl());
+      AuthorityRecordCollection authorityRecordCollection = storage.getAuthorityRecordCollection(context);
+      String id = payload.getContext().get(MARC_AUTHORITY_ID);
+
+      deleteAuthorityRecord(id, authorityRecordCollection)
+        .onSuccess(successHandler(payload, future))
+        .onFailure(failureHandler(payload, future));
+    } catch (Exception e) {
+      LOGGER.error(constructMsg(DELETE_FAILED_MSG_PATTERN, payload), e);
+      future.completeExceptionally(e);
+    }
+
+    return future;
   }
 
   @Override
-  protected String nextEventType() {
-    return DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value();
+  public boolean isEligible(DataImportEventPayload payload) {
+    if (isExpectedPayload(payload)) {
+      ProfileSnapshotWrapper currentNode = payload.getCurrentNode();
+      if (currentNode != null && ACTION_PROFILE == currentNode.getContentType()) {
+        var actionProfile = mapFrom(currentNode.getContent()).mapTo(ActionProfile.class);
+        return DELETE == actionProfile.getAction() && MARC_AUTHORITY == actionProfile.getFolioRecord();
+      }
+    }
+
+    return false;
   }
 
-  @Override
-  protected ActionProfile.Action profileAction() {
-    return DELETE;
+  private boolean isExpectedPayload(DataImportEventPayload payload) {
+    return payload != null
+      && payload.getContext() != null
+      && !payload.getContext().isEmpty()
+      && StringUtils.isNotBlank(payload.getContext().get(MARC_AUTHORITY_ID));
   }
 
-  @Override
-  protected ActionProfile.FolioRecord sourceRecordType() {
-    return MARC_AUTHORITY;
-  }
-
-  @Override
-  protected ActionProfile.FolioRecord targetRecordType() {
-    return AUTHORITY;
-  }
-
-  @Override
-  protected ProfileSnapshotWrapper.ContentType profileContentType() {
-    return MAPPING_PROFILE;
-  }
-
-  private Future<Authority> deleteAuthority(Authority authority, AuthorityRecordCollection authorityCollection) {
+  private Future<Authority> deleteAuthorityRecord(String id, AuthorityRecordCollection authorityCollection) {
     Promise<Authority> promise = Promise.promise();
-    authorityCollection.delete(authority.getId(), success -> promise.complete(authority),
-      failure -> promise.fail(new DataImportException(format(ERROR_DELETING_AUTHORITY_MSG_TEMPLATE, failure.getReason(),
-        failure.getStatusCode()))
+    authorityCollection.delete(id, success -> promise.complete(),
+      failure -> promise.fail(new DataImportException(format(ERROR_DELETING_AUTHORITY_MSG_TEMPLATE,
+        failure.getReason(), failure.getStatusCode()))
       ));
     return promise.future();
+  }
+
+  private Handler<Authority> successHandler(DataImportEventPayload payload,
+                                            CompletableFuture<DataImportEventPayload> future) {
+    return authority -> {
+      LOGGER.info(constructMsg(DELETE_SUCCEED_MSG_PATTERN, payload));
+      future.complete(payload);
+    };
+  }
+
+  private Handler<Throwable> failureHandler(DataImportEventPayload payload,
+                                            CompletableFuture<DataImportEventPayload> future) {
+    return e -> {
+      LOGGER.error(constructMsg(DELETE_FAILED_MSG_PATTERN, payload), e);
+      future.completeExceptionally(e);
+    };
+  }
+
+  private String constructMsg(String message, DataImportEventPayload payload) {
+    if (payload == null) {
+      return message;
+    } else {
+      return message + " " + format(
+        META_INFO_MSG_PATTERN,
+        payload.getJobExecutionId(),
+        getDataIdHeader(payload, RECORD_ID_HEADER),
+        getDataIdHeader(payload, CHUNK_ID_HEADER)
+      );
+    }
+  }
+
+  private String getDataIdHeader(DataImportEventPayload payload, String key) {
+    return payload.getContext() == null ? "-" : payload.getContext().get(key);
   }
 
 }

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandlerTest.java
@@ -1,27 +1,18 @@
 package org.folio.inventory.dataimport.handlers.actions;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.github.tomakehurst.wiremock.matching.RegexPattern;
-import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
-import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
-import org.folio.MappingMetadataDto;
-import org.folio.MappingProfile;
+import org.folio.JobProfile;
 import org.folio.inventory.TestUtil;
 import org.folio.inventory.common.domain.Success;
-import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.domain.AuthorityRecordCollection;
 import org.folio.inventory.storage.Storage;
 import org.folio.processing.mapping.MappingManager;
-import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
-import org.folio.rest.jaxrs.model.EntityType;
-import org.folio.rest.jaxrs.model.MappingDetail;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.ParsedRecord;
@@ -32,7 +23,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -41,19 +31,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static org.folio.ActionProfile.Action.DELETE;
+import static org.folio.ActionProfile.Action.UPDATE;
 import static org.folio.ActionProfile.FolioRecord.MARC_AUTHORITY;
-import static org.folio.ActionProfile.FolioRecord.AUTHORITY;
 import static org.folio.ActionProfile.FolioRecord.ITEM;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_DELETED;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -62,55 +47,42 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 public class DeleteAuthorityEventHandlerTest {
-  private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/marc-authority-rules.json";
   private static final String PARSED_AUTHORITY_RECORD = "src/test/resources/marc/authority/parsed-authority-record.json";
-  private static final String MAPPING_METADATA_URL = "/mapping-metadata";
+  private static final String MARC_AUTHORITY_ID = "MARC_AUTHORITY_ID";
 
-  private final Vertx vertx = Vertx.vertx();
   @Rule
   public WireMockRule mockServer = new WireMockRule(
     WireMockConfiguration.wireMockConfig()
       .dynamicPort()
       .notifier(new Slf4jNotifier(true)));
 
-  protected ActionProfile actionProfile = new ActionProfile()
+  private ActionProfile actionProfile = new ActionProfile()
     .withId(UUID.randomUUID().toString())
-    .withName("Delete item-SR")
+    .withName("Delete Marc Authorities")
     .withAction(DELETE)
-    .withFolioRecord(ActionProfile.FolioRecord.AUTHORITY);
+    .withFolioRecord(MARC_AUTHORITY);
 
-  private MappingProfile mappingProfile = new MappingProfile()
+  private ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
     .withId(UUID.randomUUID().toString())
-    .withName("Delete MARC authority")
-    .withIncomingRecordType(EntityType.MARC_AUTHORITY)
-    .withExistingRecordType(EntityType.MARC_AUTHORITY)
-    .withMappingDetails(new MappingDetail());
-
-  protected ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
     .withProfileId(actionProfile.getId())
     .withContentType(ACTION_PROFILE)
-    .withContent(JsonObject.mapFrom(actionProfile).getMap())
-    .withChildSnapshotWrappers(Collections.singletonList(
-      new ProfileSnapshotWrapper()
-        .withProfileId(mappingProfile.getId())
-        .withContentType(MAPPING_PROFILE)
-        .withContent(JsonObject.mapFrom(mappingProfile).getMap())));
+    .withContent(actionProfile);
 
   @Mock
-  protected AuthorityRecordCollection authorityCollection;
+  private AuthorityRecordCollection authorityCollection;
 
   @Mock
-  protected Storage storage;
+  private Storage storage;
 
-  protected DeleteAuthorityEventHandler eventHandler;
+  private DeleteAuthorityEventHandler eventHandler;
+
+  private HashMap<String, String> context = new HashMap<>();
 
   @Before
   public void setUp() throws IOException {
     MockitoAnnotations.openMocks(this);
     MappingManager.clearReaderFactories();
-    MappingMetadataCache mappingMetadataCache = new MappingMetadataCache(vertx, vertx.createHttpClient(), 3600);
-    eventHandler = new DeleteAuthorityEventHandler(storage, mappingMetadataCache);
-    JsonObject mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
+    eventHandler = new DeleteAuthorityEventHandler(storage);
 
     doAnswer(invocationOnMock -> {
       Consumer<Success<Void>> successHandler = invocationOnMock.getArgument(1);
@@ -118,34 +90,30 @@ public class DeleteAuthorityEventHandlerTest {
       return null;
     }).when(authorityCollection).delete(any(), any(), any());
 
-    WireMock.stubFor(get(new UrlPathPattern(new RegexPattern(MAPPING_METADATA_URL + "/.*"), true))
-      .willReturn(WireMock.ok().withBody(Json.encode(new MappingMetadataDto()
-        .withMappingParams(Json.encode(new MappingParameters()))
-        .withMappingRules(mappingRules.encode())))));
+    var parsedAuthorityRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD));
+    context.put(MARC_AUTHORITY_ID,
+      Json.encode(new Record()
+        .withId(UUID.randomUUID().toString())
+        .withParsedRecord(new ParsedRecord().withContent(parsedAuthorityRecord.encode()))));
   }
 
   @Test
-  public void shouldProcessEvent() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+  public void shouldProcessEvent() throws InterruptedException, ExecutionException, TimeoutException {
     when(storage.getAuthorityRecordCollection(any())).thenReturn(authorityCollection);
 
-    var parsedAuthorityRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD));
-    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedAuthorityRecord.encode()));
-    HashMap<String, String> context = new HashMap<>();
-    context.put(MARC_AUTHORITY.value(), Json.encode(record));
-
-    org.folio.DataImportEventPayload dataImportEventPayload = new org.folio.DataImportEventPayload()
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withOkapiUrl(mockServer.baseUrl())
       .withContext(context)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper);
 
     CompletableFuture<org.folio.DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
     org.folio.DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.SECONDS);
 
     assertEquals(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value(), actualDataImportEventPayload.getEventType());
-    assertNotNull(actualDataImportEventPayload.getContext().get(AUTHORITY.value()));
-    assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(AUTHORITY.value())).getString("id"));
+    assertNotNull(actualDataImportEventPayload.getContext().get(MARC_AUTHORITY_ID));
+    assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(MARC_AUTHORITY_ID)).getString("id"));
   }
 
   @Test(expected = ExecutionException.class)
@@ -154,7 +122,7 @@ public class DeleteAuthorityEventHandlerTest {
       .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
       .withContext(null)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper);
 
     CompletableFuture<DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
     future.get(5, TimeUnit.MILLISECONDS);
@@ -166,31 +134,31 @@ public class DeleteAuthorityEventHandlerTest {
       .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper);
 
     CompletableFuture<DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
     future.get(5, TimeUnit.MILLISECONDS);
   }
 
   @Test(expected = ExecutionException.class)
-  public void shouldThrowExceptionIfMarcAuthorityIsEmptyInContext()
+  public void shouldThrowExceptionIfMarcAuthorityIdIsEmptyInContext()
     throws ExecutionException, InterruptedException, TimeoutException {
 
     HashMap<String, String> context = new HashMap<>();
-    context.put(MARC_AUTHORITY.value(), "");
+    context.put(MARC_AUTHORITY_ID, "");
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
       .withContext(context)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper);
 
     CompletableFuture<DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
     future.get(5, TimeUnit.MILLISECONDS);
   }
 
   @Test(expected = ExecutionException.class)
-  public void shouldThrowExceptionIfMarcAuthorityIsNotInContext()
+  public void shouldThrowExceptionIfMarcAuthorityIdIsNotInContext()
     throws ExecutionException, InterruptedException, TimeoutException {
 
     HashMap<String, String> context = new HashMap<>();
@@ -200,72 +168,71 @@ public class DeleteAuthorityEventHandlerTest {
       .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
       .withContext(context)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper);
 
     CompletableFuture<DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
     future.get(5, TimeUnit.MILLISECONDS);
   }
 
   @Test
-  public void shouldReturnFailedFutureIfCurrentActionProfileHasNoMappingProfile() throws IOException {
-    var parsedAuthorityRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD));
-
-    HashMap<String, String> context = new HashMap<>();
-    context.put(MARC_AUTHORITY.value(),
-      Json.encode(new Record().withParsedRecord(new ParsedRecord().withContent(parsedAuthorityRecord.encode()))));
-
+  public void isEligibleShouldReturnTrue() {
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
       .withContext(context)
-      .withCurrentNode(new ProfileSnapshotWrapper()
-        .withContentType(ACTION_PROFILE)
-        .withContent(actionProfile));
-
-    CompletableFuture<DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
-
-    ExecutionException exception = assertThrows(ExecutionException.class, future::get);
-    assertThat(exception.getCause().getMessage(), containsString("Unexpected payload"));
-  }
-
-  @Test
-  public void isEligibleShouldReturnTrue() throws IOException {
-    var parsedAuthorityRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD));
-
-    HashMap<String, String> context = new HashMap<>();
-    context.put(MARC_AUTHORITY.value(),
-      Json.encode(new Record().withParsedRecord(new ParsedRecord().withContent(parsedAuthorityRecord.encode()))));
-
-    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
-      .withContext(context)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper);
     assertTrue(eventHandler.isEligible(dataImportEventPayload));
   }
 
   @Test
-  public void isEligibleShouldReturnFalseIfCurrentNodeIsEmpty() {
+  public void isEligibleShouldReturnFalseIfPayloadIsNull() {
+    assertFalse(eventHandler.isEligible(null));
+  }
+
+  @Test
+  public void isEligibleShouldReturnFalseIfCurrentNodeIsEmpty(){
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
-      .withContext(new HashMap<>());
+      .withContext(context);
     assertFalse(eventHandler.isEligible(dataImportEventPayload));
   }
 
   @Test
-  public void isEligibleShouldReturnFalseIfActionIsNotCreate() {
+  public void isEligibleShouldReturnFalseIfCurrentNodeIsNotActionProfile(){
+    JobProfile jobProfile = new JobProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create MARC Authority")
+      .withDataType(JobProfile.DataType.MARC);
+    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(jobProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(jobProfile);
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
+      .withContext(context)
+      .withCurrentNode(profileSnapshotWrapper);
+    assertFalse(eventHandler.isEligible(dataImportEventPayload));
+  }
+
+  @Test
+  public void isEligibleShouldReturnFalseIfActionIsNotDelete() {
     ActionProfile actionProfile = new ActionProfile()
       .withId(UUID.randomUUID().toString())
-      .withName("Delete Item")
-      .withAction(DELETE)
-      .withFolioRecord(AUTHORITY);
+      .withName("Update Marc Authorities")
+      .withAction(UPDATE)
+      .withFolioRecord(MARC_AUTHORITY);
+
     ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
       .withId(UUID.randomUUID().toString())
       .withProfileId(actionProfile.getId())
-      .withContentType(JOB_PROFILE)
+      .withContentType(ACTION_PROFILE)
       .withContent(actionProfile);
+
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
-      .withContext(new HashMap<>())
-      .withProfileSnapshot(profileSnapshotWrapper);
+      .withContext(context)
+      .withCurrentNode(profileSnapshotWrapper);
+
     assertFalse(eventHandler.isEligible(dataImportEventPayload));
   }
 
@@ -273,24 +240,22 @@ public class DeleteAuthorityEventHandlerTest {
   public void isEligibleShouldReturnFalseIfRecordIsNotAuthority() {
     ActionProfile actionProfile = new ActionProfile()
       .withId(UUID.randomUUID().toString())
-      .withName("Delete Item")
+      .withName("Delete Marc Authorities")
       .withAction(DELETE)
       .withFolioRecord(ITEM);
+
     ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
       .withId(UUID.randomUUID().toString())
       .withProfileId(actionProfile.getId())
-      .withContentType(JOB_PROFILE)
+      .withContentType(ACTION_PROFILE)
       .withContent(actionProfile);
+
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
-      .withContext(new HashMap<>())
-      .withProfileSnapshot(profileSnapshotWrapper);
-    assertFalse(eventHandler.isEligible(dataImportEventPayload));
-  }
+      .withContext(context)
+      .withCurrentNode(profileSnapshotWrapper);
 
-  @Test
-  public void isPostProcessingNeededShouldReturnTrue() {
-    assertTrue(eventHandler.isPostProcessingNeeded());
+    assertFalse(eventHandler.isEligible(dataImportEventPayload));
   }
 
 }

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandlerTest.java
@@ -3,19 +3,14 @@ package org.folio.inventory.dataimport.handlers.actions;
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonObject;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
 import org.folio.JobProfile;
-import org.folio.inventory.TestUtil;
 import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.domain.AuthorityRecordCollection;
 import org.folio.inventory.storage.Storage;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
-import org.folio.rest.jaxrs.model.Record;
-import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,7 +42,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 public class DeleteAuthorityEventHandlerTest {
-  private static final String PARSED_AUTHORITY_RECORD = "src/test/resources/marc/authority/parsed-authority-record.json";
   private static final String MARC_AUTHORITY_ID = "MARC_AUTHORITY_ID";
 
   @Rule
@@ -90,11 +84,7 @@ public class DeleteAuthorityEventHandlerTest {
       return null;
     }).when(authorityCollection).delete(any(), any(), any());
 
-    var parsedAuthorityRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD));
-    context.put(MARC_AUTHORITY_ID,
-      Json.encode(new Record()
-        .withId(UUID.randomUUID().toString())
-        .withParsedRecord(new ParsedRecord().withContent(parsedAuthorityRecord.encode()))));
+    context.put(MARC_AUTHORITY_ID, UUID.randomUUID().toString());
   }
 
   @Test
@@ -113,7 +103,6 @@ public class DeleteAuthorityEventHandlerTest {
 
     assertEquals(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value(), actualDataImportEventPayload.getEventType());
     assertNotNull(actualDataImportEventPayload.getContext().get(MARC_AUTHORITY_ID));
-    assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(MARC_AUTHORITY_ID)).getString("id"));
   }
 
   @Test(expected = ExecutionException.class)

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandlerTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 public class DeleteAuthorityEventHandlerTest {
-  private static final String MARC_AUTHORITY_ID = "MARC_AUTHORITY_ID";
+  private static final String AUTHORITY_RECORD_ID = "AUTHORITY_RECORD_ID";
 
   @Rule
   public WireMockRule mockServer = new WireMockRule(
@@ -84,7 +84,7 @@ public class DeleteAuthorityEventHandlerTest {
       return null;
     }).when(authorityCollection).delete(any(), any(), any());
 
-    context.put(MARC_AUTHORITY_ID, UUID.randomUUID().toString());
+    context.put(AUTHORITY_RECORD_ID, UUID.randomUUID().toString());
   }
 
   @Test
@@ -102,7 +102,7 @@ public class DeleteAuthorityEventHandlerTest {
     org.folio.DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.SECONDS);
 
     assertEquals(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value(), actualDataImportEventPayload.getEventType());
-    assertNotNull(actualDataImportEventPayload.getContext().get(MARC_AUTHORITY_ID));
+    assertNotNull(actualDataImportEventPayload.getContext().get(AUTHORITY_RECORD_ID));
   }
 
   @Test(expected = ExecutionException.class)
@@ -134,7 +134,7 @@ public class DeleteAuthorityEventHandlerTest {
     throws ExecutionException, InterruptedException, TimeoutException {
 
     HashMap<String, String> context = new HashMap<>();
-    context.put(MARC_AUTHORITY_ID, "");
+    context.put(AUTHORITY_RECORD_ID, "");
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/DeleteAuthorityEventHandlerTest.java
@@ -1,0 +1,296 @@
+package org.folio.inventory.dataimport.handlers.actions;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import org.folio.ActionProfile;
+import org.folio.DataImportEventPayload;
+import org.folio.MappingMetadataDto;
+import org.folio.MappingProfile;
+import org.folio.inventory.TestUtil;
+import org.folio.inventory.common.domain.Success;
+import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.domain.AuthorityRecordCollection;
+import org.folio.inventory.storage.Storage;
+import org.folio.processing.mapping.MappingManager;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.rest.jaxrs.model.EntityType;
+import org.folio.rest.jaxrs.model.MappingDetail;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static org.folio.ActionProfile.Action.DELETE;
+import static org.folio.ActionProfile.FolioRecord.MARC_AUTHORITY;
+import static org.folio.ActionProfile.FolioRecord.AUTHORITY;
+import static org.folio.ActionProfile.FolioRecord.ITEM;
+import static org.folio.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_DELETED;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+public class DeleteAuthorityEventHandlerTest {
+  private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/marc-authority-rules.json";
+  private static final String PARSED_AUTHORITY_RECORD = "src/test/resources/marc/authority/parsed-authority-record.json";
+  private static final String MAPPING_METADATA_URL = "/mapping-metadata";
+
+  private final Vertx vertx = Vertx.vertx();
+  @Rule
+  public WireMockRule mockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new Slf4jNotifier(true)));
+
+  protected ActionProfile actionProfile = new ActionProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Delete item-SR")
+    .withAction(DELETE)
+    .withFolioRecord(ActionProfile.FolioRecord.AUTHORITY);
+
+  private MappingProfile mappingProfile = new MappingProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Delete MARC authority")
+    .withIncomingRecordType(EntityType.MARC_AUTHORITY)
+    .withExistingRecordType(EntityType.MARC_AUTHORITY)
+    .withMappingDetails(new MappingDetail());
+
+  protected ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+    .withProfileId(actionProfile.getId())
+    .withContentType(ACTION_PROFILE)
+    .withContent(JsonObject.mapFrom(actionProfile).getMap())
+    .withChildSnapshotWrappers(Collections.singletonList(
+      new ProfileSnapshotWrapper()
+        .withProfileId(mappingProfile.getId())
+        .withContentType(MAPPING_PROFILE)
+        .withContent(JsonObject.mapFrom(mappingProfile).getMap())));
+
+  @Mock
+  protected AuthorityRecordCollection authorityCollection;
+
+  @Mock
+  protected Storage storage;
+
+  protected DeleteAuthorityEventHandler eventHandler;
+
+  @Before
+  public void setUp() throws IOException {
+    MockitoAnnotations.openMocks(this);
+    MappingManager.clearReaderFactories();
+    MappingMetadataCache mappingMetadataCache = new MappingMetadataCache(vertx, vertx.createHttpClient(), 3600);
+    eventHandler = new DeleteAuthorityEventHandler(storage, mappingMetadataCache);
+    JsonObject mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
+
+    doAnswer(invocationOnMock -> {
+      Consumer<Success<Void>> successHandler = invocationOnMock.getArgument(1);
+      successHandler.accept(new Success<>(null));
+      return null;
+    }).when(authorityCollection).delete(any(), any(), any());
+
+    WireMock.stubFor(get(new UrlPathPattern(new RegexPattern(MAPPING_METADATA_URL + "/.*"), true))
+      .willReturn(WireMock.ok().withBody(Json.encode(new MappingMetadataDto()
+        .withMappingParams(Json.encode(new MappingParameters()))
+        .withMappingRules(mappingRules.encode())))));
+  }
+
+  @Test
+  public void shouldProcessEvent() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    when(storage.getAuthorityRecordCollection(any())).thenReturn(authorityCollection);
+
+    var parsedAuthorityRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedAuthorityRecord.encode()));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_AUTHORITY.value(), Json.encode(record));
+
+    org.folio.DataImportEventPayload dataImportEventPayload = new org.folio.DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withOkapiUrl(mockServer.baseUrl())
+      .withContext(context)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<org.folio.DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
+    org.folio.DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.SECONDS);
+
+    assertEquals(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value(), actualDataImportEventPayload.getEventType());
+    assertNotNull(actualDataImportEventPayload.getContext().get(AUTHORITY.value()));
+    assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(AUTHORITY.value())).getString("id"));
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void shouldThrowExceptionIfContextIsNull() throws ExecutionException, InterruptedException, TimeoutException {
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
+      .withContext(null)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
+    future.get(5, TimeUnit.MILLISECONDS);
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void shouldThrowExceptionIfContextIsEmpty() throws ExecutionException, InterruptedException, TimeoutException {
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
+      .withContext(new HashMap<>())
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
+    future.get(5, TimeUnit.MILLISECONDS);
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void shouldThrowExceptionIfMarcAuthorityIsEmptyInContext()
+    throws ExecutionException, InterruptedException, TimeoutException {
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_AUTHORITY.value(), "");
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
+    future.get(5, TimeUnit.MILLISECONDS);
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void shouldThrowExceptionIfMarcAuthorityIsNotInContext()
+    throws ExecutionException, InterruptedException, TimeoutException {
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put("Test_Value", "");
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
+    future.get(5, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void shouldReturnFailedFutureIfCurrentActionProfileHasNoMappingProfile() throws IOException {
+    var parsedAuthorityRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD));
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_AUTHORITY.value(),
+      Json.encode(new Record().withParsedRecord(new ParsedRecord().withContent(parsedAuthorityRecord.encode()))));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
+      .withContext(context)
+      .withCurrentNode(new ProfileSnapshotWrapper()
+        .withContentType(ACTION_PROFILE)
+        .withContent(actionProfile));
+
+    CompletableFuture<DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
+
+    ExecutionException exception = assertThrows(ExecutionException.class, future::get);
+    assertThat(exception.getCause().getMessage(), containsString("Unexpected payload"));
+  }
+
+  @Test
+  public void isEligibleShouldReturnTrue() throws IOException {
+    var parsedAuthorityRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD));
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_AUTHORITY.value(),
+      Json.encode(new Record().withParsedRecord(new ParsedRecord().withContent(parsedAuthorityRecord.encode()))));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
+      .withContext(context)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+    assertTrue(eventHandler.isEligible(dataImportEventPayload));
+  }
+
+  @Test
+  public void isEligibleShouldReturnFalseIfCurrentNodeIsEmpty() {
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
+      .withContext(new HashMap<>());
+    assertFalse(eventHandler.isEligible(dataImportEventPayload));
+  }
+
+  @Test
+  public void isEligibleShouldReturnFalseIfActionIsNotCreate() {
+    ActionProfile actionProfile = new ActionProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Delete Item")
+      .withAction(DELETE)
+      .withFolioRecord(AUTHORITY);
+    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(actionProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(actionProfile);
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
+      .withContext(new HashMap<>())
+      .withProfileSnapshot(profileSnapshotWrapper);
+    assertFalse(eventHandler.isEligible(dataImportEventPayload));
+  }
+
+  @Test
+  public void isEligibleShouldReturnFalseIfRecordIsNotAuthority() {
+    ActionProfile actionProfile = new ActionProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Delete Item")
+      .withAction(DELETE)
+      .withFolioRecord(ITEM);
+    ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(actionProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(actionProfile);
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value())
+      .withContext(new HashMap<>())
+      .withProfileSnapshot(profileSnapshotWrapper);
+    assertFalse(eventHandler.isEligible(dataImportEventPayload));
+  }
+
+  @Test
+  public void isPostProcessingNeededShouldReturnTrue() {
+    assertTrue(eventHandler.isPostProcessingNeeded());
+  }
+
+}


### PR DESCRIPTION
## Purpose
The module should be able to process the DI_SRS_MARC_AUTHORITY_RECORD_DELETED event.

## Approach
Subscribe to DI_SRS_MARC_AUTHORITY_RECORD_DELETED topic
Create a handler for Authority delete action that will delete Authority from mod-inventory-storage

## Learning
[MODINV-635](https://issues.folio.org/browse/MODINV-635)