### PR TITLE
MODINV-748 - Link update: Update instance according to srs.bib event

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -103,6 +103,9 @@ After setup, it is good to check logs in all related modules for errors.
     * "_kafkacache.topic.replication.factor_": 1
     * "_kafkacache.log.retention.ms_": 18000000
     * "_kafkacache.topic_": events_cache
+* These variables are relevant from the **XXXXX** release. Module version from X.X.X:
+    * "_inventory.kafka.MarcBibUpdateConsumerVerticle.instancesNumber_": 1
+    * "_inventory.kafka.MarcBibUpdateConsumer.loadLimit_": 5
 
 # Making Requests
 

--- a/README.MD
+++ b/README.MD
@@ -104,7 +104,7 @@ After setup, it is good to check logs in all related modules for errors.
     * "_kafkacache.log.retention.ms_": 18000000
     * "_kafkacache.topic_": events_cache
 * These variables are relevant from the **XXXXX** release. Module version from X.X.X:
-    * "_inventory.kafka.MarcBibUpdateConsumerVerticle.instancesNumber_": 1
+    * "_inventory.kafka.MarcBibUpdateConsumerVerticle.instancesNumber_": 3
     * "_inventory.kafka.MarcBibUpdateConsumer.loadLimit_": 5
 
 # Making Requests

--- a/src/main/java/org/folio/inventory/Launcher.java
+++ b/src/main/java/org/folio/inventory/Launcher.java
@@ -23,12 +23,14 @@ public class Launcher {
   private static final String DATA_IMPORT_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG = "inventory.kafka.DataImportConsumerVerticle.instancesNumber";
   private static final String MARC_BIB_INSTANCE_HRID_SET_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG = "inventory.kafka.MarcBibInstanceHridSetConsumerVerticle.instancesNumber";
   private static final String QUICK_MARC_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG = "inventory.kafka.QuickMarcConsumerVerticle.instancesNumber";
+  private static final String MARC_BIB_UPDATE_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG = "inventory.kafka.MarcBibUpdateConsumerVerticle.instancesNumber";
   private static final VertxAssistant vertxAssistant = new VertxAssistant();
 
   private static String inventoryModuleDeploymentId;
   private static String consumerVerticleDeploymentId;
   private static String marcInstHridSetConsumerVerticleDeploymentId;
   private static String quickMarcConsumerVerticleDeploymentId;
+  private static String marcBibUpdateConsumerVerticleDeploymentId;
 
   public static void main(String[] args)
     throws InterruptedException, ExecutionException, TimeoutException {
@@ -87,20 +89,25 @@ public class Launcher {
     int dataImportConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(DATA_IMPORT_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "3"));
     int instanceHridSetConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(MARC_BIB_INSTANCE_HRID_SET_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "3"));
     int quickMarcConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(QUICK_MARC_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "1"));
+    int marcBibUpdateConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(MARC_BIB_UPDATE_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "1"));
 
     CompletableFuture<String> future1 = new CompletableFuture<>();
     CompletableFuture<String> future2 = new CompletableFuture<>();
     CompletableFuture<String> future3 = new CompletableFuture<>();
+    CompletableFuture<String> future4 = new CompletableFuture<>();
     vertxAssistant.deployVerticle(DataImportConsumerVerticle.class.getName(),
       consumerVerticlesConfig, dataImportConsumerVerticleNumber, future1);
     vertxAssistant.deployVerticle(MarcHridSetConsumerVerticle.class.getName(),
       consumerVerticlesConfig, instanceHridSetConsumerVerticleNumber, future2);
     vertxAssistant.deployVerticle(QuickMarcConsumerVerticle.class.getName(),
       consumerVerticlesConfig, quickMarcConsumerVerticleNumber, future3);
+    vertxAssistant.deployVerticle(MarcBibUpdateConsumerVerticle.class.getName(),
+      consumerVerticlesConfig, marcBibUpdateConsumerVerticleNumber, future4);
 
     consumerVerticleDeploymentId = future1.get(20, TimeUnit.SECONDS);
     marcInstHridSetConsumerVerticleDeploymentId = future2.get(20, TimeUnit.SECONDS);
     quickMarcConsumerVerticleDeploymentId = future3.get(20, TimeUnit.SECONDS);
+    marcBibUpdateConsumerVerticleDeploymentId = future4.get(20, TimeUnit.SECONDS);
   }
 
   private static void stop() {
@@ -114,6 +121,7 @@ public class Launcher {
       .thenCompose(v -> vertxAssistant.undeployVerticle(consumerVerticleDeploymentId))
       .thenCompose(v -> vertxAssistant.undeployVerticle(marcInstHridSetConsumerVerticleDeploymentId))
       .thenCompose(v -> vertxAssistant.undeployVerticle(quickMarcConsumerVerticleDeploymentId))
+      .thenCompose(v -> vertxAssistant.undeployVerticle(marcBibUpdateConsumerVerticleDeploymentId))
       .thenAccept(v -> vertxAssistant.stop(stopped));
 
     stopped.thenAccept(v -> log.info("Server Stopped"));

--- a/src/main/java/org/folio/inventory/Launcher.java
+++ b/src/main/java/org/folio/inventory/Launcher.java
@@ -89,7 +89,7 @@ public class Launcher {
     int dataImportConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(DATA_IMPORT_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "3"));
     int instanceHridSetConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(MARC_BIB_INSTANCE_HRID_SET_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "3"));
     int quickMarcConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(QUICK_MARC_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "1"));
-    int marcBibUpdateConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(MARC_BIB_UPDATE_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "1"));
+    int marcBibUpdateConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(MARC_BIB_UPDATE_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "3"));
 
     CompletableFuture<String> future1 = new CompletableFuture<>();
     CompletableFuture<String> future2 = new CompletableFuture<>();

--- a/src/main/java/org/folio/inventory/MarcBibUpdateConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/MarcBibUpdateConsumerVerticle.java
@@ -1,0 +1,96 @@
+package org.folio.inventory;
+
+import static org.folio.inventory.dataimport.util.ConsumerWrapperUtil.constructModuleName;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_ENV;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_HOST;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_MAX_REQUEST_SIZE;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_PORT;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_REPLICATION_FACTOR;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.OKAPI_URL;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.dataimport.consumers.MarcBibUpdateKafkaHandler;
+import org.folio.inventory.dataimport.handlers.actions.InstanceUpdateDelegate;
+import org.folio.inventory.storage.Storage;
+import org.folio.kafka.GlobalLoadSensor;
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.KafkaConsumerWrapper;
+import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.kafka.SubscriptionDefinition;
+
+public class MarcBibUpdateConsumerVerticle extends AbstractVerticle {
+  private static final Logger LOGGER = LogManager.getLogger(MarcBibUpdateConsumerVerticle.class);
+  private static final GlobalLoadSensor GLOBAL_LOAD_SENSOR = new GlobalLoadSensor();
+  private static final String SRS_MARC_BIB_TOPIC_NAME = "srs.marc-bib";
+  private final int loadLimit = getLoadLimit();
+  private KafkaConsumerWrapper<String, String> marcBibUpdateConsumerWrapper;
+
+  @Override
+  public void start(Promise<Void> startPromise) {
+    JsonObject config = vertx.getOrCreateContext().config();
+    KafkaConfig kafkaConfig = getKafkaConfig(config);
+    marcBibUpdateConsumerWrapper = createConsumer(kafkaConfig, SRS_MARC_BIB_TOPIC_NAME);
+    HttpClient client = vertx.createHttpClient();
+    Storage storage = Storage.basedUpon(config, client);
+    InstanceUpdateDelegate instanceUpdateDelegate = new InstanceUpdateDelegate(storage);
+    String mappingMetadataExpirationTime = getCacheEnvVariable(config,"inventory.mapping-metadata-cache.expiration.time.seconds");
+    MappingMetadataCache mappingMetadataCache = new MappingMetadataCache(vertx, client, Long.parseLong(mappingMetadataExpirationTime));
+
+    MarcBibUpdateKafkaHandler marcBibUpdateKafkaHandler = new MarcBibUpdateKafkaHandler(instanceUpdateDelegate, mappingMetadataCache);
+
+    marcBibUpdateConsumerWrapper.start(marcBibUpdateKafkaHandler, constructModuleName())
+      .onFailure(startPromise::fail)
+      .onSuccess(ar -> startPromise.complete());
+  }
+
+  private KafkaConsumerWrapper<String, String> createConsumer(KafkaConfig kafkaConfig, String srsMarcBibTopicName) {
+    SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper.createSubscriptionDefinition(
+        kafkaConfig.getEnvId(), KafkaTopicNameHelper.getDefaultNameSpace(), srsMarcBibTopicName);
+
+    return KafkaConsumerWrapper.<String, String>builder()
+      .context(context)
+      .vertx(vertx)
+      .kafkaConfig(kafkaConfig)
+      .loadLimit(loadLimit)
+      .globalLoadSensor(GLOBAL_LOAD_SENSOR)
+      .subscriptionDefinition(subscriptionDefinition)
+      .build();
+  }
+
+  @Override
+  public void stop(Promise<Void> stopPromise) {
+    marcBibUpdateConsumerWrapper.stop()
+      .onComplete(ar -> stopPromise.complete());
+  }
+
+  private int getLoadLimit() {
+    return Integer.parseInt(System.getProperty("inventory.kafka.MarcBibUpdateConsumer.loadLimit","5"));
+  }
+
+  private KafkaConfig getKafkaConfig(JsonObject config) {
+    KafkaConfig kafkaConfig = KafkaConfig.builder()
+      .envId(config.getString(KAFKA_ENV))
+      .kafkaHost(config.getString(KAFKA_HOST))
+      .kafkaPort(config.getString(KAFKA_PORT))
+      .okapiUrl(config.getString(OKAPI_URL))
+      .replicationFactor(Integer.parseInt(config.getString(KAFKA_REPLICATION_FACTOR)))
+      .maxRequestSize(Integer.parseInt(config.getString(KAFKA_MAX_REQUEST_SIZE)))
+      .build();
+    LOGGER.info("kafkaConfig: {}", kafkaConfig);
+    return kafkaConfig;
+  }
+
+  private String getCacheEnvVariable(JsonObject config, String variableName) {
+    String cacheExpirationTime = config.getString(variableName);
+    if (StringUtils.isBlank(cacheExpirationTime)) {
+      cacheExpirationTime = "3600";
+    }
+    return cacheExpirationTime;
+  }
+}

--- a/src/main/java/org/folio/inventory/MarcBibUpdateConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/MarcBibUpdateConsumerVerticle.java
@@ -49,9 +49,11 @@ public class MarcBibUpdateConsumerVerticle extends AbstractVerticle {
       .onSuccess(ar -> startPromise.complete());
   }
 
-  private KafkaConsumerWrapper<String, String> createConsumer(KafkaConfig kafkaConfig, String srsMarcBibTopicName) {
-    SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper.createSubscriptionDefinition(
-        kafkaConfig.getEnvId(), KafkaTopicNameHelper.getDefaultNameSpace(), srsMarcBibTopicName);
+  private KafkaConsumerWrapper<String, String> createConsumer(KafkaConfig kafkaConfig, String topicEventType) {
+    SubscriptionDefinition subscriptionDefinition = SubscriptionDefinition.builder()
+      .eventType(topicEventType)
+      .subscriptionPattern(formatSubscriptionPattern(kafkaConfig.getEnvId(), topicEventType))
+      .build();
 
     return KafkaConsumerWrapper.<String, String>builder()
       .context(context)
@@ -92,5 +94,9 @@ public class MarcBibUpdateConsumerVerticle extends AbstractVerticle {
       cacheExpirationTime = "3600";
     }
     return cacheExpirationTime;
+  }
+
+  public static String formatSubscriptionPattern(String env, String eventType) {
+    return String.join("\\.", env, "\\w{1,}", eventType);
   }
 }

--- a/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
@@ -1,0 +1,90 @@
+package org.folio.inventory.dataimport.consumers;
+
+import static java.lang.String.format;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.MappingMetadataDto;
+import org.folio.dbschema.ObjectMapperTool;
+import org.folio.inventory.common.Context;
+import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.dataimport.handlers.actions.InstanceUpdateDelegate;
+import org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil;
+import org.folio.kafka.AsyncRecordHandler;
+import org.folio.kafka.KafkaHeaderUtils;
+import org.folio.processing.exceptions.EventProcessingException;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.Record;
+
+public class MarcBibUpdateKafkaHandler implements AsyncRecordHandler<String, String> {
+
+  private static final Logger LOGGER = LogManager.getLogger(MarcBibUpdateKafkaHandler.class);
+  private static final String MAPPING_METADATA_NOT_FOUND_MSG = "MappingParameters and mapping rules snapshots were not found by jobExecutionId '%s'";
+  private static final String RECORD_KEY = "record";
+  private static final String MAPPING_RULES_KEY = "MAPPING_RULES";
+  private static final String MAPPING_PARAMS_KEY = "MAPPING_PARAMS";
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperTool.getMapper();
+  private static final String RECORD_ID_HEADER = "recordId";
+  private static final String CHUNK_ID_HEADER = "chunkId";
+  private static final String JOB_ID = "jobId";
+  private static final String MARC_BIB_RECORD_TYPE = "marc-bib";
+
+  private final InstanceUpdateDelegate instanceUpdateDelegate;
+  private final MappingMetadataCache mappingMetadataCache;
+
+  public MarcBibUpdateKafkaHandler(InstanceUpdateDelegate instanceUpdateDelegate, MappingMetadataCache mappingMetadataCache) {
+    this.instanceUpdateDelegate = instanceUpdateDelegate;
+    this.mappingMetadataCache = mappingMetadataCache;
+  }
+
+  @Override
+  public Future<String> handle(KafkaConsumerRecord<String, String> record) {
+    try {
+      Promise<String> promise = Promise.promise();
+      Event event = OBJECT_MAPPER.readValue(record.value(), Event.class);
+      @SuppressWarnings("unchecked")
+      HashMap<String, String> eventPayload = OBJECT_MAPPER.readValue(event.getEventPayload(), HashMap.class);
+      Map<String, String> headersMap = KafkaHeaderUtils.kafkaHeadersToMap(record.headers());
+      String recordId = headersMap.get(RECORD_ID_HEADER);
+      String chunkId = headersMap.get(CHUNK_ID_HEADER);
+      String jobExecutionId = eventPayload.get(JOB_ID);
+      LOGGER.info("Event payload has been received with event type: {}, recordId: {} by jobExecution: {} and chunkId: {}", event.getEventType(), recordId, jobExecutionId, chunkId);
+
+      Context context = EventHandlingUtil.constructContext(headersMap.get(OKAPI_TENANT_HEADER), headersMap.get(OKAPI_TOKEN_HEADER), headersMap.get(OKAPI_URL_HEADER));
+      Record marcBibRecord = new JsonObject(eventPayload.get(RECORD_KEY)).mapTo(Record.class);
+
+      mappingMetadataCache.getByRecordType(jobExecutionId, context, MARC_BIB_RECORD_TYPE)
+        .map(metadataOptional -> metadataOptional.orElseThrow(() ->
+          new EventProcessingException(format(MAPPING_METADATA_NOT_FOUND_MSG, jobExecutionId))))
+        .onSuccess(mappingMetadataDto -> ensureEventPayloadWithMappingMetadata(eventPayload, mappingMetadataDto))
+        .compose(v -> instanceUpdateDelegate.handle(eventPayload, marcBibRecord, context))
+        .onComplete(ar -> {
+          if (ar.succeeded()) {
+            promise.complete(record.key());
+          } else {
+            LOGGER.error("Failed to update marc-bib by jobExecutionId {}:{}", jobExecutionId, ar.cause());
+            promise.fail(ar.cause());
+          }
+        });
+      return promise.future();
+    } catch (Exception e) {
+      LOGGER.error(format("Failed to process data import kafka record from topic %s", record.topic()), e);
+      return Future.failedFuture(e);
+    }
+  }
+  private void ensureEventPayloadWithMappingMetadata(HashMap<String, String> eventPayload, MappingMetadataDto mappingMetadataDto) {
+    eventPayload.put(MAPPING_RULES_KEY, mappingMetadataDto.getMappingRules());
+    eventPayload.put(MAPPING_PARAMS_KEY, mappingMetadataDto.getMappingParams());
+  }
+
+}

--- a/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
@@ -1,7 +1,7 @@
 package org.folio.inventory.dataimport.consumers;
 
 import static java.lang.String.format;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
 
@@ -23,20 +23,19 @@ import org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.processing.exceptions.EventProcessingException;
-import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.Record;
 
 public class MarcBibUpdateKafkaHandler implements AsyncRecordHandler<String, String> {
 
   private static final Logger LOGGER = LogManager.getLogger(MarcBibUpdateKafkaHandler.class);
-  private static final String MAPPING_METADATA_NOT_FOUND_MSG = "MappingParameters and mapping rules snapshots were not found by jobExecutionId '%s'";
+  private static final String MAPPING_METADATA_NOT_FOUND_MSG = "MappingParameters and mapping rules snapshots were not found by jobId '%s'";
   private static final String RECORD_KEY = "record";
   private static final String MAPPING_RULES_KEY = "MAPPING_RULES";
   private static final String MAPPING_PARAMS_KEY = "MAPPING_PARAMS";
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperTool.getMapper();
-  private static final String RECORD_ID_HEADER = "recordId";
-  private static final String CHUNK_ID_HEADER = "chunkId";
   private static final String JOB_ID = "jobId";
+  private static final String TYPE_KEY = "type";
+  private static final String TENANT_KEY = "tenant";
   private static final String MARC_BIB_RECORD_TYPE = "marc-bib";
 
   private final InstanceUpdateDelegate instanceUpdateDelegate;
@@ -51,28 +50,31 @@ public class MarcBibUpdateKafkaHandler implements AsyncRecordHandler<String, Str
   public Future<String> handle(KafkaConsumerRecord<String, String> record) {
     try {
       Promise<String> promise = Promise.promise();
-      Event event = OBJECT_MAPPER.readValue(record.value(), Event.class);
       @SuppressWarnings("unchecked")
-      HashMap<String, String> eventPayload = OBJECT_MAPPER.readValue(event.getEventPayload(), HashMap.class);
+      HashMap<String, String> payloadMap = OBJECT_MAPPER.readValue(record.value(), HashMap.class);
       Map<String, String> headersMap = KafkaHeaderUtils.kafkaHeadersToMap(record.headers());
-      String recordId = headersMap.get(RECORD_ID_HEADER);
-      String chunkId = headersMap.get(CHUNK_ID_HEADER);
-      String jobExecutionId = eventPayload.get(JOB_ID);
-      LOGGER.info("Event payload has been received with event type: {}, recordId: {} by jobExecution: {} and chunkId: {}", event.getEventType(), recordId, jobExecutionId, chunkId);
+      String jobId = payloadMap.get(JOB_ID);
+      String type = payloadMap.get(TYPE_KEY);
+      LOGGER.info("Event payload has been received with event type: {} by jobId: {}", type, jobId);
 
-      Context context = EventHandlingUtil.constructContext(headersMap.get(OKAPI_TENANT_HEADER), headersMap.get(OKAPI_TOKEN_HEADER), headersMap.get(OKAPI_URL_HEADER));
-      Record marcBibRecord = new JsonObject(eventPayload.get(RECORD_KEY)).mapTo(Record.class);
+      if (isEmpty(payloadMap.get(RECORD_KEY))) {
+        String message = String.format("Event message does not contain required data to update Instance by jobId: '%s'", jobId);
+        LOGGER.error(message);
+        return Future.failedFuture(message);
+      }
+      Context context = EventHandlingUtil.constructContext(payloadMap.get(TENANT_KEY), headersMap.get(OKAPI_TOKEN_HEADER), headersMap.get(OKAPI_URL_HEADER));
+      Record marcBibRecord = new JsonObject(payloadMap.get(RECORD_KEY)).mapTo(Record.class);
 
-      mappingMetadataCache.getByRecordType(jobExecutionId, context, MARC_BIB_RECORD_TYPE)
+      mappingMetadataCache.getByRecordType(jobId, context, MARC_BIB_RECORD_TYPE)
         .map(metadataOptional -> metadataOptional.orElseThrow(() ->
-          new EventProcessingException(format(MAPPING_METADATA_NOT_FOUND_MSG, jobExecutionId))))
-        .onSuccess(mappingMetadataDto -> ensureEventPayloadWithMappingMetadata(eventPayload, mappingMetadataDto))
-        .compose(v -> instanceUpdateDelegate.handle(eventPayload, marcBibRecord, context))
+          new EventProcessingException(format(MAPPING_METADATA_NOT_FOUND_MSG, jobId))))
+        .onSuccess(mappingMetadataDto -> ensureEventPayloadWithMappingMetadata(payloadMap, mappingMetadataDto))
+        .compose(v -> instanceUpdateDelegate.handle(payloadMap, marcBibRecord, context))
         .onComplete(ar -> {
           if (ar.succeeded()) {
             promise.complete(record.key());
           } else {
-            LOGGER.error("Failed to update marc-bib by jobExecutionId {}:{}", jobExecutionId, ar.cause());
+            LOGGER.error("Failed to update instance by jobId {}:{}", jobId, ar.cause());
             promise.fail(ar.cause());
           }
         });

--- a/src/main/java/org/folio/inventory/domain/dto/InstanceEvent.java
+++ b/src/main/java/org/folio/inventory/domain/dto/InstanceEvent.java
@@ -1,0 +1,128 @@
+package org.folio.inventory.domain.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.HashMap;
+import java.util.Map;
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"jobId", "record", "type", "tenant", "ts"})
+public class InstanceEvent {
+  @JsonProperty("jobId")
+  private String jobId;
+  @JsonProperty("record")
+  private String record;
+  @JsonProperty("type")
+  private InstanceEvent.EventType type;
+  @JsonProperty("tenant")
+  private String tenant;
+  @JsonProperty("ts")
+  private String ts;
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  public void setJobId(String jobId) {
+    this.jobId = jobId;
+  }
+
+  public InstanceEvent withJobId(String jobId) {
+    this.jobId = jobId;
+    return this;
+  }
+
+  public String getRecord() {
+    return record;
+  }
+
+  public void setRecord(String record) {
+    this.record = record;
+  }
+
+  public InstanceEvent withRecord(String record) {
+    this.record = record;
+    return this;
+  }
+
+  public EventType getType() {
+    return type;
+  }
+
+  public void setType(EventType type) {
+    this.type = type;
+  }
+
+  public InstanceEvent withType(EventType type) {
+    this.type = type;
+    return this;
+  }
+
+  public String getTenant() {
+    return tenant;
+  }
+
+  public void setTenant(String tenant) {
+    this.tenant = tenant;
+  }
+
+  public InstanceEvent withTenant(String tenant) {
+    this.tenant = tenant;
+    return this;
+  }
+
+  public String getTs() {
+    return ts;
+  }
+
+  public void setTs(String ts) {
+    this.ts = ts;
+  }
+
+  public InstanceEvent withTs(String ts) {
+    this.ts = ts;
+    return this;
+  }
+
+  public static enum EventType {
+    UPDATE("UPDATE"),
+    DELETE("DELETE");
+    private final String value;
+    private static final Map<String, InstanceEvent.EventType> CONSTANTS = new HashMap();
+
+    private EventType(String value) {
+      this.value = value;
+    }
+
+    public String toString() {
+      return this.value;
+    }
+
+    @JsonValue
+    public String value() {
+      return this.value;
+    }
+
+    @JsonCreator
+    public static InstanceEvent.EventType fromValue(String value) {
+      InstanceEvent.EventType constant = CONSTANTS.get(value);
+      if (constant == null) {
+        throw new IllegalArgumentException(value);
+      } else {
+        return constant;
+      }
+    }
+
+    static {
+      InstanceEvent.EventType[] var0 = values();
+      int var1 = var0.length;
+
+      for(int var2 = 0; var2 < var1; ++var2) {
+        InstanceEvent.EventType c = var0[var2];
+        CONSTANTS.put(c.value, c);
+      }
+    }
+  }
+}

--- a/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateConsumerVerticleTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateConsumerVerticleTest.java
@@ -1,0 +1,64 @@
+package org.folio.inventory.dataimport.consumers;
+
+import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
+import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.defaultClusterConfig;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_ENV;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_HOST;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_MAX_REQUEST_SIZE;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_PORT;
+import static org.folio.inventory.dataimport.util.KafkaConfigConstants.KAFKA_REPLICATION_FACTOR;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import net.mguenther.kafka.junit.EmbeddedKafkaCluster;
+import org.folio.inventory.MarcBibUpdateConsumerVerticle;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MarcBibUpdateConsumerVerticleTest {
+  private static final String KAFKA_ENV_NAME = "test-env";
+  private static Vertx vertx = Vertx.vertx();
+  public static EmbeddedKafkaCluster cluster;
+
+  @Test
+  public void shouldDeployVerticle(TestContext context) {
+    Async async = context.async();
+    cluster = provisionWith(defaultClusterConfig());
+    cluster.start();
+    String[] hostAndPort = cluster.getBrokerList().split(":");
+    DeploymentOptions options = new DeploymentOptions()
+      .setConfig(new JsonObject()
+        .put(KAFKA_HOST, hostAndPort[0])
+        .put(KAFKA_PORT, hostAndPort[1])
+        .put(KAFKA_REPLICATION_FACTOR, "1")
+        .put(KAFKA_ENV, KAFKA_ENV_NAME)
+        .put(KAFKA_MAX_REQUEST_SIZE, "1048576"))
+      .setWorker(true);
+
+    Promise<String> promise = Promise.promise();
+    vertx.deployVerticle(MarcBibUpdateConsumerVerticle.class.getName(), options, promise);
+
+    promise.future().onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      async.complete();
+    });
+
+  }
+
+  @AfterClass
+  public static void tearDownClass(TestContext context) {
+    Async async = context.async();
+    vertx.close(ar -> {
+      cluster.stop();
+      async.complete();
+    });
+  }
+
+}

--- a/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandlerTest.java
@@ -1,0 +1,182 @@
+package org.folio.inventory.dataimport.consumers;
+
+import static org.folio.inventory.dataimport.consumers.MarcHoldingsRecordHridSetKafkaHandler.JOB_EXECUTION_ID_KEY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.folio.MappingMetadataDto;
+import org.folio.inventory.TestUtil;
+import org.folio.inventory.common.Context;
+import org.folio.inventory.common.domain.Failure;
+import org.folio.inventory.common.domain.Success;
+import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.dataimport.handlers.actions.InstanceUpdateDelegate;
+import org.folio.inventory.domain.instances.Instance;
+import org.folio.inventory.domain.instances.InstanceCollection;
+import org.folio.inventory.storage.Storage;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.Record;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(VertxUnitRunner.class)
+public class MarcBibUpdateKafkaHandlerTest {
+
+  private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/bib-rules.json";
+  private static final String RECORD_PATH = "src/test/resources/handlers/bib-record.json";
+  private static final String INSTANCE_PATH = "src/test/resources/handlers/instance.json";
+  private static final String RECORD_KEY = "record";
+  private static final String JOB_ID = "jobId";
+
+  @Mock
+  private Storage mockedStorage;
+  @Mock
+  private InstanceCollection mockedInstanceCollection;
+  @Mock
+  private KafkaConsumerRecord<String, String> kafkaRecord;
+  @Mock
+  private MappingMetadataCache mappingMetadataCache;
+
+  private JsonObject mappingRules;
+  private Record record;
+  private Instance existingInstance;
+  private MarcBibUpdateKafkaHandler marcBibUpdateKafkaHandler;
+  private AutoCloseable mocks;
+
+  @Before
+  public void setUp() throws IOException {
+    mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
+    existingInstance = Instance.fromJson(new JsonObject(TestUtil.readFileFromPath(INSTANCE_PATH)));
+    record = Json.decodeValue(TestUtil.readFileFromPath(RECORD_PATH), Record.class);
+    record.getParsedRecord().withContent(JsonObject.mapFrom(record.getParsedRecord().getContent()).encode());
+
+    mocks = MockitoAnnotations.openMocks(this);
+    when(mockedStorage.getInstanceCollection(any(Context.class))).thenReturn(mockedInstanceCollection);
+
+    doAnswer(invocationOnMock -> {
+      Consumer<Success<Instance>> successHandler = invocationOnMock.getArgument(1);
+      successHandler.accept(new Success<>(existingInstance));
+      return null;
+    }).when(mockedInstanceCollection).findById(anyString(), any(), any());
+
+    doAnswer(invocationOnMock -> {
+      Instance instance = invocationOnMock.getArgument(0);
+      Consumer<Success<Instance>> successHandler = invocationOnMock.getArgument(1);
+      successHandler.accept(new Success<>(instance));
+      return null;
+    }).when(mockedInstanceCollection).update(any(Instance.class), any(), any());
+
+    Mockito.when(mappingMetadataCache.getByRecordType(anyString(), any(Context.class), anyString()))
+      .thenReturn(Future.succeededFuture(Optional.of(new MappingMetadataDto()
+        .withMappingRules(mappingRules.encode())
+        .withMappingParams(Json.encode(new MappingParameters())))));
+
+    marcBibUpdateKafkaHandler = new MarcBibUpdateKafkaHandler(new InstanceUpdateDelegate(mockedStorage), mappingMetadataCache);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  public void shouldReturnSucceededFutureWithObtainedRecordKey(TestContext context) throws IOException {
+    // given
+    Async async = context.async();
+    Map<String, String> payload = new HashMap<>();
+    payload.put(RECORD_KEY, Json.encode(record));
+    payload.put(JOB_ID, UUID.randomUUID().toString());
+
+    Event event = new Event().withId("test_id").withEventPayload(Json.encode(payload));
+    String expectedKafkaRecordKey = "test_key";
+    when(kafkaRecord.key()).thenReturn(expectedKafkaRecordKey);
+    when(kafkaRecord.value()).thenReturn(Json.encode(event));
+
+    // when
+    Future<String> future = marcBibUpdateKafkaHandler.handle(kafkaRecord);
+
+    // then
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertEquals(expectedKafkaRecordKey, ar.result());
+      async.complete();
+    });
+
+    verify(mockedInstanceCollection, times(1)).findById(anyString(), any(), any());
+    verify(mockedInstanceCollection, times(1)).update(any(Instance.class), any(), any());
+    verify(mappingMetadataCache, times(1)).getByRecordType(anyString(), any(Context.class), anyString());
+  }
+
+  @Test
+  public void shouldReturnFailedFutureWhenMappingRulesNotFound(TestContext context) throws IOException {
+    // given
+    Async async = context.async();
+    Mockito.when(mappingMetadataCache.getByRecordType(anyString(), any(Context.class), anyString()))
+      .thenReturn(Future.succeededFuture(Optional.empty()));
+    Map<String, String> payload = new HashMap<>();
+    payload.put(RECORD_KEY, Json.encode(record));
+    payload.put(JOB_ID, UUID.randomUUID().toString());
+
+    Event event = new Event().withId("test_id").withEventPayload(Json.encode(payload));
+    when(kafkaRecord.value()).thenReturn(Json.encode(event));
+
+    // when
+    Future<String> future = marcBibUpdateKafkaHandler.handle(kafkaRecord);
+
+    // then
+    future.onComplete(ar -> {
+      context.assertTrue(ar.failed());
+      context.assertTrue(ar.cause().getMessage().contains("MappingParameters and mapping rules snapshots were not found by jobExecutionId"));
+      async.complete();
+    });
+
+    verify(mockedInstanceCollection, times(0)).findById(anyString(), any(), any());
+    verify(mockedInstanceCollection, times(0)).update(any(Instance.class), any(), any());
+    verify(mappingMetadataCache, times(1)).getByRecordType(anyString(), any(Context.class), anyString());
+  }
+
+  @Test
+  public void shouldReturnFailedFutureWhenPayloadCanNotBeMapped(TestContext context) {
+    // given
+    Async async = context.async();
+    Event event = new Event().withId("test_id").withEventPayload(null);
+    when(kafkaRecord.value()).thenReturn(Json.encode(event));
+
+    // when
+    Future<String> future = marcBibUpdateKafkaHandler.handle(kafkaRecord);
+
+    // then
+    future.onComplete(ar -> {
+      context.assertTrue(ar.failed());
+      async.complete();
+    });
+
+    verify(mockedInstanceCollection, times(0)).findById(anyString(), any(), any());
+    verify(mockedInstanceCollection, times(0)).update(any(Instance.class), any(), any());
+    verify(mappingMetadataCache, times(0)).getByRecordType(anyString(), any(Context.class), anyString());
+  }
+
+}


### PR DESCRIPTION
## Purpose
Link update: Update instance according to srs.bib event

## Approach

1. Introduce a new verticle that will init consumer for `srs.marc-bib` topic
2. Register verticle in `Launcher`
3. Introduce a handler for a consumer. It should:

- Retrieve mapping rules and mapping parameters for marc-bib (GET /mapping-metadata/type/marc-bib)
- Use local cache to store mapping metadata (MappingMetadataCache), use jobId from message
- Use InstanceUpdateDelegate to update instance record in mod-inventory-storage

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed

## Learnings
https://issues.folio.org/browse/MODINV-748