### PR TITLE
MODINV-686 - Add source record preparation before mapping to instance for instance update

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
@@ -103,8 +103,8 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler {
       String chunkId = dataImportEventPayload.getContext().get(CHUNK_ID_HEADER);
       mappingMetadataCache.get(jobExecutionId, context)
         .compose(parametersOptional -> parametersOptional
-          .map(mappingMetadata -> prepareAndExecuteMapping(dataImportEventPayload, new JsonObject(mappingMetadata.getMappingRules()), new JsonObject(mappingMetadata.getMappingParams())
-            .mapTo(MappingParameters.class), instanceToUpdate))
+          .map(mappingMetadata -> prepareAndExecuteMapping(dataImportEventPayload, new JsonObject(mappingMetadata.getMappingRules()),
+            Json.decodeValue(mappingMetadata.getMappingParams(), MappingParameters.class), instanceToUpdate))
           .orElseGet(() -> Future.failedFuture(format(MAPPING_PARAMETERS_NOT_FOUND_MSG, jobExecutionId,
             recordId, chunkId))))
         .compose(e -> {


### PR DESCRIPTION
## Purpose
it is necessary to perform preparation of record from payload before mapping to instance to avoid changing instance fields controlled by MARC record fields which are protected by protection settings while processing action profile for instance update.

## Approach
* add "source" instance field check to the ReplaceInstanceEventHandler event handler
 * if the "source" instance field is not equal to MARC, then proceed with event processing as is
 * if the "source" field equals MARC then
   * obtain MARC record related to the target instance by the instance Id from mod-source-record-storage (/source-storage/records/\{instanceId}/formatted?idType=INSTANCE)
   * perform record parsed content preparation using the util method from data-import-processing-core library and use the prepared parsed content for instance mapping
   * ensure a payload of instance update result message (DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING) with prepared record content to be saved in the mod-source-record-storage
* update and add tests

## Learning
[MODINV-686](https://issues.folio.org/browse/MODINV-686)