### PR TITLE
MODINV-723 - Pre-set event type to payload before processing event for entities matching

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
@@ -33,6 +33,7 @@ public abstract class AbstractMatchEventHandler implements EventHandler {
   @Override
   public CompletableFuture<DataImportEventPayload> handle(DataImportEventPayload dataImportEventPayload) {
     CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
+    dataImportEventPayload.setEventType(getNotMatchedEventType());
     dataImportEventPayload.getEventsChain().add(dataImportEventPayload.getEventType());
     Context context = constructContext(dataImportEventPayload.getTenant(),
       dataImportEventPayload.getToken(), dataImportEventPayload.getOkapiUrl());

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
@@ -33,8 +33,8 @@ public abstract class AbstractMatchEventHandler implements EventHandler {
   @Override
   public CompletableFuture<DataImportEventPayload> handle(DataImportEventPayload dataImportEventPayload) {
     CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
-    dataImportEventPayload.setEventType(getNotMatchedEventType());
     dataImportEventPayload.getEventsChain().add(dataImportEventPayload.getEventType());
+    dataImportEventPayload.setEventType(getNotMatchedEventType());
     Context context = constructContext(dataImportEventPayload.getTenant(),
       dataImportEventPayload.getToken(), dataImportEventPayload.getOkapiUrl());
 

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchInstanceEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchInstanceEventHandlerUnitTest.java
@@ -264,6 +264,22 @@ public class MatchInstanceEventHandlerUnitTest {
   }
 
   @Test
+  public void shouldSetInstanceNotMatchedEventToEventPayloadOnHandleIfFailedToGetMappingMetadata(TestContext testContext) {
+    Async async = testContext.async();
+    when(mappingMetadataCache.get(anyString(), any(Context.class)))
+      .thenReturn(Future.failedFuture("test error"));
+
+    EventHandler eventHandler = new MatchInstanceEventHandler(mappingMetadataCache);
+    DataImportEventPayload eventPayload = createEventPayload();
+
+    eventHandler.handle(eventPayload).whenComplete((updatedEventPayload, throwable) -> {
+      testContext.assertNotNull(throwable);
+      testContext.assertEquals(DI_INVENTORY_INSTANCE_NOT_MATCHED.value(), eventPayload.getEventType());
+      async.complete();
+    });
+  }
+
+  @Test
   public void shouldReturnFalseOnIsEligibleIfNullCurrentNode() {
     EventHandler eventHandler = new MatchInstanceEventHandler(mappingMetadataCache);
     DataImportEventPayload eventPayload = new DataImportEventPayload();


### PR DESCRIPTION
## Purpose
it should be possible to save errors to the data import journal due to infrastructure failure during event processing for entities matching. For instance, such error can occur on getting mapping metadata.

## Approach
* set corresponding event type to dataImportEventPayload before processing in the AbstractMatchEventHandler handler to make it processable by journal handler
* add test


## Learning
[MODINV-723](https://issues.folio.org/browse/MODINV-723)