### PR TITLE
MODDICORE-247 - Record matches are not decreased when additional match conditions are added to a job profile

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -304,7 +304,7 @@ public class UpdateItemEventHandler implements EventHandler {
         try {
           eventPayload.setCurrentNode(ObjectMapperTool.getMapper().readValue(eventPayload.getContext().get(CURRENT_NODE_PROPERTY), ProfileSnapshotWrapper.class));
         } catch (JsonProcessingException e) {
-          LOG.error(format("Cannot map from CURRENT_NODE value %s", e.getCause()));
+          LOG.error("Cannot map from CURRENT_NODE value", e);
         }
         eventPayload.getContext().remove(CURRENT_EVENT_TYPE_PROPERTY);
         eventPayload.getContext().remove(CURRENT_NODE_PROPERTY);

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
@@ -36,7 +36,7 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
 
   private final Vertx vertx;
 
-  public AbstractLoader(Vertx vertx) {
+  protected AbstractLoader(Vertx vertx) {
     this.vertx = vertx;
   }
 

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
@@ -16,6 +16,8 @@ import org.folio.processing.matching.loader.MatchValueLoader;
 import org.folio.processing.matching.loader.query.LoadQuery;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ReactTo;
 
 import java.io.UnsupportedEncodingException;
 import java.util.List;
@@ -23,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.constructContext;
 
 public abstract class AbstractLoader<T> implements MatchValueLoader {
@@ -84,7 +87,8 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
 
   private boolean canProcessMultiMatchResult(DataImportEventPayload eventPayload) {
     List<ProfileSnapshotWrapper> childProfiles = eventPayload.getCurrentNode().getChildSnapshotWrappers();
-    return !childProfiles.isEmpty() && childProfiles.get(0).getContentType().equals(ProfileSnapshotWrapper.ContentType.MATCH_PROFILE);
+    return isNotEmpty(childProfiles) && ReactTo.MATCH.equals(childProfiles.get(0).getReactTo())
+      && ContentType.MATCH_PROFILE.equals(childProfiles.get(0).getContentType());
   }
 
   @Override
@@ -98,8 +102,7 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
       .map(Object::toString)
       .collect(Collectors.joining(" OR "));
 
-    String cqlSubMatch = format(" AND id == (%s)", preparedIds);
-    return cqlSubMatch;
+    return format(" AND id == (%s)", preparedIds);
   }
 
   protected abstract EntityType getEntityType();

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
@@ -60,9 +60,9 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
               loadResult.setValue(mapEntityToJsonString(collection.records.get(0)));
             } else if (collection.totalRecords > 1) {
               if (canProcessMultiMatchResult(eventPayload)) {
-                LOG.info("Found multiple records by CQL query: [{}]. Found records IDs: {}", cql, mapEntityListToIdsJson(collection.records));
+                LOG.info("Found multiple records by CQL query: [{}]. Found records IDs: {}", cql, mapEntityListToIdsJsonString(collection.records));
                 loadResult.setEntityType(MULTI_MATCH_IDS);
-                loadResult.setValue(mapEntityListToIdsJson(collection.records));
+                loadResult.setValue(mapEntityListToIdsJsonString(collection.records));
               } else {
                 String errorMessage = String.format("Found multiple records matching specified conditions. CQL query: [%s].%nFound records: %s", cql, Json.encodePrettily(collection.records));
                 LOG.error(errorMessage);
@@ -113,5 +113,5 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
 
   protected abstract String mapEntityToJsonString(T entity);
 
-  protected abstract String mapEntityListToIdsJson(List<T> entityList);
+  protected abstract String mapEntityListToIdsJsonString(List<T> entityList);
 }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AuthorityLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AuthorityLoader.java
@@ -61,7 +61,7 @@ public class AuthorityLoader extends AbstractLoader<Authority> {
   }
 
   @Override
-  protected String mapEntityListToIdsJson(List<Authority> authorityList) {
+  protected String mapEntityListToIdsJsonString(List<Authority> authorityList) {
     List<String> idList = authorityList.stream()
       .map(Authority::getId)
       .collect(Collectors.toList());

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/HoldingLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/HoldingLoader.java
@@ -64,7 +64,7 @@ public class HoldingLoader extends AbstractLoader<HoldingsRecord> {
   }
 
   @Override
-  protected String mapEntityListToIdsJson(List<HoldingsRecord> holdingList) {
+  protected String mapEntityListToIdsJsonString(List<HoldingsRecord> holdingList) {
     List<String> idList = holdingList.stream()
       .map(HoldingsRecord::getId)
       .collect(Collectors.toList());

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/HoldingLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/HoldingLoader.java
@@ -10,9 +10,12 @@ import org.folio.inventory.domain.SearchableCollection;
 import org.folio.inventory.storage.Storage;
 import org.folio.rest.jaxrs.model.EntityType;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 public class HoldingLoader extends AbstractLoader<HoldingsRecord> {
 
@@ -39,13 +42,15 @@ public class HoldingLoader extends AbstractLoader<HoldingsRecord> {
   protected String addCqlSubMatchCondition(DataImportEventPayload eventPayload) {
     String cqlSubMatch = EMPTY;
     if (eventPayload.getContext() != null) {
-      if (!isEmpty(eventPayload.getContext().get(EntityType.HOLDINGS.value()))) {
+      if (isNotEmpty(eventPayload.getContext().get(AbstractLoader.MULTI_MATCH_IDS))) {
+        cqlSubMatch = getConditionByMultiMatchResult(eventPayload);
+      } else if (isNotEmpty(eventPayload.getContext().get(EntityType.HOLDINGS.value()))) {
         JsonObject holdingAsJson = new JsonObject(eventPayload.getContext().get(EntityType.HOLDINGS.value()));
         if (holdingAsJson.getJsonObject(HOLDINGS_FIELD) != null) {
           holdingAsJson = holdingAsJson.getJsonObject(HOLDINGS_FIELD);
         }
         cqlSubMatch = format(" AND id == \"%s\"", holdingAsJson.getString("id"));
-      } else if (!isEmpty(eventPayload.getContext().get(EntityType.INSTANCE.value()))) {
+      } else if (isNotEmpty(eventPayload.getContext().get(EntityType.INSTANCE.value()))) {
         JsonObject instanceAsJson = new JsonObject(eventPayload.getContext().get(EntityType.INSTANCE.value()));
         cqlSubMatch = format(" AND instanceId == \"%s\"", instanceAsJson.getString("id"));
       }
@@ -56,5 +61,14 @@ public class HoldingLoader extends AbstractLoader<HoldingsRecord> {
   @Override
   protected String mapEntityToJsonString(HoldingsRecord holdingsRecord) {
     return Json.encode(holdingsRecord);
+  }
+
+  @Override
+  protected String mapEntityListToIdsJson(List<HoldingsRecord> holdingList) {
+    List<String> idList = holdingList.stream()
+      .map(HoldingsRecord::getId)
+      .collect(Collectors.toList());
+
+    return Json.encode(idList);
   }
 }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/InstanceLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/InstanceLoader.java
@@ -10,9 +10,13 @@ import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.storage.Storage;
 import org.folio.rest.jaxrs.model.EntityType;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.folio.rest.jaxrs.model.EntityType.INSTANCE;
 
 public class InstanceLoader extends AbstractLoader<Instance> {
 
@@ -25,7 +29,7 @@ public class InstanceLoader extends AbstractLoader<Instance> {
 
   @Override
   protected EntityType getEntityType() {
-    return EntityType.INSTANCE;
+    return INSTANCE;
   }
 
   @Override
@@ -36,9 +40,13 @@ public class InstanceLoader extends AbstractLoader<Instance> {
   @Override
   protected String addCqlSubMatchCondition(DataImportEventPayload eventPayload) {
     String cqlSubMatch = EMPTY;
-    if (eventPayload.getContext() != null && !isEmpty(eventPayload.getContext().get(EntityType.INSTANCE.value()))) {
-      JsonObject instanceAsJson = new JsonObject(eventPayload.getContext().get(EntityType.INSTANCE.value()));
-      cqlSubMatch = format(" AND id == \"%s\"", instanceAsJson.getString("id"));
+    if (eventPayload.getContext() != null) {
+      if (isNotEmpty(eventPayload.getContext().get(AbstractLoader.MULTI_MATCH_IDS))) {
+        cqlSubMatch = getConditionByMultiMatchResult(eventPayload);
+      } else if (isNotEmpty(eventPayload.getContext().get(INSTANCE.value()))) {
+        JsonObject instanceAsJson = new JsonObject(eventPayload.getContext().get(INSTANCE.value()));
+        cqlSubMatch = format(" AND id == \"%s\"", instanceAsJson.getString("id"));
+      }
     }
     return cqlSubMatch;
   }
@@ -46,5 +54,14 @@ public class InstanceLoader extends AbstractLoader<Instance> {
   @Override
   protected String mapEntityToJsonString(Instance instance) {
     return Json.encode(instance);
+  }
+
+  @Override
+  protected String mapEntityListToIdsJson(List<Instance> instanceList) {
+    List<String> idList = instanceList.stream()
+      .map(Instance::getId)
+      .collect(Collectors.toList());
+
+    return Json.encode(idList);
   }
 }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/InstanceLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/InstanceLoader.java
@@ -57,7 +57,7 @@ public class InstanceLoader extends AbstractLoader<Instance> {
   }
 
   @Override
-  protected String mapEntityListToIdsJson(List<Instance> instanceList) {
+  protected String mapEntityListToIdsJsonString(List<Instance> instanceList) {
     List<String> idList = instanceList.stream()
       .map(Instance::getId)
       .collect(Collectors.toList());

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/ItemLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/ItemLoader.java
@@ -65,7 +65,7 @@ public class ItemLoader extends AbstractLoader<Item> {
   }
 
   @Override
-  protected String mapEntityListToIdsJson(List<Item> itemList) {
+  protected String mapEntityListToIdsJsonString(List<Item> itemList) {
     List<String> idList = itemList.stream()
       .map(Item::getId)
       .collect(Collectors.toList());

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchAuthorityEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchAuthorityEventHandlerUnitTest.java
@@ -469,8 +469,7 @@ public class MatchAuthorityEventHandlerUnitTest {
   @Test
   public void shouldMatchWithSubConditionBasedOnMultiMatchResultOnHandleEventPayload(TestContext testContext) throws UnsupportedEncodingException {
     Async async = testContext.async();
-    List<String> multiMatchResult = List.of(
-      "bd39d7cc-f313-47ea-bf2d-abcac2b24a64", "e6dc8015-fcad-40cf-afa9-e817a605dc06");
+    List<String> multiMatchResult = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
     Authority expectedAuthority = createAuthority();
 
     MatchDetail personalNameMatchDetail = new MatchDetail()

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchHoldingEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchHoldingEventHandlerUnitTest.java
@@ -64,6 +64,7 @@ import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.MatchExpression.DataValueType.VALUE_FROM_RECORD;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ReactTo.MATCH;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
@@ -418,7 +419,8 @@ public class MatchHoldingEventHandlerUnitTest {
     DataImportEventPayload eventPayload = createEventPayload().withContext(context);
     eventPayload.getCurrentNode().setChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
       .withContent(new MatchProfile().withExistingRecordType(HOLDINGS).withIncomingRecordType(MARC_BIBLIOGRAPHIC))
-      .withContentType(MATCH_PROFILE)));
+      .withContentType(MATCH_PROFILE)
+      .withReactTo(MATCH)));
 
     eventHandler.handle(eventPayload).whenComplete((processedPayload, throwable) -> testContext.verify(v -> {
       testContext.assertNull(throwable);

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchHoldingEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchHoldingEventHandlerUnitTest.java
@@ -2,6 +2,8 @@ package org.folio.inventory.eventhandlers;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -43,6 +45,7 @@ import org.mockito.MockitoAnnotations;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -54,12 +57,15 @@ import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_MATCHED;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_NOT_MATCHED;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.MatchDetail.MatchCriterion.EXACTLY_MATCHES;
+import static org.folio.inventory.dataimport.handlers.matching.loaders.AbstractLoader.MULTI_MATCH_IDS;
 import static org.folio.rest.jaxrs.model.EntityType.HOLDINGS;
 import static org.folio.rest.jaxrs.model.EntityType.ITEM;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.MatchExpression.DataValueType.VALUE_FROM_RECORD;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -353,6 +359,75 @@ public class MatchHoldingEventHandlerUnitTest {
       testContext.assertEquals(DI_INVENTORY_HOLDING_MATCHED.value(), updatedEventPayload.getEventType());
       async.complete();
     });
+  }
+
+  @Test
+  public void shouldMatchWithSubConditionBasedOnMultiMatchResultOnHandleEventPayload(TestContext testContext) throws UnsupportedEncodingException {
+    Async async = testContext.async();
+    List<String> multiMatchResult = List.of("bd39d7cc-f313-47ea-bf2d-abcac2b24a64", "e6dc8015-fcad-40cf-afa9-e817a605dc06");
+    HoldingsRecord expectedHolding = createHolding();
+
+    doAnswer(invocation -> {
+      Consumer<Success<MultipleRecords<HoldingsRecord>>> successHandler = invocation.getArgument(2);
+      Success<MultipleRecords<HoldingsRecord>> result =
+        new Success<>(new MultipleRecords<>(singletonList(expectedHolding), 1));
+      successHandler.accept(result);
+      return null;
+    }).when(holdingCollection)
+      .findByCql(eq(format("hrid == \"%s\" AND id == (%s OR %s)", HOLDING_HRID, multiMatchResult.get(0), multiMatchResult.get(1))),
+        any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    EventHandler eventHandler = new MatchHoldingEventHandler(mappingMetadataCache);
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MULTI_MATCH_IDS, Json.encode(multiMatchResult));
+    context.put(MAPPING_PARAMS, LOCATIONS_PARAMS);
+    context.put(RELATIONS, MATCHING_RELATIONS);
+    DataImportEventPayload eventPayload = createEventPayload().withContext(context);
+
+    eventHandler.handle(eventPayload).whenComplete((processedPayload, throwable) -> {
+      testContext.assertNull(throwable);
+      testContext.assertEquals(1, processedPayload.getEventsChain().size());
+      testContext.assertEquals(processedPayload.getEventsChain(), singletonList(DI_SRS_MARC_BIB_RECORD_CREATED.value()));
+      testContext.assertEquals(DI_INVENTORY_HOLDING_MATCHED.value(), processedPayload.getEventType());
+      testContext.assertEquals(
+        Json.decodeValue(processedPayload.getContext().get(HOLDINGS.value()), HoldingsRecord.class).getId(),
+        expectedHolding.getId());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldPutMultipleMatchResultToPayloadOnHandleEventPayload(TestContext testContext) throws UnsupportedEncodingException {
+    Async async = testContext.async();
+    List<HoldingsRecord> matchedHoldings = List.of(new HoldingsRecord().withId(HOLDING_ID), new HoldingsRecord().withId(UUID.randomUUID().toString()));
+
+    doAnswer(invocation -> {
+      Consumer<Success<MultipleRecords<HoldingsRecord>>> successHandler = invocation.getArgument(2);
+      Success<MultipleRecords<HoldingsRecord>> result =
+        new Success<>(new MultipleRecords<>(matchedHoldings, 2));
+      successHandler.accept(result);
+      return null;
+    }).when(holdingCollection)
+      .findByCql(eq(format("hrid == \"%s\"", HOLDING_HRID)),
+        any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    EventHandler eventHandler = new MatchHoldingEventHandler(mappingMetadataCache);
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MAPPING_PARAMS, LOCATIONS_PARAMS);
+    context.put(RELATIONS, MATCHING_RELATIONS);
+    DataImportEventPayload eventPayload = createEventPayload().withContext(context);
+    eventPayload.getCurrentNode().setChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+      .withContent(new MatchProfile().withExistingRecordType(HOLDINGS).withIncomingRecordType(MARC_BIBLIOGRAPHIC))
+      .withContentType(MATCH_PROFILE)));
+
+    eventHandler.handle(eventPayload).whenComplete((processedPayload, throwable) -> testContext.verify(v -> {
+      testContext.assertNull(throwable);
+      testContext.assertEquals(1, processedPayload.getEventsChain().size());
+      testContext.assertEquals(DI_INVENTORY_HOLDING_MATCHED.value(), processedPayload.getEventType());
+      assertThat(new JsonArray(processedPayload.getContext().get(MULTI_MATCH_IDS)),
+        hasItems(matchedHoldings.get(0).getId(), matchedHoldings.get(1).getId()));
+      async.complete();
+    }));
   }
 
   private DataImportEventPayload createEventPayload() {

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchHoldingEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchHoldingEventHandlerUnitTest.java
@@ -365,7 +365,7 @@ public class MatchHoldingEventHandlerUnitTest {
   @Test
   public void shouldMatchWithSubConditionBasedOnMultiMatchResultOnHandleEventPayload(TestContext testContext) throws UnsupportedEncodingException {
     Async async = testContext.async();
-    List<String> multiMatchResult = List.of("bd39d7cc-f313-47ea-bf2d-abcac2b24a64", "e6dc8015-fcad-40cf-afa9-e817a605dc06");
+    List<String> multiMatchResult = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
     HoldingsRecord expectedHolding = createHolding();
 
     doAnswer(invocation -> {

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchInstanceEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchInstanceEventHandlerUnitTest.java
@@ -329,7 +329,7 @@ public class MatchInstanceEventHandlerUnitTest {
     throws UnsupportedEncodingException {
     Async async = testContext.async();
 
-    List<String> multiMatchResult = List.of("bd39d7cc-f313-47ea-bf2d-abcac2b24a64", "e6dc8015-fcad-40cf-afa9-e817a605dc06");
+    List<String> multiMatchResult = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
     Instance expectedInstance = createInstance();
 
     doAnswer(invocation -> {

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchInstanceEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchInstanceEventHandlerUnitTest.java
@@ -2,6 +2,8 @@ package org.folio.inventory.eventhandlers;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -41,6 +43,7 @@ import org.mockito.MockitoAnnotations;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -52,11 +55,14 @@ import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_MATCHED;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_NOT_MATCHED;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.MatchDetail.MatchCriterion.EXACTLY_MATCHES;
+import static org.folio.inventory.dataimport.handlers.matching.loaders.AbstractLoader.MULTI_MATCH_IDS;
 import static org.folio.rest.jaxrs.model.EntityType.INSTANCE;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.MatchExpression.DataValueType.VALUE_FROM_RECORD;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -286,7 +292,6 @@ public class MatchInstanceEventHandlerUnitTest {
   @Test
   public void shouldMatchWithSubMatchByInstanceOnHandleEventPayload(TestContext testContext) throws UnsupportedEncodingException {
     Async async = testContext.async();
-
     doAnswer(ans -> {
       Consumer<Success<MultipleRecords<Instance>>> callback = ans.getArgument(2);
       Success<MultipleRecords<Instance>> result =
@@ -314,6 +319,86 @@ public class MatchInstanceEventHandlerUnitTest {
       testContext.assertEquals(DI_INVENTORY_INSTANCE_MATCHED.value(), updatedEventPayload.getEventType());
       async.complete();
     });
+  }
+
+  @Test
+  public void shouldMatchWithSubConditionBasedOnMultiMatchResultOnHandleEventPayload(TestContext testContext)
+    throws UnsupportedEncodingException {
+    Async async = testContext.async();
+
+    List<String> multiMatchResult = List.of("bd39d7cc-f313-47ea-bf2d-abcac2b24a64", "e6dc8015-fcad-40cf-afa9-e817a605dc06");
+    Instance expectedInstance = createInstance();
+
+    doAnswer(invocation -> {
+      Consumer<Success<MultipleRecords<Instance>>> successHandler = invocation.getArgument(2);
+      Success<MultipleRecords<Instance>> result =
+        new Success<>(new MultipleRecords<>(singletonList(expectedInstance), 1));
+      successHandler.accept(result);
+      return null;
+    }).when(instanceCollection)
+      .findByCql(eq(format("hrid == \"%s\" AND id == (%s OR %s)", INSTANCE_HRID, multiMatchResult.get(0), multiMatchResult.get(1))),
+        any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    EventHandler eventHandler = new MatchInstanceEventHandler(mappingMetadataCache);
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MULTI_MATCH_IDS, Json.encode(multiMatchResult));
+    context.put(MAPPING_PARAMS, LOCATIONS_PARAMS);
+    context.put(RELATIONS, MATCHING_RELATIONS);
+    DataImportEventPayload eventPayload = createEventPayload().withContext(context);
+
+    eventHandler.handle(eventPayload).whenComplete((processedPayload, throwable) -> {
+      testContext.assertNull(throwable);
+      testContext.assertEquals(1, processedPayload.getEventsChain().size());
+      testContext.assertEquals(
+        processedPayload.getEventsChain(),
+        singletonList(DI_SRS_MARC_BIB_RECORD_CREATED.value())
+      );
+      testContext.assertEquals(DI_INVENTORY_INSTANCE_MATCHED.value(), processedPayload.getEventType());
+      testContext.assertEquals(new JsonObject(processedPayload.getContext().get(INSTANCE.value())).getString("id"), expectedInstance.getId());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldPutMultipleMatchResultToPayloadOnHandleEventPayload(TestContext testContext)
+    throws UnsupportedEncodingException {
+
+    Async async = testContext.async();
+    List<Instance> matchedInstances = List.of(
+      new Instance(UUID.randomUUID().toString(), "1", "in1", "MARC", "Wonderful", "12334"),
+      new Instance(UUID.randomUUID().toString(), "1", "in2", "MARC", "Wonderful", "12334"));
+
+    doAnswer(invocation -> {
+      Consumer<Success<MultipleRecords<Instance>>> successHandler = invocation.getArgument(2);
+      Success<MultipleRecords<Instance>> result =
+        new Success<>(new MultipleRecords<>(matchedInstances, 2));
+      successHandler.accept(result);
+      return null;
+    }).when(instanceCollection)
+      .findByCql(eq(format("hrid == \"%s\"", INSTANCE_HRID)),
+        any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    MatchProfile subMatchProfile = new MatchProfile()
+      .withExistingRecordType(INSTANCE)
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC);
+
+    EventHandler eventHandler = new MatchInstanceEventHandler(mappingMetadataCache);
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MAPPING_PARAMS, LOCATIONS_PARAMS);
+    context.put(RELATIONS, MATCHING_RELATIONS);
+    DataImportEventPayload eventPayload = createEventPayload().withContext(context);
+    eventPayload.getCurrentNode().setChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+      .withContentType(MATCH_PROFILE)
+      .withContent(subMatchProfile)));
+
+    eventHandler.handle(eventPayload).whenComplete((processedPayload, throwable) -> testContext.verify(v -> {
+      testContext.assertNull(throwable);
+      testContext.assertEquals(1, processedPayload.getEventsChain().size());
+      testContext.assertEquals(DI_INVENTORY_INSTANCE_MATCHED.value(), processedPayload.getEventType());
+      assertThat(new JsonArray(processedPayload.getContext().get(MULTI_MATCH_IDS)),
+        hasItems(matchedInstances.get(0).getId(), matchedInstances.get(1).getId()));
+      async.complete();
+    }));
   }
 
   private DataImportEventPayload createEventPayload() {

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchItemEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchItemEventHandlerUnitTest.java
@@ -2,6 +2,8 @@ package org.folio.inventory.eventhandlers;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -44,6 +46,7 @@ import org.mockito.MockitoAnnotations;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -55,11 +58,14 @@ import static org.folio.DataImportEventTypes.DI_INVENTORY_ITEM_MATCHED;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_ITEM_NOT_MATCHED;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.MatchDetail.MatchCriterion.EXACTLY_MATCHES;
+import static org.folio.inventory.dataimport.handlers.matching.loaders.AbstractLoader.MULTI_MATCH_IDS;
 import static org.folio.rest.jaxrs.model.EntityType.ITEM;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.MatchExpression.DataValueType.VALUE_FROM_RECORD;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -350,6 +356,82 @@ public class MatchItemEventHandlerUnitTest {
       testContext.assertEquals(DI_INVENTORY_ITEM_MATCHED.value(), updatedEventPayload.getEventType());
       async.complete();
     });
+  }
+
+  @Test
+  public void shouldMatchWithSubConditionBasedOnMultiMatchResultOnHandleEventPayload(TestContext testContext) throws UnsupportedEncodingException {
+    Async async = testContext.async();
+    List<String> multiMatchResult = List.of("bd39d7cc-f313-47ea-bf2d-abcac2b24a64", "e6dc8015-fcad-40cf-afa9-e817a605dc06");
+    Item expectedItem = createItem();
+
+    doAnswer(invocation -> {
+      Consumer<Success<MultipleRecords<Item>>> callback = invocation.getArgument(2);
+      Success<MultipleRecords<Item>> result =
+        new Success<>(new MultipleRecords<>(singletonList(expectedItem), 1));
+      callback.accept(result);
+      return null;
+    }).when(itemCollection)
+      .findByCql(eq(format("hrid == \"%s\" AND id == (%s OR %s)", ITEM_HRID, multiMatchResult.get(0), multiMatchResult.get(1))),
+        any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    EventHandler eventHandler = new MatchItemEventHandler(mappingMetadataCache);
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MULTI_MATCH_IDS, Json.encode(multiMatchResult));
+    context.put(MAPPING_PARAMS, LOCATIONS_PARAMS);
+    context.put(RELATIONS, MATCHING_RELATIONS);
+    DataImportEventPayload eventPayload = createEventPayload().withContext(context);
+
+    eventHandler.handle(eventPayload).whenComplete((processedPayload, throwable) -> {
+      testContext.assertNull(throwable);
+      testContext.assertEquals(1, processedPayload.getEventsChain().size());
+      testContext.assertEquals(
+        processedPayload.getEventsChain(),
+        singletonList(DI_SRS_MARC_BIB_RECORD_CREATED.value())
+      );
+      testContext.assertEquals(DI_INVENTORY_ITEM_MATCHED.value(), processedPayload.getEventType());
+      testContext.assertEquals(
+        new JsonObject(processedPayload.getContext().get(ITEM.value())).getString("id"),
+        expectedItem.getId());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldPutMultipleMatchResultToPayloadOnHandleEventPayload(TestContext testContext) throws UnsupportedEncodingException {
+    Async async = testContext.async();
+    List<Item> matchedItems = List.of(
+      new Item(ITEM_ID, "1", HOLDING_ID, new Status(ItemStatusName.AVAILABLE),
+        UUID.randomUUID().toString(), UUID.randomUUID().toString(), new JsonObject()),
+      new Item(UUID.randomUUID().toString(), "1", HOLDING_ID, new Status(ItemStatusName.AVAILABLE),
+        UUID.randomUUID().toString(), UUID.randomUUID().toString(), new JsonObject()));
+
+    doAnswer(invocation -> {
+      Consumer<Success<MultipleRecords<Item>>> callback = invocation.getArgument(2);
+      Success<MultipleRecords<Item>> result =
+        new Success<>(new MultipleRecords<>(matchedItems, 2));
+      callback.accept(result);
+      return null;
+    }).when(itemCollection)
+      .findByCql(eq(format("hrid == \"%s\"", ITEM_HRID)),
+        any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    EventHandler eventHandler = new MatchItemEventHandler(mappingMetadataCache);
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MAPPING_PARAMS, LOCATIONS_PARAMS);
+    context.put(RELATIONS, MATCHING_RELATIONS);
+    DataImportEventPayload eventPayload = createEventPayload().withContext(context);
+    eventPayload.getCurrentNode().setChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+      .withContent(new MatchProfile().withExistingRecordType(ITEM).withIncomingRecordType(MARC_BIBLIOGRAPHIC))
+      .withContentType(MATCH_PROFILE)));
+
+    eventHandler.handle(eventPayload).whenComplete((processedPayload, throwable) -> testContext.verify(v -> {
+      testContext.assertNull(throwable);
+      testContext.assertEquals(1, processedPayload.getEventsChain().size());
+      testContext.assertEquals(DI_INVENTORY_ITEM_MATCHED.value(), processedPayload.getEventType());
+      assertThat(new JsonArray(processedPayload.getContext().get(MULTI_MATCH_IDS)),
+        hasItems(matchedItems.get(0).getId(), matchedItems.get(1).getId()));
+      async.complete();
+    }));
   }
 
   private DataImportEventPayload createEventPayload() {

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchItemEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchItemEventHandlerUnitTest.java
@@ -64,6 +64,7 @@ import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.MatchExpression.DataValueType.VALUE_FROM_RECORD;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ReactTo.MATCH;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
@@ -422,7 +423,8 @@ public class MatchItemEventHandlerUnitTest {
     DataImportEventPayload eventPayload = createEventPayload().withContext(context);
     eventPayload.getCurrentNode().setChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
       .withContent(new MatchProfile().withExistingRecordType(ITEM).withIncomingRecordType(MARC_BIBLIOGRAPHIC))
-      .withContentType(MATCH_PROFILE)));
+      .withContentType(MATCH_PROFILE)
+      .withReactTo(MATCH)));
 
     eventHandler.handle(eventPayload).whenComplete((processedPayload, throwable) -> testContext.verify(v -> {
       testContext.assertNull(throwable);

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchItemEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchItemEventHandlerUnitTest.java
@@ -362,7 +362,7 @@ public class MatchItemEventHandlerUnitTest {
   @Test
   public void shouldMatchWithSubConditionBasedOnMultiMatchResultOnHandleEventPayload(TestContext testContext) throws UnsupportedEncodingException {
     Async async = testContext.async();
-    List<String> multiMatchResult = List.of("bd39d7cc-f313-47ea-bf2d-abcac2b24a64", "e6dc8015-fcad-40cf-afa9-e817a605dc06");
+    List<String> multiMatchResult = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
     Item expectedItem = createItem();
 
     doAnswer(invocation -> {


### PR DESCRIPTION
## Purpose
Previously an error should be propagated when multiple inventory entities (instance etc) are matched.
Currently, it's necessary to process multiple match results by next sub-match profile if such exists

## Approach
* check whether current match profile contains a sub-match profile that linked for matches and populate matching result for further processing
* provide logic for entities loaders to process multiple matching results from the previous matching
* add tests

## Learning
[MODINV-652](https://issues.folio.org/browse/MODINV-652)