### PR TITLE
MODINV-669 Fix latency in create holdings flow

### DIFF
--- a/src/main/java/org/folio/inventory/services/HoldingsCollectionService.java
+++ b/src/main/java/org/folio/inventory/services/HoldingsCollectionService.java
@@ -45,7 +45,7 @@ public class HoldingsCollectionService {
   public Future<String> findInstanceIdByHrid(InstanceCollection instanceCollection, String instanceHrid) {
     Promise<String> promise = Promise.promise();
     try {
-      instanceCollection.findByCql(format("hrid=%s", instanceHrid), PagingParameters.defaults(),
+      instanceCollection.findByCql(format("hrid==%s", instanceHrid), PagingParameters.defaults(),
         findResult -> {
           if (findResult.getResult() != null && findResult.getResult().totalRecords == 1) {
             var instanceId = findResult.getResult().records.get(0).getId();


### PR DESCRIPTION
## Purpose 
Fix latency in create holdings flow

## Approach
`hrid` field is indexed with btree. To speed up search by `hrid` operator `==` should be used in cql query