### PR TITLE
Modinv 616

### DIFF
--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -33,10 +33,6 @@
       "items": {
         "type": "object",
         "properties": {
-          "id": {
-            "description": "Id of the related instance",
-            "type": "string"
-          },
           "siblingInstanceId": {
             "description": "Id of the sibling instance",
             "type": "string"

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -33,19 +33,14 @@
       "items": {
         "type": "object",
         "properties": {
-          "siblingInstanceId": {
-            "description": "Id of the sibling instance",
-            "type": "string"
-          },
-          "instanceRelationshipTypeId": {
-            "description": "Id of the relationship type",
+          "relatedInstanceId": {
+            "description": "Id of the related instance",
             "type": "string"
           }
         },
         "additionalProperties": false,
         "required": [
-          "siblingInstanceId",
-          "instanceRelationshipTypeId"
+          "relatedInstanceId"
         ]
       }
     },

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -27,6 +27,32 @@
       "type": "string",
       "description": "The metadata source and its format of the underlying record to the instance record. (e.g. FOLIO if it's a record created in Inventory;  MARC if it's a MARC record created in MARCcat or EPKB if it's a record coming from eHoldings)"
     },
+    "relatedInstances": {
+      "description": "Array of related instances",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Id of the related instance",
+            "type": "string"
+          },
+          "siblingInstanceId": {
+            "description": "Id of the sibling instance",
+            "type": "string"
+          },
+          "instanceRelationshipTypeId": {
+            "description": "Id of the relationship type",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "siblingInstanceId",
+          "instanceRelationshipTypeId"
+        ]
+      }
+    },
     "parentInstances": {
       "description": "Array of parent instances",
       "type": "array",

--- a/src/main/java/org/folio/inventory/domain/instances/Instance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/Instance.java
@@ -266,7 +266,7 @@ public class Instance {
     json.put(ADMININSTRATIVE_NOTES_KEY, getAdministrativeNotes());
     putIfNotNull(json, MATCH_KEY_KEY, getMatchKey());
     putIfNotNull(json, INDEX_TITLE_KEY, getIndexTitle());
-    putIfNotNull(json, RELATED_INSTANCES_KEY, getRelatedInstances());
+    putIfNotNull(json, RELATED_INSTANCES_KEY, relatedInstances);
     putIfNotNull(json, PARENT_INSTANCES_KEY, parentInstances);
     putIfNotNull(json, CHILD_INSTANCES_KEY, childInstances);
     putIfNotNull(json, IS_BOUND_WITH_KEY, getIsBoundWith());

--- a/src/main/java/org/folio/inventory/domain/instances/Instance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/Instance.java
@@ -32,6 +32,7 @@ public class Instance {
   public static final String HRID_KEY = "hrid";
   public static final String MATCH_KEY_KEY = "matchKey";
   public static final String SOURCE_KEY = "source";
+  public static final String RELATED_INSTANCES_KEY = "relatedInstances";
   public static final String PARENT_INSTANCES_KEY = "parentInstances";
   public static final String CHILD_INSTANCES_KEY = "childInstances";
   public static final String PRECEDING_TITLES_KEY = "precedingTitles";
@@ -77,6 +78,7 @@ public class Instance {
   private final String hrid;
   private String matchKey;
   private final String source;
+  private List<RelatedInstance> relatedInstances = new ArrayList();
   private List<InstanceRelationshipToParent> parentInstances = new ArrayList();
   private List<InstanceRelationshipToChild> childInstances = new ArrayList();
   private List<PrecedingSucceedingTitle> precedingTitles = new ArrayList<>();
@@ -153,6 +155,7 @@ public class Instance {
       instanceJson.getString(INSTANCE_TYPE_ID_KEY))
       .setIndexTitle(instanceJson.getString(INDEX_TITLE_KEY))
       .setMatchKey(instanceJson.getString(MATCH_KEY_KEY))
+      .setRelatedInstances(instanceJson.getJsonArray(RELATED_INSTANCES_KEY))
       .setParentInstances(instanceJson.getJsonArray(PARENT_INSTANCES_KEY))
       .setChildInstances(instanceJson.getJsonArray(CHILD_INSTANCES_KEY))
       .setPrecedingTitles(instanceJson.getJsonArray(PRECEDING_TITLES_KEY))
@@ -263,6 +266,7 @@ public class Instance {
     json.put(ADMININSTRATIVE_NOTES_KEY, getAdministrativeNotes());
     putIfNotNull(json, MATCH_KEY_KEY, getMatchKey());
     putIfNotNull(json, INDEX_TITLE_KEY, getIndexTitle());
+    putIfNotNull(json, RELATED_INSTANCES_KEY, getRelatedInstances());
     putIfNotNull(json, PARENT_INSTANCES_KEY, parentInstances);
     putIfNotNull(json, CHILD_INSTANCES_KEY, childInstances);
     putIfNotNull(json, IS_BOUND_WITH_KEY, getIsBoundWith());
@@ -330,6 +334,21 @@ public class Instance {
 
   public Instance setIndexTitle(String indexTitle) {
     this.indexTitle = indexTitle;
+    return this;
+  }
+
+  public Instance setRelatedInstances(List<RelatedInstance> relatedInstances) {
+    this.relatedInstances = (relatedInstances != null ? relatedInstances : this.relatedInstances);
+    return this;
+  }
+
+  public Instance setRelatedInstances(JsonArray relatedInstances) {
+    this.relatedInstances = relatedInstances != null
+      ? JsonArrayHelper.toList(relatedInstances).stream()
+      .map(RelatedInstance::new)
+      .collect(Collectors.toList())
+      : new ArrayList<>();
+
     return this;
   }
 
@@ -631,6 +650,10 @@ public class Instance {
 
   public List<String> getAdministrativeNotes() {
     return administrativeNotes;
+  }
+
+  public List<RelatedInstance> getRelatedInstances() {
+    return relatedInstances;
   }
 
   public List<InstanceRelationshipToParent> getParentInstances() {

--- a/src/main/java/org/folio/inventory/domain/instances/RelatedInstance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/RelatedInstance.java
@@ -4,25 +4,21 @@ import io.vertx.core.json.JsonObject;
 
 public class RelatedInstance {
   // JSON property names
-  public static final String SIBLING_INSTANCE_ID_KEY = "siblingInstanceId";
-  public static final String INSTANCE_RELATIONSHIP_TYPE_ID_KEY = "instanceRelationshipTypeId";
+  public static final String RELATED_INSTANCE_ID_KEY = "relatedInstanceId";
 
-  public final String siblingInstanceId;
-  public final String instanceRelationshipTypeId;
+  public final String relatedInstanceId;
 
-  public RelatedInstance (String siblingInstanceId, String instanceRelationshipTypeId) {
-    this.siblingInstanceId = siblingInstanceId;
-    this.instanceRelationshipTypeId = instanceRelationshipTypeId;
+  public RelatedInstance (String relatedInstanceId) {
+    this.relatedInstanceId = relatedInstanceId;
   }
 
   public RelatedInstance (JsonObject rel) {
-    this(rel.getString(SIBLING_INSTANCE_ID_KEY),
-         rel.getString(INSTANCE_RELATIONSHIP_TYPE_ID_KEY));
+    this(rel.getString(RELATED_INSTANCE_ID_KEY));
   }
 
   @Override
   public String toString() {
-    return "{ \""+SIBLING_INSTANCE_ID_KEY+"\": \""+siblingInstanceId+"\", \""+INSTANCE_RELATIONSHIP_TYPE_ID_KEY+"\": \""+instanceRelationshipTypeId+"\"}";
+    return "{ \""+RELATED_INSTANCE_ID_KEY+"\": \""+relatedInstanceId+"\" }";
   }
 
   @Override

--- a/src/main/java/org/folio/inventory/domain/instances/RelatedInstance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/RelatedInstance.java
@@ -1,0 +1,45 @@
+package org.folio.inventory.domain.instances;
+
+import io.vertx.core.json.JsonObject;
+
+public class RelatedInstance {
+  // JSON property names
+  public static final String ID_KEY = "id";
+  public static final String SIBLING_INSTANCE_ID_KEY = "siblingInstanceId";
+  public static final String INSTANCE_RELATIONSHIP_TYPE_ID_KEY = "instanceRelationshipTypeId";
+
+  public final String id;
+  public final String siblingInstanceId;
+  public final String instanceRelationshipTypeId;
+
+  public RelatedInstance (String id, String siblingInstanceId, String instanceRelationshipTypeId) {
+    this.id = id;
+    this.siblingInstanceId = siblingInstanceId;
+    this.instanceRelationshipTypeId = instanceRelationshipTypeId;
+  }
+
+  public RelatedInstance (JsonObject rel) {
+    this(rel.getString(ID_KEY),
+         rel.getString(SIBLING_INSTANCE_ID_KEY),
+         rel.getString(INSTANCE_RELATIONSHIP_TYPE_ID_KEY));
+  }
+
+  @Override
+  public String toString() {
+    return "{ \""+ID_KEY+"\": \""+id+"\", \""+SIBLING_INSTANCE_ID_KEY+"\": \""+siblingInstanceId+"\", \""+INSTANCE_RELATIONSHIP_TYPE_ID_KEY+"\": \""+instanceRelationshipTypeId+"\"}";
+  }
+
+  @Override
+  public boolean equals (Object object) {
+    if (object instanceof RelatedInstance) {
+      return object.toString().equals(this.toString());
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return toString().hashCode();
+  }
+}

--- a/src/main/java/org/folio/inventory/domain/instances/RelatedInstance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/RelatedInstance.java
@@ -4,29 +4,25 @@ import io.vertx.core.json.JsonObject;
 
 public class RelatedInstance {
   // JSON property names
-  public static final String ID_KEY = "id";
   public static final String SIBLING_INSTANCE_ID_KEY = "siblingInstanceId";
   public static final String INSTANCE_RELATIONSHIP_TYPE_ID_KEY = "instanceRelationshipTypeId";
 
-  public final String id;
   public final String siblingInstanceId;
   public final String instanceRelationshipTypeId;
 
-  public RelatedInstance (String id, String siblingInstanceId, String instanceRelationshipTypeId) {
-    this.id = id;
+  public RelatedInstance (String siblingInstanceId, String instanceRelationshipTypeId) {
     this.siblingInstanceId = siblingInstanceId;
     this.instanceRelationshipTypeId = instanceRelationshipTypeId;
   }
 
   public RelatedInstance (JsonObject rel) {
-    this(rel.getString(ID_KEY),
-         rel.getString(SIBLING_INSTANCE_ID_KEY),
+    this(rel.getString(SIBLING_INSTANCE_ID_KEY),
          rel.getString(INSTANCE_RELATIONSHIP_TYPE_ID_KEY));
   }
 
   @Override
   public String toString() {
-    return "{ \""+ID_KEY+"\": \""+id+"\", \""+SIBLING_INSTANCE_ID_KEY+"\": \""+siblingInstanceId+"\", \""+INSTANCE_RELATIONSHIP_TYPE_ID_KEY+"\": \""+instanceRelationshipTypeId+"\"}";
+    return "{ \""+SIBLING_INSTANCE_ID_KEY+"\": \""+siblingInstanceId+"\", \""+INSTANCE_RELATIONSHIP_TYPE_ID_KEY+"\": \""+instanceRelationshipTypeId+"\"}";
   }
 
   @Override

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -10,12 +10,19 @@ import static org.folio.inventory.support.EndpointFailureHandler.handleFailure;
 import static org.folio.inventory.support.http.server.SuccessResponse.noContent;
 import static org.folio.inventory.validation.InstancesValidators.refuseWhenHridChanged;
 
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.BodyHandler;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.HttpStatus;
@@ -48,18 +55,12 @@ import org.folio.inventory.validation.InstancePrecedingSucceedingTitleValidators
 import org.folio.inventory.validation.InstancesValidators;
 import org.folio.rest.client.SourceStorageRecordsClient;
 
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
 
 
 public class Instances extends AbstractInstances {

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -160,6 +160,7 @@ public class Instances extends AbstractInstances {
       .thenCompose(InstancePrecedingSucceedingTitleValidators::refuseWhenUnconnectedHasNoTitle)
       .thenCompose(instance -> storage.getInstanceCollection(context).add(instance))
       .thenCompose(response -> {
+        response.setRelatedInstances(newInstance.getRelatedInstances());
         response.setParentInstances(newInstance.getParentInstances());
         response.setChildInstances(newInstance.getChildInstances());
         response.setPrecedingTitles(newInstance.getPrecedingTitles());
@@ -338,6 +339,24 @@ public class Instances extends AbstractInstances {
       }
     );
   }
+
+  // /**
+  //  * Fetches instance relationships for multiple Instance records, populates, responds
+  //  *
+  //  * @param instancesResponse Multi record Instances result
+  //  * @param routingContext Routing
+  //  */
+  // private CompletableFuture<InstancesResponse> fetchRelatedInstances(
+  //   InstancesResponse instancesResponse,
+  //   RoutingContext routingContext) {
+
+  //   final List<String> instanceIds =
+  //     getInstanceIdsFromInstanceResult(instancesResponse.getSuccess());
+
+  //   return createInstanceRelationshipsService(routingContext)
+  //     .fetchInstanceRelationships(instanceIds)
+  //     .thenCompose(response -> withInstancesRelationships(instancesResponse, response));
+  // }
 
   /**
    * Fetches instance relationships for multiple Instance records, populates, responds

--- a/src/main/java/org/folio/inventory/resources/InstancesBatch.java
+++ b/src/main/java/org/folio/inventory/resources/InstancesBatch.java
@@ -207,6 +207,7 @@ public class InstancesBatch extends AbstractInstances {
       for (Instance createdInstance : createdInstances) {
         Instance newInstance = mapInstanceById.get(createdInstance.getId());
         if (newInstance != null) {
+          createdInstance.setRelatedInstances(newInstance.getRelatedInstances());
           createdInstance.setParentInstances(newInstance.getParentInstances());
           createdInstance.setChildInstances(newInstance.getChildInstances());
           createdInstance.setPrecedingTitles(newInstance.getPrecedingTitles());

--- a/src/main/java/org/folio/inventory/resources/InstancesResponse.java
+++ b/src/main/java/org/folio/inventory/resources/InstancesResponse.java
@@ -5,12 +5,14 @@ import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.InstanceRelationshipToChild;
 import org.folio.inventory.domain.instances.InstanceRelationshipToParent;
+import org.folio.inventory.domain.instances.RelatedInstance;
 import org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle;
 
 import java.util.*;
 
 public class InstancesResponse {
   private Success<MultipleRecords<Instance>> success;
+  private Map<String, List<RelatedInstance>> relatedInstanceMap = new HashMap();
   private Map<String, List<InstanceRelationshipToParent>> parentInstanceMap = new HashMap();
   private Map<String, List<InstanceRelationshipToChild>> childInstanceMap = new HashMap();
   private Map<String, List<PrecedingSucceedingTitle>> precedingTitlesMap = new HashMap();
@@ -28,6 +30,17 @@ public class InstancesResponse {
 
   public boolean hasRecords () {
     return !success.getResult().records.isEmpty();
+  }
+
+  public Map<String, List<RelatedInstance>> getRelatedInstanceMap() {
+    return Collections.unmodifiableMap(relatedInstanceMap);
+  }
+
+  public InstancesResponse setRelatedInstanceMap(
+    Map<String, List<RelatedInstance>> relatedInstanceMap) {
+
+    this.relatedInstanceMap = relatedInstanceMap;
+    return this;
   }
 
   public Map<String, List<InstanceRelationshipToParent>> getParentInstanceMap() {

--- a/src/main/java/org/folio/inventory/services/RelatedInstancesService.java
+++ b/src/main/java/org/folio/inventory/services/RelatedInstancesService.java
@@ -1,0 +1,39 @@
+package org.folio.inventory.services;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.inventory.domain.instances.Instance;
+import org.folio.inventory.domain.instances.RelatedInstance;
+import org.folio.inventory.storage.external.CollectionResourceClient;
+import org.folio.inventory.storage.external.CqlQuery;
+import org.folio.inventory.storage.external.MultipleRecordsFetchClient;
+
+import io.vertx.core.json.JsonObject;
+
+public class RelatedInstancesService {
+  private final MultipleRecordsFetchClient fetchClient;
+
+  public RelatedInstancesService(CollectionResourceClient fetchClient) {
+    this.fetchClient = createFetchClient(fetchClient);
+  }
+
+  public CompletableFuture<List<JsonObject>> fetchRelatedInstances(List<String> instanceIds) {
+    return fetchClient.find(instanceIds, this::fetchRelatedInstancesCql);
+  }
+
+  private CqlQuery fetchRelatedInstancesCql(List<String> instanceIds) {
+    return CqlQuery.exactMatchAny(RelatedInstance.RELATED_INSTANCE_ID_KEY, instanceIds);
+  }
+
+  private MultipleRecordsFetchClient createFetchClient(
+    CollectionResourceClient relatedInstancesClient) {
+
+    return MultipleRecordsFetchClient.builder()
+      .withCollectionPropertyName(Instance.RELATED_INSTANCES_KEY)
+      .withExpectedStatus(200)
+      .withCollectionResourceClient(relatedInstancesClient)
+      .build();
+  }
+
+}

--- a/src/test/java/api/RelatedInstanceTest.java
+++ b/src/test/java/api/RelatedInstanceTest.java
@@ -10,9 +10,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.util.Random;
 import java.util.UUID;
 
-import org.folio.InstanceRelationshipType;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.RelatedInstance;
+import org.folio.inventory.support.http.client.IndividualResource;
 import org.junit.Test;
 
 import api.support.ApiTests;
@@ -21,28 +21,32 @@ import io.vertx.core.json.JsonObject;
 
 public class RelatedInstanceTest extends ApiTests {
 
-  private static final String SIBLING_INSTANCE_KEY = "siblingInstanceId";
-
   @Test
   public void canFetchOneInstanceWithRelatedInstances() throws Exception {
     
     var firstInstanceId = UUID.randomUUID();
     var secondInstanceId = UUID.randomUUID();
 
-    instancesClient.create(nod(firstInstanceId)
-      .put(Instance.TITLE_KEY, randomString("first"))
-      .put(Instance.RELATED_INSTANCES_KEY, new JsonArray()
-        .add(createRelatedInstance(secondInstanceId)))
-    );
+    var firstNodJson = nod(firstInstanceId)
+    .put(Instance.TITLE_KEY, randomString("first"))
+    .put(Instance.RELATED_INSTANCES_KEY, new JsonArray()
+      .add(createRelatedInstance(secondInstanceId)));
 
-    instancesClient.create(nod(secondInstanceId)
-      .put(Instance.TITLE_KEY, randomString("second"))
-      .put(Instance.RELATED_INSTANCES_KEY, new JsonArray()
-        .add(createRelatedInstance(firstInstanceId)))
-    );
+    instancesClient.create(firstNodJson);
+
+    var secondNodJson = nod(secondInstanceId)
+    .put(Instance.TITLE_KEY, randomString("second"))
+    .put(Instance.RELATED_INSTANCES_KEY, new JsonArray()
+      .add(createRelatedInstance(firstInstanceId)));
+
+    instancesClient.create(secondNodJson);
     
     var firstInstanceJson = instancesClient.getById(firstInstanceId).getJson();
     var firstInstanceRelatedInstancesJson = firstInstanceJson.getJsonArray(Instance.RELATED_INSTANCES_KEY);
+    
+    System.out.print("\n\n");
+    System.out.print(firstInstanceJson);
+    System.out.print("\n\n");
     
     assertThat(firstInstanceRelatedInstancesJson, notNullValue());
     assertThat(firstInstanceRelatedInstancesJson.size(), not(0));
@@ -50,7 +54,7 @@ public class RelatedInstanceTest extends ApiTests {
     var firstInstanceFirstRelatedInstanceJson = firstInstanceRelatedInstancesJson.getJsonObject(0);
 
     assertThat(firstInstanceRelatedInstancesJson, notNullValue());
-    assertThat(firstInstanceFirstRelatedInstanceJson.getString(SIBLING_INSTANCE_KEY), is(secondInstanceId));
+    assertThat(firstInstanceFirstRelatedInstanceJson.getString(RelatedInstance.RELATED_INSTANCE_ID_KEY), is(secondInstanceId.toString()));
 
     var secondInstanceJson = instancesClient.getById(secondInstanceId).getJson();
     var secondInstanceRelatedInstancesJson = secondInstanceJson.getJsonArray(Instance.RELATED_INSTANCES_KEY);
@@ -61,22 +65,13 @@ public class RelatedInstanceTest extends ApiTests {
     var secondInstanceFirstRelatedInstanceJson = secondInstanceRelatedInstancesJson.getJsonObject(0);
     
     assertThat(secondInstanceFirstRelatedInstanceJson, notNullValue());
-    assertThat(secondInstanceFirstRelatedInstanceJson.getString(SIBLING_INSTANCE_KEY), is(firstInstanceId));
+    assertThat(secondInstanceFirstRelatedInstanceJson.getString(RelatedInstance.RELATED_INSTANCE_ID_KEY), is(firstInstanceId.toString()));
 
   }
 
-  private JsonObject createRelatedInstance(UUID siblingInstanceId) {
-    String instanceRelationshipTypeID = UUID.randomUUID().toString();
-
-    instanceRelationshipTypeFixture.createIfNotExist(mapFrom(
-      new InstanceRelationshipType()
-        .withId(instanceRelationshipTypeID)
-        .withName("siblings")
-      ));  
-
+  private JsonObject createRelatedInstance(UUID relatedInstanceId) {
     return  mapFrom(new RelatedInstance(
-        siblingInstanceId.toString(), 
-        instanceRelationshipTypeID
+        relatedInstanceId.toString()
       ));
   }
 

--- a/src/test/java/api/RelatedInstanceTest.java
+++ b/src/test/java/api/RelatedInstanceTest.java
@@ -1,0 +1,69 @@
+package api;
+
+import static api.support.InstanceSamples.nod;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Random;
+import java.util.UUID;
+
+import org.folio.inventory.domain.instances.Instance;
+import org.junit.Test;
+
+import api.support.ApiTests;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class RelatedInstanceTest extends ApiTests {
+
+  private static final String RELATED_INSTANCE_KEY = "relatedInstance";
+  private static final String INSTANCE_RELATIONSHIP_TYPE_ID_KEY = "instanceRelationshipTypeId";
+
+  @Test
+  public void canFetchMultipleInstancesWithRelatedInstances() throws Exception {
+
+  }
+
+  @Test
+  public void canFetchOneInstanceWithRelatedInstances() throws Exception {
+    
+    var firstInstanceId = UUID.randomUUID();
+    var secondInstanceId = UUID.randomUUID();
+
+    instancesClient.create(nod(firstInstanceId)
+      .put(Instance.TITLE_KEY, randomString("first"))
+      .put(Instance.RELATED_INSTANCES_KEY, new JsonArray()
+        .add(createRelatedInstance(secondInstanceId)))
+    );
+
+    instancesClient.create(nod(secondInstanceId)
+      .put(Instance.TITLE_KEY, randomString("second"))
+      .put(Instance.RELATED_INSTANCES_KEY, new JsonArray()
+        .add(createRelatedInstance(firstInstanceId)))
+    );
+    
+    var firstInstanceJson = instancesClient.getById(firstInstanceId).getJson();
+    var firstInstanceRelatedInstancesJson = firstInstanceJson.getJsonArray(Instance.RELATED_INSTANCES_KEY);
+    assertThat(firstInstanceRelatedInstancesJson.size(), is(1));
+    assertThat(firstInstanceRelatedInstancesJson.getJsonObject(0).getString(RELATED_INSTANCE_KEY), is(secondInstanceId));
+
+    var secondInstanceJson = instancesClient.getById(secondInstanceId).getJson();
+    var secondInstanceRelatedInstancesJson = secondInstanceJson.getJsonArray(Instance.RELATED_INSTANCES_KEY);
+    assertThat(secondInstanceRelatedInstancesJson.size(), is(1));
+    assertThat(secondInstanceRelatedInstancesJson.getJsonObject(0).getString(RELATED_INSTANCE_KEY), is(firstInstanceId));
+
+  }
+
+  private JsonObject createRelatedInstance(UUID relatedInstance) {
+    return new JsonObject()
+      .put(RELATED_INSTANCE_KEY, relatedInstance)
+      .put(INSTANCE_RELATIONSHIP_TYPE_ID_KEY, instanceRelationshipTypeFixture.createIfNotExist(new JsonObject()
+        .put("id", UUID.randomUUID().toString())
+        .put("name", "siblings")));
+  }
+
+  private String randomString(String prefix) {
+    return prefix + new Random().nextLong();
+  }
+
+}

--- a/src/test/java/api/RelatedInstanceTest.java
+++ b/src/test/java/api/RelatedInstanceTest.java
@@ -16,7 +16,7 @@ import io.vertx.core.json.JsonObject;
 
 public class RelatedInstanceTest extends ApiTests {
 
-  private static final String RELATED_INSTANCE_KEY = "relatedInstance";
+  private static final String SIBLING_INSTANCE_KEY = "siblingInstanceId";
   private static final String INSTANCE_RELATIONSHIP_TYPE_ID_KEY = "instanceRelationshipTypeId";
 
   @Test
@@ -45,18 +45,18 @@ public class RelatedInstanceTest extends ApiTests {
     var firstInstanceJson = instancesClient.getById(firstInstanceId).getJson();
     var firstInstanceRelatedInstancesJson = firstInstanceJson.getJsonArray(Instance.RELATED_INSTANCES_KEY);
     assertThat(firstInstanceRelatedInstancesJson.size(), is(1));
-    assertThat(firstInstanceRelatedInstancesJson.getJsonObject(0).getString(RELATED_INSTANCE_KEY), is(secondInstanceId));
+    assertThat(firstInstanceRelatedInstancesJson.getJsonObject(0).getString(SIBLING_INSTANCE_KEY), is(secondInstanceId));
 
     var secondInstanceJson = instancesClient.getById(secondInstanceId).getJson();
     var secondInstanceRelatedInstancesJson = secondInstanceJson.getJsonArray(Instance.RELATED_INSTANCES_KEY);
     assertThat(secondInstanceRelatedInstancesJson.size(), is(1));
-    assertThat(secondInstanceRelatedInstancesJson.getJsonObject(0).getString(RELATED_INSTANCE_KEY), is(firstInstanceId));
+    assertThat(secondInstanceRelatedInstancesJson.getJsonObject(0).getString(SIBLING_INSTANCE_KEY), is(firstInstanceId));
 
   }
 
-  private JsonObject createRelatedInstance(UUID relatedInstance) {
+  private JsonObject createRelatedInstance(UUID siblingInstance) {
     return new JsonObject()
-      .put(RELATED_INSTANCE_KEY, relatedInstance)
+      .put(SIBLING_INSTANCE_KEY, siblingInstance)
       .put(INSTANCE_RELATIONSHIP_TYPE_ID_KEY, instanceRelationshipTypeFixture.createIfNotExist(new JsonObject()
         .put("id", UUID.randomUUID().toString())
         .put("name", "siblings")));

--- a/src/test/java/api/RelatedInstanceTest.java
+++ b/src/test/java/api/RelatedInstanceTest.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.RelatedInstance;
-import org.folio.inventory.support.http.client.IndividualResource;
 import org.junit.Test;
 
 import api.support.ApiTests;

--- a/src/test/java/api/support/fixtures/InstanceRelationshipTypeFixture.java
+++ b/src/test/java/api/support/fixtures/InstanceRelationshipTypeFixture.java
@@ -12,14 +12,14 @@ public class InstanceRelationshipTypeFixture extends ReferenceRecordFixture {
   }
 
   public ReferenceRecordResponse boundWith() {
-    return createIfNotExist(newInstanceRelationship("bound-with"));
+    return createIfNotExist(newInstanceRelationshipType("bound-with"));
   }
 
   public ReferenceRecordResponse monographicSeries() {
-    return createIfNotExist(newInstanceRelationship("monographic series"));
+    return createIfNotExist(newInstanceRelationshipType("monographic series"));
   }
 
-  private JsonObject newInstanceRelationship(String name) {
+  private JsonObject newInstanceRelationshipType(String name) {
     return new JsonObject()
       .put("id", UUID.randomUUID().toString())
       .put("name", name);


### PR DESCRIPTION
Resolves [MODINV-616](https://issues.folio.org/browse/MODINV-616) by adding a list of relatedInstances to the instance. This required a modification to the instance.json and the addition of instructions in the POM for this schema to be used for code generation. 

This may conflict with the generation which is taking place in [data-import-processing-core](https://github.com/folio-org/data-import-processing-core/blob/master/pom.xml#L242).