### PR TITLE
MODINV-679: Updating an instance with data import erases administrative note

### DIFF
--- a/src/main/java/org/folio/inventory/support/InstanceUtil.java
+++ b/src/main/java/org/folio/inventory/support/InstanceUtil.java
@@ -17,6 +17,7 @@ public class InstanceUtil {
 
   private static final String STATISTICAL_CODE_IDS_PROPERTY = "statisticalCodeIds";
   private static final String NATURE_OF_CONTENT_TERM_IDS_PROPERTY = "natureOfContentTermIds";
+  private static final String ADMINISTRATIVE_NOTES_PROPERTY = "administrativeNotes";
   private static final String PARENT_INSTANCES_PROPERTY = "parentInstances";
   private static final String CHILDREN_INSTANCES_PROPERTY = "childInstances";
 
@@ -50,6 +51,7 @@ public class InstanceUtil {
       .withStatisticalCodeIds(existing.getStatisticalCodeIds())
       .withNatureOfContentTermIds(existing.getNatureOfContentTermIds())
       .withTags(new Tags().withTagList(existing.getTags()))
+      .withAdministrativeNotes(existing.getAdministrativeNotes())
       .withParentInstances(parentInstances)
       .withChildInstances(childInstances);
 
@@ -84,14 +86,16 @@ public class InstanceUtil {
   }
 
   public static JsonObject mergeInstances(JsonObject existing, JsonObject mapped) {
-    //Statistical code, nature of content terms, parent/childInstances don`t revealed via mergeIn() because of simple array type.
+    //Statistical code, nature of content terms, administrative notes, parent/childInstances don`t revealed via mergeIn() because of simple array type.
     JsonArray statisticalCodeIds = existing.getJsonArray(STATISTICAL_CODE_IDS_PROPERTY);
     JsonArray natureOfContentTermIds = existing.getJsonArray(NATURE_OF_CONTENT_TERM_IDS_PROPERTY);
+    JsonArray administrativeNotes = existing.getJsonArray(ADMINISTRATIVE_NOTES_PROPERTY);
     JsonArray parents = existing.getJsonArray(PARENT_INSTANCES_PROPERTY);
     JsonArray children = existing.getJsonArray(CHILDREN_INSTANCES_PROPERTY);
     JsonObject mergedInstanceAsJson = existing.mergeIn(mapped);
     mergedInstanceAsJson.put(STATISTICAL_CODE_IDS_PROPERTY, statisticalCodeIds);
     mergedInstanceAsJson.put(NATURE_OF_CONTENT_TERM_IDS_PROPERTY, natureOfContentTermIds);
+    mergedInstanceAsJson.put(ADMINISTRATIVE_NOTES_PROPERTY, administrativeNotes);
     mergedInstanceAsJson.put(PARENT_INSTANCES_PROPERTY, parents);
     mergedInstanceAsJson.put(CHILDREN_INSTANCES_PROPERTY, children);
     return mergedInstanceAsJson;

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/util/InstanceUtilTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/util/InstanceUtilTest.java
@@ -17,6 +17,8 @@ import org.folio.inventory.domain.instances.InstanceRelationshipToParent;
 import org.folio.inventory.support.InstanceUtil;
 import org.junit.Test;
 
+import com.google.common.collect.Lists;
+
 public class InstanceUtilTest {
 
   @Test
@@ -72,6 +74,7 @@ public class InstanceUtilTest {
     existing.setParentInstances(parents);
     existing.setChildInstances(children);
     existing.setTags(tagList);
+    existing.setAdministrativeNotes(Lists.newArrayList("Adm note1", "Adm note2"));
 
     org.folio.inventory.domain.instances.Instance instance = InstanceUtil.mergeFieldsWhichAreNotControlled(existing, mapped);
     assertEquals("30773a27-b485-4dab-aeb6-b8c04fa3cb17", instance.getId());
@@ -91,5 +94,7 @@ public class InstanceUtilTest {
     assertEquals(tagList, instance.getTags());
     assertEquals("30773a27-b485-4dab-aeb6-b8c04fa3cb19", instance.getParentInstances().get(0).getId());
     assertEquals("30773a27-b485-4dab-aeb6-b8c04fa3cb19", instance.getChildInstances().get(0).getId());
+    assertEquals("Adm note1", instance.getAdministrativeNotes().get(0));
+    assertEquals("Adm note2", instance.getAdministrativeNotes().get(1));
   }
 }


### PR DESCRIPTION
1. Added "administrativeNotes" to the existing mechanism.
2. Test added.