### PR TITLE
MODINV-715 Update instance import overwrites the update date for instance status when profile is not editing the instance status

### DIFF
--- a/src/main/java/org/folio/inventory/support/InstanceUtil.java
+++ b/src/main/java/org/folio/inventory/support/InstanceUtil.java
@@ -2,6 +2,7 @@ package org.folio.inventory.support;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.folio.ChildInstance;
 import org.folio.ParentInstance;
 import org.folio.Tags;
@@ -47,6 +48,7 @@ public class InstanceUtil {
       .withPreviouslyHeld(existing.getPreviouslyHeld())
       .withCatalogedDate(existing.getCatalogedDate())
       .withStatusId(existing.getStatusId())
+      .withStatusUpdatedDate(existing.getStatusUpdatedDate())
       .withStatisticalCodeIds(existing.getStatisticalCodeIds())
       .withNatureOfContentTermIds(existing.getNatureOfContentTermIds())
       .withTags(new Tags().withTagList(existing.getTags()))
@@ -103,12 +105,8 @@ public class InstanceUtil {
   /**
    * Returns the value if s can be parsed as Integer. Returns null if s is null.
    *
-   * @throws NumberFormatException if s is not null and cannot be parsed as Integer.
    */
   private static Integer asIntegerOrNull(String s) {
-    if (s == null) {
-      return null;
-    }
-    return Integer.parseInt(s);
+    return NumberUtils.isParsable(s) ? Integer.parseInt(s) : null;
   }
 }

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/util/InstanceUtilTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/util/InstanceUtilTest.java
@@ -14,7 +14,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 public class InstanceUtilTest {
 
@@ -45,8 +47,8 @@ public class InstanceUtilTest {
     statisticalCodeIds.add("30773a27-b485-4dab-aeb6-b8c04fa3cb18");
 
     List<String> natureOfContentTermIds = new ArrayList<>();
-    statisticalCodeIds.add("30773a27-b485-4dab-aeb6-b8c04fa3cb21");
-    statisticalCodeIds.add("30773a27-b485-4dab-aeb6-b8c04fa3cb22");
+    natureOfContentTermIds.add("30773a27-b485-4dab-aeb6-b8c04fa3cb21");
+    natureOfContentTermIds.add("30773a27-b485-4dab-aeb6-b8c04fa3cb22");
 
     List<InstanceRelationshipToParent> parents = new ArrayList<>();
     parents.add(new InstanceRelationshipToParent("30773a27-b485-4dab-aeb6-b8c04fa3cb19", "30773a27-b485-4dab-aeb6-b8c04fa3cb23", "30773a27-b485-4dab-aeb6-b8c04fa3cb24"));
@@ -67,6 +69,7 @@ public class InstanceUtilTest {
     existing.setPreviouslyHeld(true);
     existing.setCatalogedDate("");
     existing.setStatusId("30773a27-b485-4dab-aeb6-b8c04fa3cb26");
+    existing.setStatusUpdatedDate("2022-05-17T13:48:42.559+0000");
     existing.setNatureOfContentTermIds(natureOfContentTermIds);
     existing.setParentInstances(parents);
     existing.setChildInstances(children);
@@ -86,6 +89,7 @@ public class InstanceUtilTest {
     assertTrue(instance.getPreviouslyHeld());
     assertEquals("", instance.getCatalogedDate());
     assertEquals("30773a27-b485-4dab-aeb6-b8c04fa3cb26", instance.getStatusId());
+    assertEquals("2022-05-17T13:48:42.559+0000", instance.getStatusUpdatedDate());
     assertEquals(natureOfContentTermIds, instance.getNatureOfContentTermIds());
     assertNotNull(instance.getTags());
     assertEquals(tagList, instance.getTags());
@@ -102,7 +106,7 @@ public class InstanceUtilTest {
 
     org.folio.Instance mapped = new org.folio.Instance().withVersion(3);
     org.folio.inventory.domain.instances.Instance merged = InstanceUtil.mergeFieldsWhichAreNotControlled(existing, mapped);
-    assertEquals(merged.getId(), "id");
-    assertEquals(merged.getVersion(),"3");
+    assertEquals("id", merged.getId());
+    assertEquals("3", merged.getVersion());
   }
 }


### PR DESCRIPTION
### Purpose
Before merging existing and maped instances (one of step preparation before mapping) we didn't map status updated date. As result it was overwriten in the instance replace operation where we don't set Instance status term in mapping profile.

### Learning
[MODINV-715](https://issues.folio.org/browse/MODINV-715)