### PR TITLE
MODINV-692: Upgrade dependencies (CVE-2022-0839, CVE-2020-13956)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.0</version>
+        <version>2.17.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
+      <version>31.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -97,12 +97,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
-      <version>4.5.2</version>
+      <version>${httpcomponents.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-cache</artifactId>
-      <version>4.5.2</version>
+      <version>${httpcomponents.version}</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
@@ -284,9 +284,10 @@
     <testcontainers.version>1.15.3</testcontainers.version>
     <vertx.version>4.2.6</vertx.version>
     <jsonschema2pojo_output_dir>${project.build.directory}/generated-sources/jsonschema2pojo</jsonschema2pojo_output_dir>
+    <httpcomponents.version>4.5.13</httpcomponents.version>
     <lombok.version>1.18.16</lombok.version>
     <postgres.version>42.3.3</postgres.version>
-    <liquibase.version>4.6.2</liquibase.version>
+    <liquibase.version>4.9.1</liquibase.version>
     <kafkaclients.version>3.1.0</kafkaclients.version>
     <junit.version>4.13.2</junit.version>
   </properties>


### PR DESCRIPTION
Upgrade liquibase-core from 4.6.2 to 4.9.1 fixing XML External Entity (XXE) Injection: https://nvd.nist.gov/vuln/detail/CVE-2022-0839

Upgrade httpclient from 4.5.2 to 4.5.13 fixing Improper Input Validation: https://nvd.nist.gov/vuln/detail/CVE-2020-13956

Upgrade guava from 29.0 to 31.1 fixing false positive report about Information Disclosure: https://nvd.nist.gov/vuln/detail/CVE-2020-8908

Upgrade log4j from 2.17.0 to 2.17.2 fixing false positive report about Arbitrary Code Execution: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832