### PR TITLE
MODINV-646: Add logic to skip sending DI_ERROR from mod-inventory in case for duplicates.

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/exceptions/DuplicatedEventException.java
+++ b/src/main/java/org/folio/inventory/dataimport/exceptions/DuplicatedEventException.java
@@ -1,0 +1,8 @@
+package org.folio.inventory.dataimport.exceptions;
+
+public class DuplicatedEventException extends RuntimeException {
+
+  public DuplicatedEventException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/inventory/dataimport/util/DataImportConstants.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/DataImportConstants.java
@@ -1,0 +1,10 @@
+package org.folio.inventory.dataimport.util;
+
+public class DataImportConstants {
+
+  public static final String UNIQUE_ID_ERROR_MESSAGE = "id value already exists in table";
+
+
+  private DataImportConstants() {
+  }
+}

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandlerTest.java
@@ -2,6 +2,7 @@ package org.folio.inventory.dataimport.handlers.actions;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static java.util.concurrent.CompletableFuture.completedStage;
+import static org.folio.inventory.dataimport.util.DataImportConstants.UNIQUE_ID_ERROR_MESSAGE;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
@@ -42,6 +43,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import org.apache.http.HttpStatus;
+import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.domain.relationship.RecordToEntity;
 import org.folio.inventory.services.IdStorageService;
 import org.junit.Before;
@@ -170,6 +172,35 @@ public class CreateAuthorityEventHandlerTest {
   @Test
   public void shouldProcessEvent() throws IOException, InterruptedException, ExecutionException, TimeoutException {
     when(storage.getAuthorityRecordCollection(any())).thenReturn(authorityCollection);
+
+    var parsedAuthorityRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedAuthorityRecord.encode()));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_AUTHORITY.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_AUTHORITY_RECORD_CREATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withOkapiUrl(mockServer.baseUrl())
+      .withContext(context)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createMarcAuthoritiesEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.SECONDS);
+
+    assertEquals(DI_INVENTORY_AUTHORITY_CREATED.value(), actualDataImportEventPayload.getEventType());
+    assertNotNull(actualDataImportEventPayload.getContext().get(AUTHORITY.value()));
+    assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(AUTHORITY.value())).getString("id"));
+  }
+
+  @Test
+  public void shouldProcessEventEvenIfDuplicatedInventoryStorageErrorExists() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    when(storage.getAuthorityRecordCollection(any())).thenReturn(authorityCollection);
+    doAnswer(invocationOnMock -> {
+      Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+      failureHandler.accept(new Failure(UNIQUE_ID_ERROR_MESSAGE, 400));
+      return null;
+    }).when(authorityCollection).add(any(), any(), any());
 
     var parsedAuthorityRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedAuthorityRecord.encode()));


### PR DESCRIPTION
1. Added a mechanism to NOT sending DI_ERROR in case of a specific error from mod-inventory-storage.
2. Tests added.