### PR TITLE
MODINV-658 - Kafka consumer initialization changes

### DIFF
--- a/src/main/java/org/folio/inventory/Launcher.java
+++ b/src/main/java/org/folio/inventory/Launcher.java
@@ -45,6 +45,9 @@ public class Launcher {
     String storageType = System.getProperty(
       "org.folio.metadata.inventory.storage.type", null);
 
+    String kafkaConsumersToBeInitialized = System.getProperty(
+      "org.folio.metadata.inventory.kafka.consumers.initialized", "true");
+
     String storageLocation = System.getProperty(
       "org.folio.metadata.inventory.storage.location", null);
 
@@ -52,9 +55,12 @@ public class Launcher {
     putNonNullConfig("storage.location", storageLocation, config);
     putNonNullConfig("port", port, config);
 
-    Map<String, Object> consumerVerticlesConfig = getConsumerVerticleConfig();
     start(config);
-    startConsumerVerticles(consumerVerticlesConfig);
+
+    if(Boolean.parseBoolean(kafkaConsumersToBeInitialized)){
+      Map<String, Object> consumerVerticlesConfig = getConsumerVerticleConfig();
+      startConsumerVerticles(consumerVerticlesConfig);
+    }
   }
 
   private static void start(Map<String, Object> config)


### PR DESCRIPTION
Added a field to initialize Kafka consumer from the environment variable.
If the field value is not initialized by default, it will execute as it was executing earlier.