### PR TITLE
MODINV-662: Fetching instance fails to respond with minimal permissions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 18.2.0 IN-PROGRESS
+
+* Added permissions to search for item records to instance retrive by id endpoint (MODINV-662)
+
 ## 18.1.0 2022-02-24
 
 * added Marc Authority handler for entities created via MARC Authority Data Import (MODINV-501)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -367,7 +367,8 @@
             "inventory-storage.preceding-succeeding-titles.collection.get",
             "inventory-storage.instance-relationships.collection.get",
             "inventory-storage.bound-with-parts.collection.get",
-            "inventory-storage.holdings.collection.get"
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.items.collection.get"
           ]
         }, {
           "methods": ["POST"],


### PR DESCRIPTION
Investigation showed the search was hanging because it could
not complete a lookup to the item-storage endpoint for bound-with 
holdings. I added that permission to the relevant endpoint.