### PR TITLE
MODSOURMAN-782. Upgrade Kafka version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafkaclients.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
       <version>${testcontainers.version}</version>
@@ -255,11 +260,12 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testcontainers.version>1.15.3</testcontainers.version>
-    <vertx.version>4.2.5</vertx.version>
+    <vertx.version>4.2.6</vertx.version>
     <jsonschema2pojo_output_dir>${project.build.directory}/generated-sources/jsonschema2pojo</jsonschema2pojo_output_dir>
     <lombok.version>1.18.16</lombok.version>
     <postgres.version>42.3.2</postgres.version>
     <liquibase.version>4.6.2</liquibase.version>
+    <kafkaclients.version>3.1.0</kafkaclients.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Make kafka-clients version consistent as in mod-data-import, mod-source-record-manager.
Currently mod-inventory uses 2.6 kafka version from transitive dependency, when:
mod-data-import uses 3.1.0 https://github.com/folio-org/mod-data-import/blob/master/pom.xml#L28
mod-source-record-manager uses 3.1.0: https://github.com/folio-org/mod-source-record-manager/blob/master/mod-source-record-manager-server/pom.xml#L19