### PR TITLE
Modinv 747 simplify move item tests

### DIFF
--- a/src/main/java/org/folio/inventory/support/JsonArrayHelper.java
+++ b/src/main/java/org/folio/inventory/support/JsonArrayHelper.java
@@ -1,16 +1,23 @@
 package org.folio.inventory.support;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import lombok.NonNull;
 
 public class JsonArrayHelper {
+  private JsonArrayHelper() { }
+
+  public static List<JsonObject> toList(@NonNull JsonObject json, String propertyName) {
+    return toList(json.getJsonArray(propertyName));
+  }
+
   public static List<JsonObject> toList(JsonArray array) {
     if (array == null) {
       return Collections.emptyList();
@@ -30,14 +37,18 @@ public class JsonArrayHelper {
       .collect(Collectors.toList());
   }
 
-  public static List<String> toListOfStrings(JsonArray jsonArray) {
-    List<String> list = new ArrayList<>();
-    if (jsonArray != null) {
-      for (int i=0; i<jsonArray.size(); i++){
-        list.add(jsonArray.getString(i));
-      }
+  public static List<String> toListOfStrings(@NonNull JsonObject json, String propertyName) {
+    return toListOfStrings(json.getJsonArray(propertyName));
+  }
+
+  public static List<String> toListOfStrings(JsonArray array) {
+    if (array == null) {
+      return Collections.emptyList();
     }
-    return list;
+
+    return IntStream.range(0, array.size())
+      .mapToObj(array::getString)
+      .collect(Collectors.toList());
   }
 
   public static <T> List<T> toList(JsonArray array, Function<JsonObject, T> mapper) {

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -37,7 +37,6 @@ import junitparams.JUnitParamsRunner;
 
 @RunWith(JUnitParamsRunner.class)
 public class ItemApiMoveExamples extends ApiTests {
-
   private static final String HOLDINGS_RECORD_ID = "holdingsRecordId";
 
   @Test
@@ -264,15 +263,16 @@ public class ItemApiMoveExamples extends ApiTests {
     return instanceId;
   }
 
-  private UUID createHoldingForInstance(UUID instanceId)
-      throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
-    return holdingsStorageClient.create(new HoldingRequestBuilder().forInstance(instanceId))
+  private UUID createHoldingForInstance(UUID instanceId) {
+    return holdingsStorageClient.create(new HoldingRequestBuilder()
+      .forInstance(instanceId))
       .getId();
   }
 
-  private UUID createNonCompatibleHoldingForInstance(UUID instanceId)
-    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
-    AbstractBuilder builder = new InvalidHoldingRequestBuilder().forInstance(instanceId);
+  private UUID createNonCompatibleHoldingForInstance(UUID instanceId) {
+    final var builder = new InvalidHoldingRequestBuilder()
+      .forInstance(instanceId);
+
     return holdingsStorageClient.create(builder).getId();
   }
 

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -34,6 +34,7 @@ import api.support.builders.ItemsMoveRequestBuilder;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
+import lombok.SneakyThrows;
 
 @RunWith(JUnitParamsRunner.class)
 public class ItemApiMoveExamples extends ApiTests {
@@ -250,7 +251,8 @@ public class ItemApiMoveExamples extends ApiTests {
     assertThat(existedHoldingId.toString(), equalTo(updatedItem2.getString(HOLDINGS_RECORD_ID)));
   }
 
-  private Response moveItems(JsonObject itemsMoveRequestBody) throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+  @SneakyThrows
+  private Response moveItems(JsonObject itemsMoveRequestBody) {
     final var postItemsMoveCompleted = okapiClient.post(ApiRoot.moveItems(), itemsMoveRequestBody);
     return postItemsMoveCompleted.toCompletableFuture().get(5, SECONDS);
   }
@@ -262,7 +264,7 @@ public class ItemApiMoveExamples extends ApiTests {
 
     return instanceId;
   }
-
+  
   private UUID createHoldingForInstance(UUID instanceId) {
     return holdingsStorageClient.create(new HoldingRequestBuilder()
       .forInstance(instanceId))

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -42,13 +42,13 @@ public class ItemApiMoveExamples extends ApiTests {
   private static final String HOLDINGS_RECORD_ID = "holdingsRecordId";
 
   @Test
-  public void canMoveItemsToDifferentHoldingsRecord() throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+  public void canMoveItemsToDifferentHoldingsRecord()
+    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
 
-    UUID instanceId = UUID.randomUUID();
-    InstanceApiClient.createInstance(okapiClient, smallAngryPlanet(instanceId));
+    final var instanceId = createInstance();
 
-    final UUID existedHoldingId = createHoldingForInstance(instanceId);
-    final UUID newHoldingId = createHoldingForInstance(instanceId);
+    final var existedHoldingId = createHoldingForInstance(instanceId);
+    final var newHoldingId = createHoldingForInstance(instanceId);
 
     Assert.assertNotEquals(existedHoldingId, newHoldingId);
 
@@ -81,8 +81,7 @@ public class ItemApiMoveExamples extends ApiTests {
   @Test
   public void shouldReportErrorsWhenOnlySomeRequestedItemsCouldNotBeMoved() throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
 
-    UUID instanceId = UUID.randomUUID();
-    InstanceApiClient.createInstance(okapiClient, smallAngryPlanet(instanceId));
+    UUID instanceId = createInstance();
 
     final UUID existedHoldingId = createHoldingForInstance(instanceId);
     final UUID newHoldingId = createHoldingForInstance(instanceId);
@@ -158,8 +157,7 @@ public class ItemApiMoveExamples extends ApiTests {
   public void cannotMoveToNonExistedHoldingsRecord()
     throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
 
-    UUID instanceId = UUID.randomUUID();
-    InstanceApiClient.createInstance(okapiClient, smallAngryPlanet(instanceId));
+    UUID instanceId = createInstance();
 
     final UUID existedHoldingId = createHoldingForInstance(instanceId);
     final UUID newHoldingId = UUID.randomUUID();
@@ -186,8 +184,7 @@ public class ItemApiMoveExamples extends ApiTests {
   public void canMoveToHoldingsRecordWithHoldingSchemasMismatching()
     throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException, IllegalAccessException {
 
-    UUID instanceId = UUID.randomUUID();
-    InstanceApiClient.createInstance(okapiClient, smallAngryPlanet(instanceId));
+    UUID instanceId = createInstance();
 
     final UUID existedHoldingId = createHoldingForInstance(instanceId);
     final UUID newHoldingId = createNonCompatibleHoldingForInstance(instanceId);
@@ -209,8 +206,7 @@ public class ItemApiMoveExamples extends ApiTests {
   @Test
   public void canMoveItemsDueToItemUpdateError() throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
 
-    UUID instanceId = UUID.randomUUID();
-    InstanceApiClient.createInstance(okapiClient, smallAngryPlanet(instanceId));
+    UUID instanceId = createInstance();
 
     final UUID existedHoldingId = createHoldingForInstance(instanceId);
     final UUID newHoldingId = createHoldingForInstance(instanceId);
@@ -253,6 +249,14 @@ public class ItemApiMoveExamples extends ApiTests {
   private Response moveItems(JsonObject itemsMoveRequestBody) throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
     final var postItemsMoveCompleted = okapiClient.post(ApiRoot.moveItems(), itemsMoveRequestBody);
     return postItemsMoveCompleted.toCompletableFuture().get(5, SECONDS);
+  }
+
+  private static UUID createInstance() {
+    final var instanceId = UUID.randomUUID();
+
+    InstanceApiClient.createInstance(okapiClient, smallAngryPlanet(instanceId));
+
+    return instanceId;
   }
 
   private UUID createHoldingForInstance(UUID instanceId)

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -3,11 +3,14 @@ package api.items;
 import static api.ApiTestSuite.ID_FOR_FAILURE;
 import static api.support.InstanceSamples.smallAngryPlanet;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.inventory.support.JsonArrayHelper.toList;
+import static org.folio.inventory.support.JsonArrayHelper.toListOfStrings;
 import static org.folio.inventory.support.http.ContentType.APPLICATION_JSON;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +21,6 @@ import java.util.stream.Stream;
 import org.folio.inventory.domain.items.ItemStatusName;
 import org.folio.inventory.support.http.client.IndividualResource;
 import org.folio.inventory.support.http.client.Response;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -60,16 +62,14 @@ public class ItemApiMoveExamples extends ApiTests {
     final var moveItemsResponse = moveItems(newHoldingId, firstItem, secondItem);
 
     assertThat(moveItemsResponse.getStatusCode(), is(200));
-    assertThat(new JsonObject(moveItemsResponse.getBody()).getJsonArray("nonUpdatedIds").size(), is(0));
+    assertThat(toList(moveItemsResponse.getJson(), "nonUpdatedIds"), hasSize(0));
     assertThat(moveItemsResponse.getContentType(), containsString(APPLICATION_JSON));
 
-    JsonObject updatedItem1 = itemsClient.getById(firstItem.getId())
-      .getJson();
-    JsonObject updatedItem2 = itemsClient.getById(secondItem.getId())
-      .getJson();
+    final var firstUpdatedItem = itemsClient.getById(firstItem.getId()).getJson();
+    final var secondUpdatedItem = itemsClient.getById(secondItem.getId()).getJson();
 
-    Assert.assertEquals(newHoldingId.toString(), updatedItem1.getString(HOLDINGS_RECORD_ID));
-    Assert.assertEquals(newHoldingId.toString(), updatedItem2.getString(HOLDINGS_RECORD_ID));
+    assertThat(firstUpdatedItem.getString(HOLDINGS_RECORD_ID), is(newHoldingId.toString()));
+    assertThat(secondUpdatedItem.getString(HOLDINGS_RECORD_ID), is(newHoldingId.toString()));
   }
 
   @Test
@@ -92,11 +92,10 @@ public class ItemApiMoveExamples extends ApiTests {
     assertThat(moveItemsResponse.getStatusCode(), is(200));
     assertThat(moveItemsResponse.getContentType(), containsString(APPLICATION_JSON));
 
-    final var notFoundIds = moveItemsResponse.getJson()
-      .getJsonArray("nonUpdatedIds")
-      .getList();
+    final var notFoundIds = toListOfStrings(moveItemsResponse.getJson(),
+      "nonUpdatedIds");
 
-    assertThat(notFoundIds.size(), is(1));
+    assertThat(notFoundIds, hasSize(1));
     assertThat(notFoundIds.get(0), equalTo(nonExistedItemId.toString()));
 
     JsonObject updatedItem1 = itemsClient.getById(item.getId())
@@ -190,11 +189,10 @@ public class ItemApiMoveExamples extends ApiTests {
 
     final var moveItemsResponse = moveItems(newHoldingId, firstItem, secondItem);
 
-    final var nonUpdatedIdsIds = moveItemsResponse.getJson()
-      .getJsonArray("nonUpdatedIds")
-      .getList();
+    final var nonUpdatedIdsIds = toListOfStrings(moveItemsResponse.getJson(),
+      "nonUpdatedIds");
 
-    assertThat(nonUpdatedIdsIds.size(), is(1));
+    assertThat(nonUpdatedIdsIds, hasSize(1));
     assertThat(nonUpdatedIdsIds.get(0), equalTo(ID_FOR_FAILURE.toString()));
 
     assertThat(moveItemsResponse.getStatusCode(), is(200));

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -41,9 +41,7 @@ public class ItemApiMoveExamples extends ApiTests {
   private static final String HOLDINGS_RECORD_ID = "holdingsRecordId";
 
   @Test
-  public void canMoveItemsToDifferentHoldingsRecord()
-    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
-
+  public void canMoveItemsToDifferentHoldingsRecord() {
     final var instanceId = createInstance();
 
     final var existedHoldingId = createHoldingForInstance(instanceId);
@@ -80,9 +78,7 @@ public class ItemApiMoveExamples extends ApiTests {
   }
 
   @Test
-  public void shouldReportErrorsWhenOnlySomeRequestedItemsCouldNotBeMoved()
-    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
-
+  public void shouldReportErrorsWhenOnlySomeRequestedItemsCouldNotBeMoved() {
     final var instanceId = createInstance();
 
     final var existedHoldingId = createHoldingForInstance(instanceId);
@@ -156,9 +152,7 @@ public class ItemApiMoveExamples extends ApiTests {
   }
 
   @Test
-  public void cannotMoveToNonExistedHoldingsRecord()
-    throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
-
+  public void cannotMoveToNonExistedHoldingsRecord() {
     final var instanceId = createInstance();
 
     final var existedHoldingId = createHoldingForInstance(instanceId);
@@ -183,9 +177,7 @@ public class ItemApiMoveExamples extends ApiTests {
   }
 
   @Test
-  public void canMoveToHoldingsRecordWithHoldingSchemasMismatching()
-    throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
-
+  public void canMoveToHoldingsRecordWithHoldingSchemasMismatching() {
     final var instanceId = createInstance();
 
     final var existedHoldingId = createHoldingForInstance(instanceId);
@@ -206,9 +198,7 @@ public class ItemApiMoveExamples extends ApiTests {
   }
 
   @Test
-  public void canMoveItemsDueToItemUpdateError()
-    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
-
+  public void canMoveItemsDueToItemUpdateError() {
     final var instanceId = createInstance();
 
     final var existedHoldingId = createHoldingForInstance(instanceId);

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.folio.inventory.domain.items.ItemStatusName;
 import org.folio.inventory.support.http.client.IndividualResource;
@@ -236,11 +238,13 @@ public class ItemApiMoveExamples extends ApiTests {
     assertThat(existedHoldingId.toString(), equalTo(updatedItem2.getString(HOLDINGS_RECORD_ID)));
   }
 
-  private Response moveItems(UUID newHoldingsId, IndividualResource firstItem,
-    IndividualResource secondItem) {
+  private Response moveItems(UUID newHoldingsId, IndividualResource... items) {
+    final var itemIds = Stream.of(items)
+      .map(IndividualResource::getId)
+      .collect(Collectors.toList());
 
     final var body = new ItemsMoveRequestBuilder(newHoldingsId,
-      new JsonArray(Arrays.asList(firstItem.getId(), secondItem.getId()))).create();
+      new JsonArray(itemIds)).create();
 
     return moveItems(body);
   }

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -30,7 +30,6 @@ import api.support.builders.AbstractBuilder;
 import api.support.builders.HoldingRequestBuilder;
 import api.support.builders.ItemRequestBuilder;
 import api.support.builders.ItemsMoveRequestBuilder;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
 import lombok.SneakyThrows;
@@ -223,10 +222,7 @@ public class ItemApiMoveExamples extends ApiTests {
   }
 
   private Response moveItems(UUID newHoldingsId, List<UUID> itemIds) {
-    final var body = new ItemsMoveRequestBuilder(newHoldingsId,
-      new JsonArray(itemIds)).create();
-
-    return moveItems(body);
+    return moveItems(new ItemsMoveRequestBuilder(newHoldingsId, itemIds).create());
   }
 
   @SneakyThrows

--- a/src/test/java/api/support/ApiRoot.java
+++ b/src/test/java/api/support/ApiRoot.java
@@ -1,18 +1,20 @@
 package api.support;
 
-import api.ApiTestSuite;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import api.ApiTestSuite;
+import lombok.SneakyThrows;
+
 public class ApiRoot {
+  private ApiRoot() { }
+
   public static String inventory() {
     return String.format("%s/inventory", ApiTestSuite.apiRoot());
   }
 
-  public static URL instances()
-    throws MalformedURLException {
-
+  @SneakyThrows
+  public static URL instances() {
     return new URL(String.format("%s/instances", inventory()));
   }
 

--- a/src/test/java/api/support/InstanceApiClient.java
+++ b/src/test/java/api/support/InstanceApiClient.java
@@ -4,34 +4,29 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.net.MalformedURLException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
 import org.folio.inventory.support.http.client.OkapiHttpClient;
-import org.folio.inventory.support.http.client.Response;
 
 import io.vertx.core.json.JsonObject;
+import lombok.SneakyThrows;
 
 public class InstanceApiClient {
+  private InstanceApiClient() { }
+
+  @SneakyThrows
   public static JsonObject createInstance(
     OkapiHttpClient client,
-    JsonObject newInstanceRequest)
-    throws MalformedURLException,
-      InterruptedException,
-      ExecutionException,
-      TimeoutException {
+    JsonObject newInstanceRequest) {
 
     final var postCompleted = client.post(ApiRoot.instances(), newInstanceRequest);
 
-    Response postResponse = postCompleted.toCompletableFuture().get(5, SECONDS);
+    final var postResponse = postCompleted.toCompletableFuture().get(5, SECONDS);
 
     assertThat("Failed to create instance",
       postResponse.getStatusCode(), is(201));
 
     final var getCompleted = client.get(postResponse.getLocation());
 
-    Response getResponse = getCompleted.toCompletableFuture().get(5, SECONDS);
+    final var getResponse = getCompleted.toCompletableFuture().get(5, SECONDS);
 
     assertThat("Failed to get instance",
       getResponse.getStatusCode(), is(200));

--- a/src/test/java/api/support/builders/ItemsMoveRequestBuilder.java
+++ b/src/test/java/api/support/builders/ItemsMoveRequestBuilder.java
@@ -1,29 +1,29 @@
 package api.support.builders;
 
 
+import static org.folio.inventory.resources.MoveApi.ITEM_IDS;
+import static org.folio.inventory.resources.MoveApi.TO_HOLDINGS_RECORD_ID;
+
+import java.util.List;
 import java.util.UUID;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-import static org.folio.inventory.resources.MoveApi.ITEM_IDS;
-import static org.folio.inventory.resources.MoveApi.TO_HOLDINGS_RECORD_ID;
-
 public class ItemsMoveRequestBuilder extends AbstractBuilder {
-
   private final UUID toHoldingsRecordId;
-  private final JsonArray itemIds;
+  private final List<UUID> itemIds;
 
-  public ItemsMoveRequestBuilder(UUID toHoldingsRecordId, JsonArray itemIds) {
+  public ItemsMoveRequestBuilder(UUID toHoldingsRecordId, List<UUID> itemIds) {
     this.toHoldingsRecordId = toHoldingsRecordId;
     this.itemIds = itemIds;
   }
 
   public JsonObject create() {
-    JsonObject itemsMoveRequest = new JsonObject();
+    final var itemsMoveRequest = new JsonObject();
 
     includeWhenPresent(itemsMoveRequest, TO_HOLDINGS_RECORD_ID, toHoldingsRecordId);
-    includeWhenPresent(itemsMoveRequest, ITEM_IDS, itemIds);
+    includeWhenPresent(itemsMoveRequest, ITEM_IDS, new JsonArray(itemIds));
 
     return itemsMoveRequest;
   }

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -220,12 +220,8 @@ public class ResourceClient {
     return putCompleted.toCompletableFuture().get(5, SECONDS);
   }
 
-  public Response getById(UUID id)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
+  @SneakyThrows
+  public Response getById(UUID id) {
     final var getCompleted = client.get(urlMaker.combine(String.format("/%s", id)));
 
     return getCompleted.toCompletableFuture().get(5, SECONDS);

--- a/src/test/java/api/support/http/ResourceClient.java
+++ b/src/test/java/api/support/http/ResourceClient.java
@@ -1,14 +1,11 @@
 package api.support.http;
 
-import api.support.builders.Builder;
-import io.vertx.core.json.JsonObject;
-import org.folio.inventory.support.JsonArrayHelper;
-import org.folio.inventory.support.http.client.IndividualResource;
-import org.folio.inventory.support.http.client.OkapiHttpClient;
-import org.folio.inventory.support.http.client.Response;
-import org.folio.util.PercentCodec;
-import org.joda.time.DateTime;
-import support.fakes.EndpointFailureDescriptor;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.util.StringUtil.urlEncode;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -18,12 +15,17 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.folio.util.StringUtil.urlEncode;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import org.folio.inventory.support.JsonArrayHelper;
+import org.folio.inventory.support.http.client.IndividualResource;
+import org.folio.inventory.support.http.client.OkapiHttpClient;
+import org.folio.inventory.support.http.client.Response;
+import org.folio.util.PercentCodec;
+import org.joda.time.DateTime;
+
+import api.support.builders.Builder;
+import io.vertx.core.json.JsonObject;
+import lombok.SneakyThrows;
+import support.fakes.EndpointFailureDescriptor;
 
 public class ResourceClient {
 
@@ -152,21 +154,12 @@ public class ResourceClient {
     this.collectionArrayPropertyName = resourceName;
   }
 
-  public IndividualResource create(Builder builder)
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
-
+  public IndividualResource create(Builder builder) {
     return create(builder.create());
   }
 
-  public IndividualResource create(JsonObject request)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
+  @SneakyThrows
+  public IndividualResource create(JsonObject request) {
     Response response = attemptToCreate(request);
 
     assertThat(


### PR DESCRIPTION
*Context*

I set out to make the changes to remove the now redundant second external collection implementation for holdings records.

As the remaining holdings record external collection implementation relies on deserialisation based upon the holdings record schema, this led to a change in behaviour of the move items API because those previously allowed moving items to an invalid (according to the schema) holdings record.

This meant I needed to change the tests in this area. And thus, I fell down a rabbit hole of making improvements to those tests.

*Approach*
* Reduce duplication of code when creating instances
* Reduce duplication of code when making the move items request
* Use sneaky throws to avoid unnecessary checked exceptions