### PR TITLE
MODSOURMAN-712. Timeout when importing MARC files. Fixing http timeouts under huge loads

### DIFF
--- a/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
@@ -57,14 +57,11 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonObject;
 
 public class DataImportConsumerVerticle extends AbstractVerticle {
 
   private static final Logger LOGGER = LogManager.getLogger(DataImportConsumerVerticle.class);
-
-  private static final int DEFAULT_HTTP_TIMEOUT_IN_MILLISECONDS = 3000;
 
   private static final List<DataImportEventTypes> EVENT_TYPES = List.of(
     DI_INVENTORY_HOLDING_CREATED,
@@ -110,8 +107,7 @@ public class DataImportConsumerVerticle extends AbstractVerticle {
     LOGGER.info(format("kafkaConfig: %s", kafkaConfig));
     EventManager.registerKafkaEventPublisher(kafkaConfig, vertx, maxDistributionNumber);
 
-    HttpClientOptions params = new HttpClientOptions().setConnectTimeout(DEFAULT_HTTP_TIMEOUT_IN_MILLISECONDS);
-    HttpClient client = vertx.createHttpClient(params);
+    HttpClient client = vertx.createHttpClient();
     Storage storage = Storage.basedUpon(vertx, config, client);
 
     String profileSnapshotExpirationTime = getCacheEnvVariable(config, "inventory.profile-snapshot-cache.expiration.time.seconds");

--- a/src/test/java/org/folio/inventory/dataimport/cache/JobProfileSnapshotCacheTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/cache/JobProfileSnapshotCacheTest.java
@@ -25,7 +25,6 @@ import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.Json;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -39,7 +38,7 @@ public class JobProfileSnapshotCacheTest {
 
   private final Vertx vertx = Vertx.vertx();
   private final ProfileSnapshotCache profileSnapshotCache = new ProfileSnapshotCache(vertx,
-    vertx.createHttpClient(new HttpClientOptions().setConnectTimeout(3000)), 3600);
+    vertx.createHttpClient(), 3600);
 
   @Rule
   public WireMockRule mockServer = new WireMockRule(

--- a/src/test/java/org/folio/inventory/dataimport/cache/MappingMetadataCacheTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/cache/MappingMetadataCacheTest.java
@@ -22,7 +22,6 @@ import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.Json;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -36,7 +35,7 @@ public class MappingMetadataCacheTest {
 
   private final Vertx vertx = Vertx.vertx();
   private final MappingMetadataCache mappingMetadataCache = new MappingMetadataCache(vertx,
-    vertx.createHttpClient(new HttpClientOptions().setConnectTimeout(3000)), 3600);
+    vertx.createHttpClient(), 3600);
 
   @Rule
   public WireMockRule mockServer = new WireMockRule(

--- a/src/test/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandlerTest.java
@@ -9,7 +9,6 @@ import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
@@ -133,7 +132,7 @@ public class DataImportKafkaHandlerTest {
       .maxRequestSize(1048576)
       .build();
 
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions().setConnectTimeout(3000));
+    HttpClient client = vertx.createHttpClient();
     dataImportKafkaHandler = new DataImportKafkaHandler(vertx, mockedStorage, client,
       new ProfileSnapshotCache(vertx, client, 3600),
       kafkaConfig, new MappingMetadataCache(vertx, client, 3600));

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
@@ -10,7 +10,6 @@ import com.google.common.collect.Lists;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import org.apache.http.HttpStatus;
@@ -169,7 +168,7 @@ public class CreateInstanceEventHandlerTest {
     Vertx vertx = Vertx.vertx();
     createInstanceEventHandler = new CreateInstanceEventHandler(storage,
       new PrecedingSucceedingTitlesHelper(context -> mockedClient), new MappingMetadataCache(vertx,
-      vertx.createHttpClient(new HttpClientOptions().setConnectTimeout(3000)), 3600),
+      vertx.createHttpClient(), 3600),
       instanceIdStorageService);
 
 

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
@@ -9,11 +9,9 @@ import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import com.google.common.collect.Lists;
 
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import scala.concurrent.Promise;
 
 import org.apache.http.HttpStatus;
 import org.folio.ActionProfile;
@@ -90,7 +88,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -178,7 +175,7 @@ public class ReplaceInstanceEventHandlerTest {
 
     Vertx vertx = Vertx.vertx();
     replaceInstanceEventHandler = new ReplaceInstanceEventHandler(storage, precedingSucceedingTitlesHelper, new MappingMetadataCache(vertx,
-      vertx.createHttpClient(new HttpClientOptions().setConnectTimeout(3000)), 3600));
+      vertx.createHttpClient(), 3600));
 
 
     doAnswer(invocationOnMock -> {


### PR DESCRIPTION
During import of 500k records we observed that some records were failed due http timeouts issues when calling mod-inventory-storage from mod-inventory.

**Here is these exceptions from performance report:** https://wiki.folio.org/display/FOLIJET/Folijet+-+Lotus+Snapshot+Performance+testing
`io.vertx.core.impl.NoStackTraceThrowable: proxyClient failure: mod-inventory-storage-23.0.0-SNAPSHOT.666 http://mod-inventory-storage/: Connection was closed: POST /holdings-storage/holdings - 6
POST /instance-storage/instances - 4
POST /item-storage/items - 3
io.vertx.core.impl.NoStackTraceThrowable: proxyClient failure: mod-inventory-storage-23.0.0-SNAPSHOT.666 http://mod-inventory-storage/: readAddress(..) failed: Connection reset by peer: POST /holdings-storage/holdings - 2
io.vertx.core.impl.NoStackTraceThrowable: proxyClient failure: mod-inventory-storage-23.0.0-SNAPSHOT.666 http://mod-inventory-storage/: finishConnect(..) failed: Connection refused: mod-inventory-storage.folijet.svc.cluster.local/172.20.83.37:80: POST /holdings-storage/holdings - 2
POST /instance-storage/instances - 3
POST /item-storage/items - 1`

Lets use the default Http Client settings with default connection timeout that equals to 60 sec.
https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/net/ClientOptionsBase.java#L34