### PR TITLE
MODINV-684: Fix "_version" is not mandatory field

### DIFF
--- a/src/main/java/org/folio/inventory/support/InstanceUtil.java
+++ b/src/main/java/org/folio/inventory/support/InstanceUtil.java
@@ -1,8 +1,7 @@
 package org.folio.inventory.support;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.folio.ChildInstance;
 import org.folio.ParentInstance;
 import org.folio.Tags;
@@ -10,8 +9,8 @@ import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.InstanceRelationshipToChild;
 import org.folio.inventory.domain.instances.InstanceRelationshipToParent;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
+import java.util.List;
 
 public class InstanceUtil {
 
@@ -42,7 +41,7 @@ public class InstanceUtil {
     //Fields which are not affects by default mapping.
     org.folio.Instance tmp = new org.folio.Instance()
       .withId(existing.getId())
-      .withVersion(Integer.parseInt(existing.getVersion()))
+      .withVersion(asIntegerOrNull(existing.getVersion()))
       .withDiscoverySuppress(existing.getDiscoverySuppress())
       .withStaffSuppress(existing.getStaffSuppress())
       .withPreviouslyHeld(existing.getPreviouslyHeld())
@@ -99,5 +98,17 @@ public class InstanceUtil {
     mergedInstanceAsJson.put(PARENT_INSTANCES_PROPERTY, parents);
     mergedInstanceAsJson.put(CHILDREN_INSTANCES_PROPERTY, children);
     return mergedInstanceAsJson;
+  }
+
+  /**
+   * Returns the value if s can be parsed as Integer. Returns null if s is null.
+   *
+   * @throws NumberFormatException if s is not null and cannot be parsed as Integer.
+   */
+  private static Integer asIntegerOrNull(String s) {
+    if (s == null) {
+      return null;
+    }
+    return Integer.parseInt(s);
   }
 }

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/util/InstanceUtilTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/util/InstanceUtilTest.java
@@ -1,14 +1,6 @@
 package org.folio.inventory.dataimport.handlers.actions.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.folio.AlternativeTitle;
 import org.folio.Contributor;
 import org.folio.Instance;
@@ -17,7 +9,12 @@ import org.folio.inventory.domain.instances.InstanceRelationshipToParent;
 import org.folio.inventory.support.InstanceUtil;
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.*;
 
 public class InstanceUtilTest {
 
@@ -96,5 +93,16 @@ public class InstanceUtilTest {
     assertEquals("30773a27-b485-4dab-aeb6-b8c04fa3cb19", instance.getChildInstances().get(0).getId());
     assertEquals("Adm note1", instance.getAdministrativeNotes().get(0));
     assertEquals("Adm note2", instance.getAdministrativeNotes().get(1));
+  }
+
+  @Test
+  public void mergeFieldsWithNullVersion() {
+    org.folio.inventory.domain.instances.Instance existing =
+      new org.folio.inventory.domain.instances.Instance("id", null, "IN00001", "source", "title", "instanceTypeId");
+
+    org.folio.Instance mapped = new org.folio.Instance().withVersion(3);
+    org.folio.inventory.domain.instances.Instance merged = InstanceUtil.mergeFieldsWhichAreNotControlled(existing, mapped);
+    assertEquals(merged.getId(), "id");
+    assertEquals(merged.getVersion(),"3");
   }
 }


### PR DESCRIPTION
## Purpose
OL field "_version" is mandatory only for cases when OL is enabled.

## Approach
Added a condition to check this case

## Learning
[MODINV-684](https://issues.folio.org/browse/MODINV-684)