### PR TITLE
MODDATAIMP-648 Show authority log after update

### DIFF
--- a/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
@@ -120,7 +120,7 @@ public class DataImportConsumerVerticle extends AbstractVerticle {
     ProfileSnapshotCache profileSnapshotCache = new ProfileSnapshotCache(vertx, client, Long.parseLong(profileSnapshotExpirationTime));
     MappingMetadataCache mappingMetadataCache = new MappingMetadataCache(vertx, client, Long.parseLong(mappingMetadataExpirationTime));
 
-    DataImportKafkaHandler dataImportKafkaHandler = new DataImportKafkaHandler(vertx, storage, client, profileSnapshotCache, mappingMetadataCache);
+    DataImportKafkaHandler dataImportKafkaHandler = new DataImportKafkaHandler(vertx, storage, client, profileSnapshotCache, kafkaConfig, mappingMetadataCache);
 
     List<Future> futures = EVENT_TYPES.stream()
       .map(eventType -> createKafkaConsumerWrapper(kafkaConfig, eventType, dataImportKafkaHandler))

--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -53,8 +53,10 @@ import org.folio.inventory.services.InstanceIdStorageService;
 import org.folio.inventory.services.ItemIdStorageService;
 import org.folio.inventory.storage.Storage;
 import org.folio.kafka.AsyncRecordHandler;
+import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.processing.events.EventManager;
+import org.folio.processing.events.services.publisher.KafkaEventPublisher;
 import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.mapper.reader.record.marc.MarcBibReaderFactory;
@@ -75,13 +77,16 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
   private Vertx vertx;
   private ProfileSnapshotCache profileSnapshotCache;
   private MappingMetadataCache mappingMetadataCache;
+  private KafkaConfig kafkaConfig;
 
   public DataImportKafkaHandler(Vertx vertx, Storage storage, HttpClient client,
                                 ProfileSnapshotCache profileSnapshotCache,
+                                KafkaConfig kafkaConfig,
                                 MappingMetadataCache mappingMetadataCache) {
     this.vertx = vertx;
     this.profileSnapshotCache = profileSnapshotCache;
     this.mappingMetadataCache = mappingMetadataCache;
+    this.kafkaConfig = kafkaConfig;
     registerDataImportProcessingHandlers(storage, client);
   }
 
@@ -147,7 +152,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     EventManager.registerEventHandler(new CreateInstanceEventHandler(storage, precedingSucceedingTitlesHelper, mappingMetadataCache, new InstanceIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx)))));
     EventManager.registerEventHandler(new CreateMarcHoldingsEventHandler(storage, mappingMetadataCache, new HoldingsIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx)))));
     EventManager.registerEventHandler(new CreateAuthorityEventHandler(storage, mappingMetadataCache, new AuthorityIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx)))));
-    EventManager.registerEventHandler(new UpdateAuthorityEventHandler(storage, mappingMetadataCache));
+    EventManager.registerEventHandler(new UpdateAuthorityEventHandler(storage, mappingMetadataCache, new KafkaEventPublisher(kafkaConfig, vertx, 100)));
     EventManager.registerEventHandler(new DeleteAuthorityEventHandler(storage));
     EventManager.registerEventHandler(new UpdateItemEventHandler(storage, mappingMetadataCache));
     EventManager.registerEventHandler(new UpdateHoldingEventHandler(storage, mappingMetadataCache));

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/AbstractAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/AbstractAuthorityEventHandler.java
@@ -118,6 +118,8 @@ public abstract class AbstractAuthorityEventHandler implements EventHandler {
 
   protected abstract ProfileSnapshotWrapper.ContentType profileContentType();
 
+  protected abstract void publishEvent(DataImportEventPayload payload);
+
   private boolean isEligibleMappingProfile(MappingProfile mappingProfile) {
     return mappingProfile.getExistingRecordType() == EntityType.fromValue(sourceRecordType().value());
   }
@@ -146,6 +148,7 @@ public abstract class AbstractAuthorityEventHandler implements EventHandler {
     return authority -> {
       LOGGER.info(constructMsg(format(ACTION_SUCCEED_MSG_PATTERN, profileAction(), targetRecordType()), payload));
       payload.getContext().put(targetRecordType().value(), Json.encode(authority));
+      publishEvent(payload);
       future.complete(payload);
     };
   }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandler.java
@@ -91,6 +91,11 @@ public class CreateAuthorityEventHandler extends AbstractAuthorityEventHandler {
   }
 
   @Override
+  protected void publishEvent(DataImportEventPayload payload) {
+
+  }
+
+  @Override
   public String getPostProcessingInitializationEventType() {
     return DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING.value();
   }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandler.java
@@ -19,14 +19,17 @@ import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.exceptions.DataImportException;
 import org.folio.inventory.domain.AuthorityRecordCollection;
 import org.folio.inventory.storage.Storage;
+import org.folio.processing.events.services.publisher.KafkaEventPublisher;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 
 public class UpdateAuthorityEventHandler extends AbstractAuthorityEventHandler {
-
   protected static final String ERROR_UPDATING_AUTHORITY_MSG_TEMPLATE = "Failed updating Authority. Cause: %s, status: '%s'";
+  private final KafkaEventPublisher eventPublisher;
 
-  public UpdateAuthorityEventHandler(Storage storage, MappingMetadataCache mappingMetadataCache) {
+  public UpdateAuthorityEventHandler(Storage storage, MappingMetadataCache mappingMetadataCache,
+                                     KafkaEventPublisher publisher) {
     super(storage, mappingMetadataCache);
+    this.eventPublisher = publisher;
   }
 
   @Override
@@ -59,6 +62,11 @@ public class UpdateAuthorityEventHandler extends AbstractAuthorityEventHandler {
   @Override
   protected ProfileSnapshotWrapper.ContentType profileContentType() {
     return MAPPING_PROFILE;
+  }
+
+  @Override
+  protected void publishEvent(DataImportEventPayload payload) {
+    eventPublisher.publish(payload);
   }
 
   @Override

--- a/src/test/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandlerTest.java
@@ -136,7 +136,7 @@ public class DataImportKafkaHandlerTest {
     HttpClient client = vertx.createHttpClient(new HttpClientOptions().setConnectTimeout(3000));
     dataImportKafkaHandler = new DataImportKafkaHandler(vertx, mockedStorage, client,
       new ProfileSnapshotCache(vertx, client, 3600),
-      new MappingMetadataCache(vertx, client, 3600));
+      kafkaConfig, new MappingMetadataCache(vertx, client, 3600));
     EventManager.clearEventHandlers();
     EventManager.registerKafkaEventPublisher(kafkaConfig, vertx, 1);
   }

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandlerTest.java
@@ -42,6 +42,7 @@ import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+import org.folio.processing.events.services.publisher.KafkaEventPublisher;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,7 +58,6 @@ import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.domain.AuthorityRecordCollection;
 import org.folio.inventory.storage.Storage;
-import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.rest.jaxrs.model.EntityType;
@@ -102,10 +102,9 @@ public class UpdateAuthorityEventHandlerTest {
   private AuthorityRecordCollection authorityCollection;
 
   @Mock
-  private OkapiHttpClient mockedClient;
-
-  @Mock
   private Storage storage;
+  @Mock
+  private KafkaEventPublisher publisher;
 
   private UpdateAuthorityEventHandler eventHandler;
 
@@ -114,7 +113,7 @@ public class UpdateAuthorityEventHandlerTest {
     MockitoAnnotations.openMocks(this);
     MappingManager.clearReaderFactories();
     MappingMetadataCache mappingMetadataCache = new MappingMetadataCache(vertx, vertx.createHttpClient(), 3600);
-    eventHandler = new UpdateAuthorityEventHandler(storage, mappingMetadataCache);
+    eventHandler = new UpdateAuthorityEventHandler(storage, mappingMetadataCache, publisher);
     JsonObject mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
 
     doAnswer(invocationOnMock -> {


### PR DESCRIPTION
### Purpose
Don't show authority log after update

### Approach
Run DI_INVENTORY_AUTHORITY_UPDATED even manualy


### Learning
[MODDATAIMP-648](https://issues.folio.org/browse/MODDATAIMP-648)
