### PR TITLE
MODINV-652 - Record matches are not decreased when additional match conditions are added to a job profile

### DIFF
--- a/src/main/java/org/folio/inventory/common/api/request/PagingParameters.java
+++ b/src/main/java/org/folio/inventory/common/api/request/PagingParameters.java
@@ -28,10 +28,6 @@ public class PagingParameters {
 
   }
 
-  public static PagingParameters from(int limit, int offset) {
-    return new PagingParameters(limit, offset);
-  }
-
   public static boolean valid(String limit, String offset) {
     if (StringUtils.isEmpty(limit) || StringUtils.isEmpty(offset)) {
       return false;

--- a/src/main/java/org/folio/inventory/common/api/request/PagingParameters.java
+++ b/src/main/java/org/folio/inventory/common/api/request/PagingParameters.java
@@ -28,6 +28,10 @@ public class PagingParameters {
 
   }
 
+  public static PagingParameters from(int limit, int offset) {
+    return new PagingParameters(limit, offset);
+  }
+
   public static boolean valid(String limit, String offset) {
     if (StringUtils.isEmpty(limit) || StringUtils.isEmpty(offset)) {
       return false;

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
@@ -34,6 +34,7 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
 
   public static final String MULTI_MATCH_IDS = "MULTI_MATCH_IDS";
   private static final String ERROR_LOAD_MSG = "Failed to load records cause: %s, status code: %s";
+  private static final int MULTI_MATCH_LOAD_LIMIT = 90;
 
   private final Vertx vertx;
 
@@ -94,13 +95,13 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
    * Otherwise, for performance needs returns paging parameters with limit = 2, which is
    * a minimum value that is necessary to get target record or identify whether multiple match result occurred.
    *
-   * @param multiMatchResultParams - identifies whether to return paging parameters for multiple matching
+   * @param multiMatchLoadingParams - identifies whether to return paging parameters for multiple matching
    * @return {@link PagingParameters}
    */
-  private PagingParameters buildPagingParameters(boolean multiMatchResultParams) {
+  private PagingParameters buildPagingParameters(boolean multiMatchLoadingParams) {
     // currently, limit = 90 is used because of constraint for URL size that is used for processing multi-match result
     // in scope of https://issues.folio.org/browse/MODDICORE-251 a new approach will be introduced for multi-matching result processing
-    return multiMatchResultParams ? new PagingParameters(90, 0) : new PagingParameters(2, 0);
+    return multiMatchLoadingParams ? new PagingParameters(MULTI_MATCH_LOAD_LIMIT, 0) : new PagingParameters(2, 0);
   }
 
   private boolean canProcessMultiMatchResult(DataImportEventPayload eventPayload) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
@@ -100,7 +100,7 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
   private PagingParameters buildPagingParameters(boolean multiMatchResultParams) {
     // currently, limit = 90 is used because of constraint for URL size that is used for processing multi-match result
     // in scope of https://issues.folio.org/browse/MODDICORE-251 a new approach will be introduced for multi-matching result processing
-    return multiMatchResultParams ? PagingParameters.from(90, 0) : PagingParameters.from(2, 0);
+    return multiMatchResultParams ? new PagingParameters(90, 0) : new PagingParameters(2, 0);
   }
 
   private boolean canProcessMultiMatchResult(DataImportEventPayload eventPayload) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/AbstractLoader.java
@@ -33,6 +33,7 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
   private static final Logger LOG = LogManager.getLogger(AbstractLoader.class);
 
   public static final String MULTI_MATCH_IDS = "MULTI_MATCH_IDS";
+  private static final String ERROR_LOAD_MSG = "Failed to load records cause: %s, status code: %s";
 
   private final Vertx vertx;
 
@@ -49,22 +50,24 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
     LoadResult loadResult = new LoadResult();
     loadResult.setEntityType(getEntityType().value());
     Context context = constructContext(eventPayload.getTenant(), eventPayload.getToken(), eventPayload.getOkapiUrl());
+    boolean canProcessMultiMatchResult = canProcessMultiMatchResult(eventPayload);
+    PagingParameters pagingParameters = buildPagingParameters(canProcessMultiMatchResult);
 
     vertx.runOnContext(v -> {
       try {
         String cql = loadQuery.getCql() + addCqlSubMatchCondition(eventPayload);
-        getSearchableCollection(context).findByCql(cql, PagingParameters.defaults(),
+        getSearchableCollection(context).findByCql(cql, pagingParameters,
           success -> {
             MultipleRecords<T> collection = success.getResult();
             if (collection.totalRecords == 1) {
               loadResult.setValue(mapEntityToJsonString(collection.records.get(0)));
             } else if (collection.totalRecords > 1) {
-              if (canProcessMultiMatchResult(eventPayload)) {
+              if (canProcessMultiMatchResult) {
                 LOG.info("Found multiple records by CQL query: [{}]. Found records IDs: {}", cql, mapEntityListToIdsJsonString(collection.records));
                 loadResult.setEntityType(MULTI_MATCH_IDS);
                 loadResult.setValue(mapEntityListToIdsJsonString(collection.records));
               } else {
-                String errorMessage = String.format("Found multiple records matching specified conditions. CQL query: [%s].%nFound records: %s", cql, Json.encodePrettily(collection.records));
+                String errorMessage = format("Found multiple records matching specified conditions. CQL query: [%s].%nFound records: %s", cql, Json.encodePrettily(collection.records));
                 LOG.error(errorMessage);
                 future.completeExceptionally(new MatchingException(errorMessage));
                 return;
@@ -74,7 +77,7 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
           },
           failure -> {
             LOG.error(failure.getReason());
-            future.completeExceptionally(new MatchingException(failure.getReason()));
+            future.completeExceptionally(new MatchingException(format(ERROR_LOAD_MSG, failure.getReason(), failure.getStatusCode())));
           });
       } catch (UnsupportedEncodingException e) {
         LOG.error("Failed to retrieve records", e);
@@ -83,6 +86,21 @@ public abstract class AbstractLoader<T> implements MatchValueLoader {
     });
 
     return future;
+  }
+
+  /**
+   * Creates paging parameters for entities loading.
+   * If matching result of current matching can be processed by next profile than returns parameters with limit = 90.
+   * Otherwise, for performance needs returns paging parameters with limit = 2, which is
+   * a minimum value that is necessary to get target record or identify whether multiple match result occurred.
+   *
+   * @param multiMatchResultParams - identifies if should return paging parameters for multiple matching
+   * @return {@link PagingParameters}
+   */
+  private PagingParameters buildPagingParameters(boolean multiMatchResultParams) {
+    // currently, limit = 90 is used because of constraint for url size that is used for processing multi-match result
+    // in scope of https://issues.folio.org/browse/MODDICORE-251 a new approach will be introduced for multi-matching result processing
+    return multiMatchResultParams ? PagingParameters.from(90, 0) : PagingParameters.from(2, 0);
   }
 
   private boolean canProcessMultiMatchResult(DataImportEventPayload eventPayload) {


### PR DESCRIPTION
## Purpose
It is necessary to expand the limit for records loading during a match profile processing. Currently a default limit value is used limit=10, that may not be enough for further processing multiple matching results by next linked match profile


## Learning
[MODINV-652](https://issues.folio.org/browse/MODINV-652)