### PR TITLE
MODINV-550: Bound-with-parts gets an empty collection

### DIFF
--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -441,7 +441,7 @@ public class Instances extends AbstractInstances {
              .find( holdingsRecordIds, this::cqlMatchAnyByHoldingsRecordIds)
              .thenCompose(
                items -> {
-                 if (items.size() == 0) {
+                 if (items.isEmpty()) {
                   return CompletableFuture.completedFuture(Collections.emptyList());
                  }
                  List<String> itemIds = new ArrayList<>();

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -441,6 +441,9 @@ public class Instances extends AbstractInstances {
              .find( holdingsRecordIds, this::cqlMatchAnyByHoldingsRecordIds)
              .thenCompose(
                items -> {
+                 if (items.size() == 0) {
+                  return CompletableFuture.completedFuture(Collections.emptyList());
+                 }
                  List<String> itemIds = new ArrayList<>();
                  Map<String,String> itemHoldingsMap = new HashMap<>();
                  for (JsonObject item : items) {

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -987,7 +987,7 @@ public class Items extends AbstractInventoryResource {
 
     String boundWithPartsByItemIdQuery = String.format("itemId==(%s)",
       item.getId());
-    log.info("bound with part future lookup: " + boundWithPartsByItemIdQuery);
+
     boundWithPartsClient.getMany(
       boundWithPartsByItemIdQuery,
       1000,
@@ -1016,7 +1016,7 @@ public class Items extends AbstractInventoryResource {
         }
       }
     } else {
-      log.error("Failed to retrieve bound-with parts, status code:  " + response.getBody() + (response != null ? response.getStatusCode() : "null response"));
+      log.error("Failed to retrieve bound-with parts, status code:  " + (response != null ? response.getStatusCode() : "null response"));
     }
 
   }
@@ -1035,7 +1035,7 @@ public class Items extends AbstractInventoryResource {
         itemIds.stream()
           .map(String::toString)
           .collect(Collectors.joining(" or ")));
-    
+
     boundWithPartsClient.getMany(
       boundWithPartsByItemIdsQuery,
       itemIds.size(),

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -437,6 +437,7 @@ public class Items extends AbstractInventoryResource {
 
             locationsClient.get(id, newFuture::complete);
           });
+
         CompletableFuture<Response> boundWithPartsFuture =
           getBoundWithPartsForMultipleItemsFuture(wrappedItems, boundWithPartsClient);
         allFutures.add(boundWithPartsFuture);
@@ -1026,6 +1027,7 @@ public class Items extends AbstractInventoryResource {
     CollectionResourceClient boundWithPartsClient)
   {
     CompletableFuture<Response> future = new CompletableFuture<>();
+
     List<String> itemIds = wrappedItems.records.stream()
       .map(Item::getId)
       .collect(Collectors.toList());

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -284,7 +284,7 @@ public class Items extends AbstractInventoryResource {
     WebContext context,
     MultipleRecords<Item> wrappedItems) {
     List<String> itemIds = wrappedItems.records.stream().map(Item::getId).collect(Collectors.toList());
-    if (itemIds.size() == 0) {
+    if (itemIds.isEmpty()) {
       JsonResponse.success(routingContext.response(),
       new ItemRepresentation(RELATIVE_ITEMS_PATH)
         .toJson(wrappedItems, null, null, null,


### PR DESCRIPTION
The cause of this problem was that the instance retrieval code that sets the 
bound-with flag does not check to see if holdings records attached to
the instance record actually have items before doing an item record lookup.
This results in it sending an empty list to the code in items that fills out the 
item records, which also has no guard to see if it's actually being passed 
item records.  The item endpoint therefore tries to look up non-existent 
records.  Most of the code just passes over the empty records, but the 
bound-with lookup actually inserts an empty value into the bound-with 
endpoint lookup, resulting in a cql query error.  

I put two guards in place to address this.  One is in the instance code that 
does the bound-with lookup, and checks to make sure there are item records 
to look up before actually doing the lookup.  the second is in the item code, 
and checks any incoming query for item record data to make sure it's actually 
being passed item UUIDs before attempting to look them up.  This second guard is
necessary because I noticed that other parts of the code trigger this problem as well.
Any search for item records that does not match any items will trigger the error,
for the same reason the instance lookup does-the code does not check to see if 
the search actually retrieved anything before passing the results to the lookup code.