### PR TITLE
MODINV-729 Extend instance contributors schema with Authority ID

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 18.3.0 IN-PROGRESS
 
 * Now supports interface users 15.0, 16.0 (MODINV-725)
+* Extend instance contributors schema with Authority ID ([MODINV-729](https://issues.folio.org/browse/MODINV-729))
 
 ## 18.2.0 2022-06-27
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "11.4",
+      "version": "11.5",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -167,6 +167,10 @@
             "type": "string",
             "description": "Contributor type terms defined by the MARC code list for relators"
           },
+          "authorityId": {
+            "type": "string",
+            "description": "ID of authority record that controls the contributor"
+          },
           "primary": {
             "type": "boolean",
             "description": "Whether this is the primary contributor"

--- a/ramls/inventory.raml
+++ b/ramls/inventory.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory API
-version: v11.4
+version: v11.5
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/src/main/java/org/folio/inventory/domain/ingest/IngestMessageProcessor.java
+++ b/src/main/java/org/folio/inventory/domain/ingest/IngestMessageProcessor.java
@@ -92,13 +92,13 @@ public class IngestMessageProcessor {
         List<Contributor> contributors = contributorsJson.stream()
           .map(contributor -> new Contributor(
             contributorNameTypes.getString("Personal name"),
-            contributor.getString("name"), "", "", null))
+            contributor.getString("name"), "", "", "", null))
           .collect(Collectors.toList());
 
         if(contributors.isEmpty()) {
           contributors.add(new Contributor(
             contributorNameTypes.getString("Personal name"),
-            "Unknown contributor", "", "", null));
+            "Unknown contributor", "", "", "", null));
         }
 
         return new Instance(

--- a/src/main/java/org/folio/inventory/domain/instances/Contributor.java
+++ b/src/main/java/org/folio/inventory/domain/instances/Contributor.java
@@ -8,19 +8,23 @@ public class Contributor {
   public static final String NAME_KEY = "name";
   public static final String CONTRIBUTOR_TYPE_ID_KEY = "contributorTypeId";
   public static final String CONTRIBUTOR_TYPE_TEXT_KEY = "contributorTypeText";
+  public static final String AUTHORITY_ID_KEY = "authorityId";
   public static final String PRIMARY_KEY = "primary";
 
   public final String contributorNameTypeId;
   public final String name;
   public final String contributorTypeId;
   public final String contributorTypeText;
+  public final String authorityId;
   public final Boolean primary;
 
-  public Contributor(String contributorNameTypeId, String name, String contributorTypeId, String contributorTypeText, Boolean primary) {
+  public Contributor(String contributorNameTypeId, String name, String contributorTypeId, String contributorTypeText,
+                     String authorityId, Boolean primary) {
     this.contributorNameTypeId = contributorNameTypeId;
     this.name = name;
     this.contributorTypeId = contributorTypeId;
     this.contributorTypeText = contributorTypeText;
+    this.authorityId = authorityId;
     this.primary = primary;
   }
 
@@ -29,6 +33,7 @@ public class Contributor {
          json.getString(NAME_KEY),
          json.getString(CONTRIBUTOR_TYPE_ID_KEY),
          json.getString(CONTRIBUTOR_TYPE_TEXT_KEY),
+         json.getString(AUTHORITY_ID_KEY),
          json.getBoolean(PRIMARY_KEY));
   }
 

--- a/src/main/java/org/folio/inventory/domain/instances/Instance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/Instance.java
@@ -854,10 +854,12 @@ public class Instance {
     return addIdentifier(identifier);
   }
 
-  public Instance addContributor(String contributorNameTypeId, String name, String contributorTypeId, String contributorTypeText, Boolean primary) {
+  public Instance addContributor(String contributorNameTypeId, String name, String contributorTypeId,
+                                 String contributorTypeText, String authorityId, Boolean primary) {
     List<Contributor> newContributors = new ArrayList<>(this.contributors);
 
-    newContributors.add(new Contributor(contributorNameTypeId, name, contributorTypeId, contributorTypeText, primary));
+    newContributors.add(new Contributor(contributorNameTypeId, name, contributorTypeId, contributorTypeText,
+      authorityId, primary));
 
     return copyInstance().setContributors(newContributors);
   }

--- a/src/test/java/api/support/InstanceSamples.java
+++ b/src/test/java/api/support/InstanceSamples.java
@@ -168,7 +168,7 @@ public class InstanceSamples {
       .put("identifiers", new JsonArray()
         .add(JsonObject.mapFrom(new Identifier("test identifier type id", "test identifier value"))))
       .put("contributors", new JsonArray()
-        .add(JsonObject.mapFrom(new Contributor("test name type id", "test name", "test type id", "test text", true))))
+        .add(JsonObject.mapFrom(new Contributor("test name type id", "test name", "test type id", "test text", "test authority id", true))))
       .put("publication", new JsonArray()
         .add(JsonObject.mapFrom(new Publication("test publisher", "test place", LocalDate.now().toString(), "test role"))))
       .put("editions", new JsonArray().add("test edition"))

--- a/src/test/java/org/folio/inventory/storage/external/ExternalInstanceCollectionExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalInstanceCollectionExamples.java
@@ -297,34 +297,34 @@ public class ExternalInstanceCollectionExamples {
   private static Instance nod() {
     return createInstance("Nod")
       .addIdentifier(ASIN_IDENTIFIER_TYPE, "B01D1PLMDO")
-      .addContributor(PERSONAL_CONTRIBUTOR_NAME_TYPE, "Barnes, Adrian", AUTHOR_CONTRIBUTOR_TYPE, "", null);
+      .addContributor(PERSONAL_CONTRIBUTOR_NAME_TYPE, "Barnes, Adrian", AUTHOR_CONTRIBUTOR_TYPE, "", "", null);
   }
 
   private static Instance uprooted() {
     return createInstance("Uprooted")
       .addIdentifier(ISBN_IDENTIFIER_TYPE, "1447294149")
       .addIdentifier(ISBN_IDENTIFIER_TYPE, "9781447294146")
-      .addContributor(PERSONAL_CONTRIBUTOR_NAME_TYPE, "Novik, Naomi", AUTHOR_CONTRIBUTOR_TYPE, "", null);
+      .addContributor(PERSONAL_CONTRIBUTOR_NAME_TYPE, "Novik, Naomi", AUTHOR_CONTRIBUTOR_TYPE, "", "", null);
   }
 
   private static Instance smallAngryPlanet() {
     return createInstance("Long Way to a Small Angry Planet")
       .addIdentifier(ISBN_IDENTIFIER_TYPE, "9781473619777")
-      .addContributor(PERSONAL_CONTRIBUTOR_NAME_TYPE, "Chambers, Becky", AUTHOR_CONTRIBUTOR_TYPE, "", null);
+      .addContributor(PERSONAL_CONTRIBUTOR_NAME_TYPE, "Chambers, Becky", AUTHOR_CONTRIBUTOR_TYPE, "", "", null);
   }
 
   private static Instance temeraire() {
     return createInstance("Temeraire")
       .addIdentifier(ISBN_IDENTIFIER_TYPE, "0007258712")
       .addIdentifier(ISBN_IDENTIFIER_TYPE, "9780007258710")
-      .addContributor(PERSONAL_CONTRIBUTOR_NAME_TYPE, "Novik, Naomi", AUTHOR_CONTRIBUTOR_TYPE, "", null);
+      .addContributor(PERSONAL_CONTRIBUTOR_NAME_TYPE, "Novik, Naomi", AUTHOR_CONTRIBUTOR_TYPE, "", "", null);
   }
 
   private static Instance interestingTimes() {
     return createInstance("Interesting Times")
       .addIdentifier(ISBN_IDENTIFIER_TYPE, "0552167541")
       .addIdentifier(ISBN_IDENTIFIER_TYPE, "9780552167543")
-      .addContributor(PERSONAL_CONTRIBUTOR_NAME_TYPE, "Pratchett, Terry", AUTHOR_CONTRIBUTOR_TYPE, "", null);
+      .addContributor(PERSONAL_CONTRIBUTOR_NAME_TYPE, "Pratchett, Terry", AUTHOR_CONTRIBUTOR_TYPE, "", "", null);
   }
 
   private static Instance createInstance(String title) {


### PR DESCRIPTION
## Purpose
It's needed to have information if a contributor is controlled by authority

## Approach
Extend instance.contributors with authorityId