### PR TITLE
Fewer sockets in use for tests MODINV-650

### DIFF
--- a/src/main/java/org/folio/inventory/common/VertxAssistant.java
+++ b/src/main/java/org/folio/inventory/common/VertxAssistant.java
@@ -26,6 +26,10 @@ public class VertxAssistant {
     }
   }
 
+  public Vertx getVertx() {
+    return vertx;
+  }
+
   public void stop() {
     CompletableFuture<Void> stopped = new CompletableFuture<>();
 

--- a/src/main/java/org/folio/inventory/support/http/client/OkapiHttpClient.java
+++ b/src/main/java/org/folio/inventory/support/http/client/OkapiHttpClient.java
@@ -15,8 +15,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
 import io.vertx.core.Vertx;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.inventory.common.WebContext;
 
 import io.vertx.core.AsyncResult;
@@ -27,8 +25,6 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 
 public class OkapiHttpClient {
-  private static final Logger LOGGER = LogManager.getLogger(OkapiHttpClient.class);
-
   private static final String TENANT_HEADER = "X-Okapi-Tenant";
   private static final String TOKEN_HEADER = "X-Okapi-Token";
   private static final String OKAPI_URL_HEADER = "X-Okapi-Url";
@@ -46,7 +42,7 @@ public class OkapiHttpClient {
   static Map<Vertx,WebClient> webClients = new HashMap<>();
 
   static WebClient getWebClient(Vertx vertx) {
-    return webClients.computeIfAbsent(vertx, x -> WebClient.create(x));
+    return webClients.computeIfAbsent(vertx, WebClient::create);
   }
 
   /** HTTP client that calls via Okapi

--- a/src/test/java/api/ApiTestSuite.java
+++ b/src/test/java/api/ApiTestSuite.java
@@ -220,7 +220,7 @@ public class ApiTestSuite {
     throws MalformedURLException {
 
     return new OkapiHttpClient(
-      WebClient.wrap(vertxAssistant.createUsingVertx(Vertx::createHttpClient)),
+      vertxAssistant.getVertx(),
       new URL(storageOkapiUrl()), TENANT_ID, TOKEN, USER_ID, null,
       it -> System.out.println(String.format("Request failed: %s", it.toString())));
   }

--- a/src/test/java/org/folio/inventory/storage/external/ExternalStorageSuite.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalStorageSuite.java
@@ -90,7 +90,7 @@ public class ExternalStorageSuite {
     throws MalformedURLException {
 
     return new OkapiHttpClient(
-      WebClient.wrap(vertxAssistant.createUsingVertx(Vertx::createHttpClient)),
+      vertxAssistant.getVertx(),
       new URL(getStorageAddress()), TENANT_ID, TENANT_TOKEN, USER_ID, "1234",
       it -> System.out.println(String.format("Request failed: %s", it.toString())));
   }

--- a/src/test/java/org/folio/inventory/support/http/client/OkapiHttpClientTests.java
+++ b/src/test/java/org/folio/inventory/support/http/client/OkapiHttpClientTests.java
@@ -152,7 +152,7 @@ public class OkapiHttpClientTests {
     assertThat(response.getStatusCode(), is(HTTP_NO_CONTENT.toInt()));
     assertThat(response.getBody(), is(emptyOrNullString()));
   }
-  
+
   //TODO: Maybe replace this with a filter extension
   private MappingBuilder matchingFolioHeaders(MappingBuilder mappingBuilder) {
     return mappingBuilder
@@ -164,8 +164,7 @@ public class OkapiHttpClientTests {
   }
 
   private OkapiHttpClient createClient() {
-    return new OkapiHttpClient(
-      WebClient.wrap(vertxAssistant.createUsingVertx(Vertx::createHttpClient)),
+    return new OkapiHttpClient(vertxAssistant.getVertx(),
       okapiUrl, tenantId, token, userId, requestId, error -> {});
   }
 


### PR DESCRIPTION
This is a test-only fix. There seem to be no problem with
main usage of clients as various Verticle implementations
create one HttpClient. However, the code could be further be
simpfified by not createing them at all.. Just pass Vertx
which is already there in many cases. And let OkapiHttpClient
worry about WebClient creation.