### PR TITLE
MODINV-577 Match logic for VRN matches to Inventory records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Added permissions to search for item records to instance retrive by id endpoint (MODINV-662)
 * Match logic for POL matches to Inventory records (MODINV-578)
+* Match logic for VRN matches to Inventory records (MODINV-577)
 
 ## 18.1.0 2022-02-24
 

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/OrdersPreloaderHelper.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/OrdersPreloaderHelper.java
@@ -9,7 +9,6 @@ import static org.folio.inventory.support.CqlHelper.buildMultipleValuesCqlQuery;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import io.vertx.core.json.JsonArray;
 
@@ -21,7 +20,6 @@ import org.folio.processing.exceptions.MatchingException;
 public class OrdersPreloaderHelper {
 
     private static final String ORDER_LINES_CQL_PATTERN = "purchaseOrder.workflowStatus==Open AND %s";
-    private static final String VRN_VALUE_CQL_PATTERN = "\"\\\"refNumber\\\":\\\"%s\\\"\"";
 
     private OrdersClient ordersClient;
 
@@ -39,14 +37,12 @@ public class OrdersPreloaderHelper {
 
         switch (preloadingField) {
             case POL: {
-                String cqlCondition = buildMultipleValuesCqlQuery("poLineNumber", loadingParameters);
+                String cqlCondition = buildMultipleValuesCqlQuery("poLineNumber==", loadingParameters);
                 return getPoLineCollection(cqlCondition, eventPayload, convertPreloadResult);
             }
             case VRN: {
-                List<String> vrnLoadingParameters = loadingParameters.stream()
-                        .map(parameter -> String.format(VRN_VALUE_CQL_PATTERN, parameter))
-                        .collect(Collectors.toList());
-                String cqlCondition = buildMultipleValuesCqlQuery("vendorDetail.referenceNumbers", "=", vrnLoadingParameters);
+                String cqlCondition = buildMultipleValuesCqlQuery("vendorDetail.referenceNumbers=/@refNumber ",
+                        loadingParameters);
                 return getPoLineCollection(cqlCondition, eventPayload, convertPreloadResult);
             }
             default: {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/PreloadingFields.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/PreloadingFields.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum PreloadingFields {
-    POL("purchaseOrderLineNumber");
+    POL("purchaseOrderLineNumber"),
+    VRN("vendorReferenceNumber");
 
     private final String existingMatchField;
 }

--- a/src/main/java/org/folio/inventory/support/CqlHelper.java
+++ b/src/main/java/org/folio/inventory/support/CqlHelper.java
@@ -28,7 +28,11 @@ public class CqlHelper {
   }
 
   public static String buildMultipleValuesCqlQuery(String parameter, List<String> values) {
-    return String.format("%s==(%s)", parameter, values.stream()
+    return buildMultipleValuesCqlQuery(parameter, "==", values);
+  }
+
+  public static String buildMultipleValuesCqlQuery(String parameter, String comparisonOperator, List<String> values) {
+    return String.format("%s%s(%s)", parameter, comparisonOperator, values.stream()
             .map(String::toString)
             .distinct()
             .collect(Collectors.joining(" or ")));

--- a/src/main/java/org/folio/inventory/support/CqlHelper.java
+++ b/src/main/java/org/folio/inventory/support/CqlHelper.java
@@ -24,15 +24,11 @@ public class CqlHelper {
    * @return CQL expression
    */
   public static String buildQueryByIds(List<String> recordIds) {
-    return buildMultipleValuesCqlQuery("id", recordIds);
+    return buildMultipleValuesCqlQuery("id==", recordIds);
   }
 
-  public static String buildMultipleValuesCqlQuery(String parameter, List<String> values) {
-    return buildMultipleValuesCqlQuery(parameter, "==", values);
-  }
-
-  public static String buildMultipleValuesCqlQuery(String parameter, String comparisonOperator, List<String> values) {
-    return String.format("%s%s(%s)", parameter, comparisonOperator, values.stream()
+  public static String buildMultipleValuesCqlQuery(String prefix, List<String> values) {
+    return String.format("%s(%s)", prefix, values.stream()
             .map(String::toString)
             .distinct()
             .collect(Collectors.joining(" or ")));

--- a/src/test/java/org/folio/inventory/eventhandlers/preloaders/OrdersPreloaderHelperTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/preloaders/OrdersPreloaderHelperTest.java
@@ -38,7 +38,6 @@ public class OrdersPreloaderHelperTest {
     private static final String EMPTY_ORDER_PRELOADING_PARAMETERS_MESSAGE = "Loading parameters for Orders preloading must not be empty";
 
     private static final String INSTANCE_ID_FIELD = "instanceId";
-    private static final String VRN_VALUE_CQL_PATTERN = "\"\\\"refNumber\\\":\\\"%s\\\"\"";
 
     @Mock
     private OrdersClient ordersClient;
@@ -79,9 +78,10 @@ public class OrdersPreloaderHelperTest {
                 .collect(Collectors.toList()));
 
         List<String> vendorReferenceNumbersMock = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
-        String orderLinesCql = String.format("purchaseOrder.workflowStatus==Open AND vendorDetail.referenceNumbers=(%s or %s)",
-                String.format(VRN_VALUE_CQL_PATTERN, vendorReferenceNumbersMock.get(0)),
-                String.format(VRN_VALUE_CQL_PATTERN, vendorReferenceNumbersMock.get(1)));
+        String orderLinesCql = String.format(
+                "purchaseOrder.workflowStatus==Open AND vendorDetail.referenceNumbers=/@refNumber (%s or %s)",
+                vendorReferenceNumbersMock.get(0),
+                vendorReferenceNumbersMock.get(1));
 
         when(ordersClient.getPoLineCollection(eq(orderLinesCql), any()))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(poLineCollectionMock)));

--- a/src/test/java/org/folio/inventory/support/CqlHelperTest.java
+++ b/src/test/java/org/folio/inventory/support/CqlHelperTest.java
@@ -39,39 +39,27 @@ public class CqlHelperTest {
   }
 
   @Test
-  public void oneRecordParameterCqlQuery() {
-    Assertions.assertThat(CqlHelper.buildMultipleValuesCqlQuery("parameter", List.of("a")))
-            .isEqualTo("parameter==(a)");
-  }
-
-  @Test
-  public void multipleRecordParametersCqlQuery() {
-    Assertions.assertThat(CqlHelper.buildMultipleValuesCqlQuery("parameter", List.of("a", "b", "c")))
-            .isEqualTo("parameter==(a or b or c)");
-  }
-
-  @Test
-  public void oneRecordCustomComparisonOperatorCqlQuery() {
-    Assertions.assertThat(CqlHelper.buildMultipleValuesCqlQuery("parameter", "=", List.of("a")))
+  public void oneRecordCustomPrefixCqlQuery() {
+    Assertions.assertThat(CqlHelper.buildMultipleValuesCqlQuery("parameter=", List.of("a")))
             .isEqualTo("parameter=(a)");
   }
 
   @Test
-  public void multipleRecordCustomComparisonOperatorCqlQuery() {
-    Assertions.assertThat(CqlHelper.buildMultipleValuesCqlQuery("parameter", "=", List.of("a", "b", "c")))
+  public void multipleRecordCustomPrefixCqlQuery() {
+    Assertions.assertThat(CqlHelper.buildMultipleValuesCqlQuery("parameter=", List.of("a", "b", "c")))
             .isEqualTo("parameter=(a or b or c)");
   }
 
   @Test
   @Parameters({
-    "    | barcode==\"\"",      // barcode==""
-    "abc | barcode==\"abc\"",   // barcode=="abc"
-    "*   | barcode==\"\\*\"",   // barcode=="\*"
-    "?   | barcode==\"\\?\"",   // barcode=="\?"
-    "^   | barcode==\"\\^\"",   // barcode=="\^"
-    "\"  | barcode==\"\\\"\"",  // barcode=="\""
-    "\\  | barcode==\"\\\\\"",  // barcode=="\\"
-    "*?^\"\\*?^\"\\ | barcode==\"\\*\\?\\^\\\"\\\\\\*\\?\\^\\\"\\\\\"", // barcode=="\*\?\^\"\\\*\?\^\"\\"
+          "    | barcode==\"\"",      // barcode==""
+          "abc | barcode==\"abc\"",   // barcode=="abc"
+          "*   | barcode==\"\\*\"",   // barcode=="\*"
+          "?   | barcode==\"\\?\"",   // barcode=="\?"
+          "^   | barcode==\"\\^\"",   // barcode=="\^"
+          "\"  | barcode==\"\\\"\"",  // barcode=="\""
+          "\\  | barcode==\"\\\\\"",  // barcode=="\\"
+          "*?^\"\\*?^\"\\ | barcode==\"\\*\\?\\^\\\"\\\\\\*\\?\\^\\\"\\\\\"", // barcode=="\*\?\^\"\\\*\?\^\"\\"
   })
   public void barcode(String barcode, String cql) {
     assertThat(CqlHelper.barcodeIs(barcode), is(cql));

--- a/src/test/java/org/folio/inventory/support/CqlHelperTest.java
+++ b/src/test/java/org/folio/inventory/support/CqlHelperTest.java
@@ -51,6 +51,18 @@ public class CqlHelperTest {
   }
 
   @Test
+  public void oneRecordCustomComparisonOperatorCqlQuery() {
+    Assertions.assertThat(CqlHelper.buildMultipleValuesCqlQuery("parameter", "=", List.of("a")))
+            .isEqualTo("parameter=(a)");
+  }
+
+  @Test
+  public void multipleRecordCustomComparisonOperatorCqlQuery() {
+    Assertions.assertThat(CqlHelper.buildMultipleValuesCqlQuery("parameter", "=", List.of("a", "b", "c")))
+            .isEqualTo("parameter=(a or b or c)");
+  }
+
+  @Test
   @Parameters({
     "    | barcode==\"\"",      // barcode==""
     "abc | barcode==\"abc\"",   // barcode=="abc"


### PR DESCRIPTION
## Purpose
To implement the matching logic invoked when a user selects Vendor reference number (VRN) as the matchpoint from an incoming MARC Bibliographic record to an existing Inventory Instance, Holdings, or Item
## Approach
- add preloading field
- extend OrdersPreloaderHelper to support VRN matches
- implement unit tests

## Learning
[MODINV-577](https://issues.folio.org/browse/MODINV-577)