### PR TITLE
MODINV-648: Upgrade Vertx to 4.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testcontainers.version>1.15.3</testcontainers.version>
-    <vertx.version>4.2.4</vertx.version>
+    <vertx.version>4.2.5</vertx.version>
     <jsonschema2pojo_output_dir>${project.build.directory}/generated-sources/jsonschema2pojo</jsonschema2pojo_output_dir>
     <lombok.version>1.18.16</lombok.version>
     <postgres.version>42.3.2</postgres.version>


### PR DESCRIPTION
## Purpose
Upgrade RMB and Vertx versions that contain fixes for the connection pool

## Learning
https://issues.folio.org/browse/MODINV-648