### PR TITLE
MODINV-705 Updating "MARC Authority" record causes errors

### DIFF
--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandlerTest.java
@@ -134,6 +134,7 @@ public class UpdateAuthorityEventHandlerTest {
   @Test
   public void shouldProcessEvent() throws IOException, InterruptedException, ExecutionException, TimeoutException {
     when(storage.getAuthorityRecordCollection(any())).thenReturn(authorityCollection);
+    when(authorityCollection.findById(anyString())).thenReturn(CompletableFuture.completedFuture(new Authority().withVersion(1)));
 
     var parsedAuthorityRecord = new JsonObject(TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedAuthorityRecord.encode()));
@@ -154,7 +155,9 @@ public class UpdateAuthorityEventHandlerTest {
 
     assertEquals(DI_INVENTORY_AUTHORITY_UPDATED.value(), actualDataImportEventPayload.getEventType());
     assertNotNull(actualDataImportEventPayload.getContext().get(AUTHORITY.value()));
-    assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(AUTHORITY.value())).getString("id"));
+    JsonObject authority = new JsonObject(actualDataImportEventPayload.getContext().get(AUTHORITY.value()));
+    assertNotNull(authority.getString("id"));
+    assertEquals("1", authority.getString("_version"));
   }
 
   @Test(expected = ExecutionException.class)


### PR DESCRIPTION
**_Purpose_**
https://issues.folio.org/browse/MODINV-705
Updating "MARC Authority" record by matching "999 ff $s" subfield fails with "Completed with errors" status and MARC record doesn't update.

**_Approach_**
The approach is to set a 'relatedRecordVersion' to the target updating record, this prevents Optimistic Locking error on update