### PR TITLE
MODINV-731: Delete instance/item by CQL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Now supports interface users 15.0, 16.0 (MODINV-725)
 * Extend instance contributors schema with Authority ID ([MODINV-729](https://issues.folio.org/browse/MODINV-729))
+* Delete instance/item by CQL ([MODINV-731](https://issues.folio.org/browse/MODINV-731))
+* Provides inventory 12.0, supports instance-storage 9.0, holdings-storage 6.0, item-storage 10.0.
 
 ## 18.2.0 2022-06-27
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * Now supports interface users 15.0, 16.0 (MODINV-725)
 * Extend instance contributors schema with Authority ID ([MODINV-729](https://issues.folio.org/browse/MODINV-729))
 * Delete instance/item by CQL ([MODINV-731](https://issues.folio.org/browse/MODINV-731))
-* Provides inventory 12.0, supports instance-storage 9.0, holdings-storage 6.0, item-storage 10.0.
+* Provides inventory 12.0, requires instance-storage 9.0, item-storage 10.0, holdings-storage 2.0 ... 6.0.
 
 ## 18.2.0 2022-06-27
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -551,11 +551,11 @@
   "requires": [
     {
       "id": "item-storage",
-      "version": "8.9 9.0 10.0"
+      "version": "10.0"
     },
     {
       "id": "instance-storage",
-      "version": "7.8 8.0 9.0"
+      "version": "9.0"
     },
     {
       "id": "instance-storage-batch",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "11.5",
+      "version": "12.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -551,11 +551,11 @@
   "requires": [
     {
       "id": "item-storage",
-      "version": "8.9 9.0"
+      "version": "8.9 9.0 10.0"
     },
     {
       "id": "instance-storage",
-      "version": "7.8 8.0"
+      "version": "7.8 8.0 9.0"
     },
     {
       "id": "instance-storage-batch",
@@ -563,7 +563,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "2.0 3.0 4.0 5.0"
+      "version": "2.0 3.0 4.0 5.0 6.0"
     },
     {
       "id": "material-types",

--- a/ramls/inventory.raml
+++ b/ramls/inventory.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory API
-version: v11.5
+version: v12.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -44,9 +44,20 @@ resourceTypes:
           ]
     post:
     delete:
+      is: [searchable: { description: "CQL to select items to delete, use cql.allRecords=1 to delete all", example: "barcode==\"123-0*\"" } ]
       responses:
         204:
-          description: "All items deleted"
+          description: "Selected items deleted"
+        400:
+          description: "Bad request, e.g. malformed query parameter"
+          body:
+            text/plain:
+              example: "query parameter is empty"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            text/plain:
+              example: "Internal server error, contact administrator"
     /{itemId}:
       type:
         collection-item:
@@ -335,9 +346,21 @@ resourceTypes:
     post:
       is: [validate]
     delete:
+      is: [searchable: { description: "CQL to select instances to delete, use cql.allRecords=1 to delete all. Deletes connected marc source records.",
+                         example: "hrid==\"in123-0*\"" } ]
       responses:
         204:
-          description: "All instances deleted"
+          description: "Selected instances deleted"
+        400:
+          description: "Bad request, e.g. malformed query parameter"
+          body:
+            text/plain:
+              example: "query parameter is empty"
+        500:
+          description: "Internal server error, e.g. due to misconfiguration"
+          body:
+            text/plain:
+              example: "Internal server error, contact administrator"
     /{instanceId}:
       type:
         collection-item:

--- a/src/main/java/org/folio/inventory/common/FutureAssistance.java
+++ b/src/main/java/org/folio/inventory/common/FutureAssistance.java
@@ -12,15 +12,31 @@ import java.util.function.Consumer;
 
 public class FutureAssistance {
   public static <T> T getOnCompletion(CompletableFuture<T> future)
-    throws InterruptedException, ExecutionException, TimeoutException {
+      throws InterruptedException, ExecutionException, TimeoutException {
 
     return future.get(2000, TimeUnit.MILLISECONDS);
   }
 
-  public static void waitForCompletion(CompletableFuture future)
-    throws InterruptedException, ExecutionException, TimeoutException {
+  public static <T> T getOnCompletion(Consumer<CompletableFuture<T>> task)
+      throws InterruptedException, ExecutionException, TimeoutException {
+
+    CompletableFuture<T> future = new CompletableFuture<T>();
+    task.accept(future);
+    return getOnCompletion(future);
+  }
+
+  public static <T> void waitForCompletion(CompletableFuture<T> future)
+      throws InterruptedException, ExecutionException, TimeoutException {
 
     future.get(2000, TimeUnit.MILLISECONDS);
+  }
+
+  public static <T> void waitForCompletion(Consumer<CompletableFuture<T>> task)
+      throws InterruptedException, ExecutionException, TimeoutException {
+
+    CompletableFuture<T> future = new CompletableFuture<>();
+    task.accept(future);
+    waitForCompletion(future);
   }
 
   public static Consumer<Success<Void>> complete(final CompletableFuture<Success<Void>> future) {

--- a/src/main/java/org/folio/inventory/common/FutureAssistance.java
+++ b/src/main/java/org/folio/inventory/common/FutureAssistance.java
@@ -20,7 +20,7 @@ public class FutureAssistance {
   public static <T> T getOnCompletion(Consumer<CompletableFuture<T>> task)
       throws InterruptedException, ExecutionException, TimeoutException {
 
-    CompletableFuture<T> future = new CompletableFuture<T>();
+    CompletableFuture<T> future = new CompletableFuture<>();
     task.accept(future);
     return getOnCompletion(future);
   }

--- a/src/main/java/org/folio/inventory/domain/AsynchronousCollection.java
+++ b/src/main/java/org/folio/inventory/domain/AsynchronousCollection.java
@@ -11,8 +11,14 @@ import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.exceptions.InternalServerErrorException;
 
 public interface AsynchronousCollection<T> {
-  void empty(Consumer<Success<Void>> completionCallback,
+  void empty(String cqlQuery,
+             Consumer<Success<Void>> completionCallback,
              Consumer<Failure> failureCallback);
+
+  default void empty(Consumer<Success<Void>> completionCallback,
+                     Consumer<Failure> failureCallback) {
+    empty("cql.allRecords=1", completionCallback, failureCallback);
+  }
 
   void add(T item,
            Consumer<Success<T>> resultCallback,

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -299,6 +299,7 @@ public class Instances extends AbstractInstances {
     WebContext context = new WebContext(routingContext);
 
     storage.getInstanceCollection(context).empty(
+      routingContext.request().getParam("query"),
       v -> noContent(routingContext.response()),
       FailureResponseConsumer.serverError(routingContext.response()));
   }

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -153,6 +153,7 @@ public class Items extends AbstractInventoryResource {
     WebContext context = new WebContext(routingContext);
 
     storage.getItemCollection(context).empty(
+        routingContext.request().getParam("query"),
       v -> SuccessResponse.noContent(routingContext.response()),
       FailureResponseConsumer.serverError(routingContext.response()));
   }

--- a/src/main/java/org/folio/inventory/resources/Items.java
+++ b/src/main/java/org/folio/inventory/resources/Items.java
@@ -153,7 +153,7 @@ public class Items extends AbstractInventoryResource {
     WebContext context = new WebContext(routingContext);
 
     storage.getItemCollection(context).empty(
-        routingContext.request().getParam("query"),
+      routingContext.request().getParam("query"),
       v -> SuccessResponse.noContent(routingContext.response()),
       FailureResponseConsumer.serverError(routingContext.response()));
   }

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleCollection.java
@@ -22,7 +22,7 @@ import org.folio.inventory.common.domain.MultipleRecords;
 import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.support.JsonArrayHelper;
 import org.folio.inventory.support.http.client.Response;
-
+import org.folio.util.PercentCodec;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -143,10 +143,15 @@ abstract class ExternalStorageModuleCollection<T> {
   }
 
   public void empty(
+    String cqlQuery,
     Consumer<Success<Void>> completionCallback,
     Consumer<Failure> failureCallback) {
 
-    deleteLocation(storageAddress, completionCallback, failureCallback);
+    if (cqlQuery == null) {
+      failureCallback.accept(new Failure("query parameter is required", 400));
+      return;
+    }
+    deleteLocation(storageAddress + "?query=" + PercentCodec.encode(cqlQuery), completionCallback, failureCallback);
   }
 
   public void findByCql(String cqlQuery,

--- a/src/main/java/org/folio/inventory/storage/memory/InMemoryIngestJobCollection.java
+++ b/src/main/java/org/folio/inventory/storage/memory/InMemoryIngestJobCollection.java
@@ -19,11 +19,16 @@ public class InMemoryIngestJobCollection implements IngestJobCollection {
 
   @Override
   public void empty(
+    String cqlQuery,
     Consumer<Success<Void>> completionCallback,
     Consumer<Failure> failureCallback) {
 
-    items.clear();
-    completionCallback.accept(new Success<>(null));
+    if ("cql.allRecords=1".equals(cqlQuery)) {
+      items.clear();
+      completionCallback.accept(new Success<>(null));
+    } else {
+      failureCallback.accept(new Failure("DELETE query=" + cqlQuery + " is not implemented", 500));
+    }
   }
 
   @Override

--- a/src/main/java/org/folio/inventory/storage/memory/InMemoryIngestJobCollection.java
+++ b/src/main/java/org/folio/inventory/storage/memory/InMemoryIngestJobCollection.java
@@ -6,7 +6,6 @@ import org.folio.inventory.common.domain.MultipleRecords;
 import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.domain.ingest.IngestJobCollection;
 import org.folio.inventory.resources.ingest.IngestJob;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -17,18 +16,21 @@ import java.util.stream.Collectors;
 public class InMemoryIngestJobCollection implements IngestJobCollection {
   private final List<IngestJob> items = new ArrayList<>();
 
+  /**
+   * This method is used by unit tests only.
+   */
   @Override
   public void empty(
     String cqlQuery,
     Consumer<Success<Void>> completionCallback,
     Consumer<Failure> failureCallback) {
 
-    if ("cql.allRecords=1".equals(cqlQuery)) {
-      items.clear();
-      completionCallback.accept(new Success<>(null));
-    } else {
-      failureCallback.accept(new Failure("DELETE query=" + cqlQuery + " is not implemented", 500));
+    if (! "cql.allRecords=1".equals(cqlQuery)) {
+      failureCallback.accept(new Failure("Not implemented, query must be cql.allRecords=1", 400));
+      return;
     }
+    items.clear();
+    completionCallback.accept(new Success<>(null));
   }
 
   @Override

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -23,6 +23,7 @@ import org.folio.inventory.support.JsonArrayHelper;
 import org.folio.inventory.support.http.ContentType;
 import org.folio.inventory.support.http.client.IndividualResource;
 import org.folio.inventory.support.http.client.Response;
+import org.folio.util.PercentCodec;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Assert;
@@ -708,7 +709,8 @@ public class InstancesApiExamples extends ApiTests {
     createInstance(nod(UUID.randomUUID()));
     createInstance(leviathanWakes(UUID.randomUUID()));
 
-    final var deleteCompleted = okapiClient.delete(ApiRoot.instances());
+    final var deleteCompleted = okapiClient.delete(
+        ApiRoot.instances() + "?query=" + PercentCodec.encode("cql.allRecords=1"));
 
     Response deleteResponse = deleteCompleted.toCompletableFuture().get(5, SECONDS);
 

--- a/src/test/java/api/TenantApiTest.java
+++ b/src/test/java/api/TenantApiTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import static api.ApiTestSuite.TENANT_ID;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.HttpStatus.HTTP_INTERNAL_SERVER_ERROR;
@@ -80,7 +79,7 @@ public class TenantApiTest extends ApiTests {
       DB_PORT, String.valueOf(pgConnectOptions.getPort()),
       DB_USERNAME, pgConnectOptions.getUser(),
       DB_PASSWORD, pgConnectOptions.getPassword());
-    PostgresConnectionOptions.setSystemProperties(new HashMap<>());
+    PostgresConnectionOptions.setSystemProperties(Map.of(DB_HOST, "invalid"));
 
     final var deleteCompletedBefore = okapiClient
       .delete(ApiRoot.tenant());

--- a/src/test/java/api/support/Preparation.java
+++ b/src/test/java/api/support/Preparation.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.inventory.support.http.client.Response;
+import org.folio.util.PercentCodec;
 
 public class Preparation {
   private final OkapiHttpClient client;
@@ -40,7 +41,8 @@ public class Preparation {
   private void deleteAll(URL root)
     throws InterruptedException, ExecutionException, TimeoutException {
 
-    final var deleteCompleted = client.delete(root);
+    final var deleteCompleted = client.delete(
+        root + "?query=" + PercentCodec.encode("cql.allRecords=1"));
 
     Response response = deleteCompleted.toCompletableFuture().get(5, TimeUnit.SECONDS);
 

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -6,6 +6,7 @@ import org.folio.inventory.support.JsonArrayHelper;
 import org.folio.inventory.support.http.client.IndividualResource;
 import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.inventory.support.http.client.Response;
+import org.folio.util.PercentCodec;
 import org.joda.time.DateTime;
 import support.fakes.EndpointFailureDescriptor;
 
@@ -259,7 +260,8 @@ public class ResourceClient {
     ExecutionException,
     TimeoutException {
 
-    final var deleteCompleted = client.delete(urlMaker.combine(""));
+    final var deleteCompleted = client.delete(urlMaker.combine(
+        "?query=" + PercentCodec.encode("cql.allRecords=1")));
 
     Response response = deleteCompleted.toCompletableFuture().get(5, SECONDS);
 

--- a/src/test/java/org/folio/inventory/storage/external/ExternalInstanceCollectionExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalInstanceCollectionExamples.java
@@ -7,6 +7,7 @@ import static org.folio.inventory.common.FutureAssistance.waitForCompletion;
 import static org.folio.inventory.storage.external.ExternalStorageSuite.getStorageAddress;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -87,6 +88,12 @@ public class ExternalInstanceCollectionExamples {
     assertThat(getSize(), is(1));
     empty("id==" + instance2.getId());
     assertThat(getSize(), is(0));
+  }
+
+  @Test
+  public void cannotEmptyIfCqlIsMissing() {
+    var e = assertThrows(ExecutionException.class, () -> empty(null));
+    assertThat(e.getCause().getMessage(), is("query parameter is required"));
   }
 
   @Test

--- a/src/test/java/support/fakes/FakeStorageModule.java
+++ b/src/test/java/support/fakes/FakeStorageModule.java
@@ -275,8 +275,14 @@ class FakeStorageModule extends AbstractVerticle {
     }
 
     Map<String, JsonObject> resourcesForTenant = getResourcesForTenant(context);
+    List<String> queries = routingContext.queryParam("query");
+    String query = queries.size() == 1 ? queries.get(0) : "";
 
-    resourcesForTenant.clear();
+    if (query.startsWith("id==")) {
+      resourcesForTenant.remove(query.substring(4));
+    } else {
+      resourcesForTenant.clear();
+    }
 
     SuccessResponse.noContent(routingContext.response());
   }


### PR DESCRIPTION
mod-inventory-storage has changed the DELETE all records API for instances, holdings and items. It requires a query parameter with the CQL query that selects the records to delete.

mod-inventory should also require this query parameter and pass it to mod-inventory-storage APIs.