### PR TITLE
FOLIO-3231 Use new api-lint and api-doc CI facilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,13 @@ buildMvn {
   publishModDescriptor = 'yes'
   publishAPI = 'yes'
   mvnDeploy = 'yes'
-  runLintRamlCop = 'yes'
   doKubeDeploy = true
   publishPreview = false
   buildNode = 'jenkins-agent-java11'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
 
   doDocker = {
     buildJavaDocker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,13 @@
 
 buildMvn {
   publishModDescriptor = 'yes'
-  publishAPI = 'yes'
   mvnDeploy = 'yes'
   doKubeDeploy = true
   publishPreview = false
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # mod-inventory
 
-Copyright (C) 2016-2020 The Open Library Foundation
+Copyright (C) 2016-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/ramls/inventory-config.raml
+++ b/ramls/inventory-config.raml
@@ -23,7 +23,7 @@ types:
             body:
               application/json:
                 example: !include examples/blocked_fields_get.json
-                schema: blocked-fields
+                type: blocked-fields
           500:
             description: "Internal server error"
             body:
@@ -39,7 +39,7 @@ types:
             body:
               application/json:
                   example: !include examples/blocked_fields_get.json
-                  schema: blocked-fields
+                  type: blocked-fields
           500:
             description: "Internal server error"
             body:

--- a/ramls/inventory.raml
+++ b/ramls/inventory.raml
@@ -70,7 +70,7 @@ resourceTypes:
               body:
                 application/json:
                   example: !include examples/item_get.json
-                  schema: item
+                  type: item
             404:
               description: "Item not found"
               body:
@@ -80,7 +80,7 @@ resourceTypes:
               description: "Validation error"
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             500:
               description: "Internal server error"
               body:
@@ -94,7 +94,7 @@ resourceTypes:
               body:
                 application/json:
                   example: !include examples/item_get.json
-                  schema: item
+                  type: item
             404:
               description: "Item not found"
               body:
@@ -104,7 +104,7 @@ resourceTypes:
               description: "Validation error"
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             500:
               description: "Internal server error"
               body:
@@ -118,7 +118,7 @@ resourceTypes:
               body:
                 application/json:
                   example: !include examples/item_get.json
-                  schema: item
+                  type: item
             404:
               description: "Item not found"
               body:
@@ -128,7 +128,7 @@ resourceTypes:
               description: "Validation error"
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             500:
               description: "Internal server error"
               body:
@@ -142,7 +142,7 @@ resourceTypes:
               body:
                 application/json:
                   example: !include examples/item_get.json
-                  schema: item
+                  type: item
             404:
               description: "Item not found"
               body:
@@ -152,7 +152,7 @@ resourceTypes:
               description: "Validation error"
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             500:
               description: "Internal server error"
               body:
@@ -166,7 +166,7 @@ resourceTypes:
               body:
                 application/json:
                   example: !include examples/item_get.json
-                  schema: item
+                  type: item
             404:
               description: "Item not found"
               body:
@@ -176,7 +176,7 @@ resourceTypes:
               description: "Validation error"
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             500:
               description: "Internal server error"
               body:
@@ -190,7 +190,7 @@ resourceTypes:
               body:
                 application/json:
                   example: !include examples/item_get.json
-                  schema: item
+                  type: item
             404:
               description: "Item not found"
               body:
@@ -200,7 +200,7 @@ resourceTypes:
               description: "Validation error"
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             500:
               description: "Internal server error"
               body:
@@ -214,7 +214,7 @@ resourceTypes:
               body:
                 application/json:
                   example: !include examples/item_get.json
-                  schema: item
+                  type: item
             404:
               description: "Item not found"
               body:
@@ -224,7 +224,7 @@ resourceTypes:
               description: "Validation error"
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             500:
               description: "Internal server error"
               body:
@@ -238,7 +238,7 @@ resourceTypes:
               body:
                 application/json:
                   example: !include examples/item_get.json
-                  schema: item
+                  type: item
             404:
               description: "Item not found"
               body:
@@ -248,7 +248,7 @@ resourceTypes:
               description: "Validation error"
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             500:
               description: "Internal server error"
               body:
@@ -262,7 +262,7 @@ resourceTypes:
               body:
                 application/json:
                   example: !include examples/item_get.json
-                  schema: item
+                  type: item
             404:
               description: "Item not found"
               body:
@@ -272,7 +272,7 @@ resourceTypes:
               description: "Validation error"
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             500:
               description: "Internal server error"
               body:


### PR DESCRIPTION
The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/

The https://dev.folio.org/reference/api/#mod-inventory section of API documentation will be automatically reconfigured:
https://dev.folio.org/reference/api/#explain-gather-config