### PR TITLE
MODINV-760 - MARC-to-MARC Holdings update stacked

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -167,8 +167,8 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     EventManager.registerEventHandler(new CreateItemEventHandler(storage, mappingMetadataCache, new ItemIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx)))));
     EventManager.registerEventHandler(new CreateHoldingEventHandler(storage, mappingMetadataCache, new HoldingsIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx)))));
     EventManager.registerEventHandler(new CreateInstanceEventHandler(storage, precedingSucceedingTitlesHelper, mappingMetadataCache, new InstanceIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx)))));
-    EventManager.registerEventHandler(new CreateMarcHoldingsEventHandler(storage, mappingMetadataCache, new HoldingsIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx))),new HoldingsCollectionService()));
-    EventManager.registerEventHandler(new UpdateMarcHoldingsEventHandler(storage, mappingMetadataCache, new HoldingsCollectionService(), new KafkaEventPublisher(kafkaConfig, vertx, 100)));
+    EventManager.registerEventHandler(new CreateMarcHoldingsEventHandler(storage, mappingMetadataCache, new HoldingsIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx))), new HoldingsCollectionService()));
+    EventManager.registerEventHandler(new UpdateMarcHoldingsEventHandler(storage, mappingMetadataCache, new KafkaEventPublisher(kafkaConfig, vertx, 100)));
     EventManager.registerEventHandler(new CreateAuthorityEventHandler(storage, mappingMetadataCache, new AuthorityIdStorageService(new EntityIdStorageDaoImpl(new PostgresClientFactory(vertx)))));
     EventManager.registerEventHandler(new UpdateAuthorityEventHandler(storage, mappingMetadataCache, new KafkaEventPublisher(kafkaConfig, vertx, 100)));
     EventManager.registerEventHandler(new DeleteAuthorityEventHandler(storage));

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateMarcHoldingsEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateMarcHoldingsEventHandler.java
@@ -201,8 +201,7 @@ public class UpdateMarcHoldingsEventHandler implements EventHandler {
 
   private Future<Holdings> fillInstanceIdByHrid(DataImportEventPayload dataImportEventPayload, Holdings holdings, Context context) {
     Promise<Holdings> promise = Promise.promise();
-    String instanceId = holdings.getInstanceId();
-    if (StringUtils.isBlank(instanceId)) {
+    if (StringUtils.isBlank(holdings.getInstanceId())) {
       var rec = Json.decodeValue(getMarcHoldingRecordAsString(dataImportEventPayload), Record.class);
       var instanceHrid = getControlFieldValue(rec, INSTANCE_HRID_TAG);
       if (isBlank(instanceHrid)) {
@@ -228,7 +227,7 @@ public class UpdateMarcHoldingsEventHandler implements EventHandler {
             var instanceIdFromDb = findResult.getResult().records.get(0).getId();
             holdings.setInstanceId(instanceIdFromDb);
             promise.complete(holdings);
-          }else{
+          } else {
             promise.fail(new EventProcessingException("No instance id found for marc holdings with hrid: " + instanceHrid));
           }
         },

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateMarcHoldingsEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateMarcHoldingsEventHandler.java
@@ -262,17 +262,12 @@ public class UpdateMarcHoldingsEventHandler implements EventHandler {
                                                  CompletableFuture<DataImportEventPayload> future) {
     return holdings -> {
       LOGGER.info(() -> constructMsg(format(ACTION_SUCCEED_MSG_PATTERN, UPDATE, HOLDINGS), payload));
-      publishEvent(payload);
       future.complete(payload);
     };
   }
 
   private String getMarcHoldingRecordAsString(DataImportEventPayload dataImportEventPayload) {
     return dataImportEventPayload.getContext().get(MARC_HOLDINGS.value());
-  }
-
-  private void publishEvent(DataImportEventPayload payload) {
-    eventPublisher.publish(payload);
   }
 
   /**

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateMarcHoldingsEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateMarcHoldingsEventHandler.java
@@ -14,6 +14,7 @@ import static org.folio.inventory.dataimport.util.LoggerUtil.logParametersEventH
 import static org.folio.inventory.dataimport.util.ParsedRecordUtil.getControlFieldValue;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -36,11 +37,12 @@ import org.folio.MappingMetadataDto;
 import org.folio.MappingProfile;
 import org.folio.dbschema.ObjectMapperTool;
 import org.folio.inventory.common.Context;
+import org.folio.inventory.common.api.request.PagingParameters;
 import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.exceptions.DataImportException;
 import org.folio.inventory.domain.HoldingsRecordCollection;
-import org.folio.inventory.services.HoldingsCollectionService;
+import org.folio.inventory.domain.instances.InstanceCollection;
 import org.folio.inventory.storage.Storage;
 import org.folio.inventory.validation.exceptions.JsonMappingException;
 import org.folio.processing.events.services.handler.EventHandler;
@@ -50,6 +52,7 @@ import org.folio.processing.mapping.defaultmapper.RecordMapper;
 import org.folio.processing.mapping.defaultmapper.RecordMapperBuilder;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.rest.jaxrs.model.EntityType;
+import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
 
@@ -71,21 +74,18 @@ public class UpdateMarcHoldingsEventHandler implements EventHandler {
   private static final String ACTION_SUCCEED_MSG_PATTERN = "Action '%s' for record '%s' succeed.";
   private static final String ACTION_FAILED_MSG_PATTERN = "Action '%s' for record '%s' failed.";
   private static final String UNEXPECTED_PAYLOAD_MSG = "Unexpected payload";
-  private static final String CANNOT_UPDATE_HOLDING_ERROR_MESSAGE = "Error updating Holding by holdingId '%s' and jobExecution '%s' recordId '%s' chunkId '%s' - %s, status code %s";
-
+  private static final String CANNOT_UPDATE_HOLDING_ERROR_MESSAGE = "Error updating Holding by holdingId %s and jobExecution '%s', failure reason: %s, status code %s";
+  private static final String ERROR_HOLDING_MSG = "Error loading inventory holdings for MARC BIB";
 
   private final Storage storage;
   private final MappingMetadataCache mappingMetadataCache;
-  private final HoldingsCollectionService holdingsCollectionService;
   private final KafkaEventPublisher eventPublisher;
 
   public UpdateMarcHoldingsEventHandler(Storage storage,
-                                        MappingMetadataCache mappingMetadataCache,
-                                        HoldingsCollectionService holdingsCollectionService,
-                                        KafkaEventPublisher eventPublisher) {
+    MappingMetadataCache mappingMetadataCache,
+    KafkaEventPublisher eventPublisher) {
     this.storage = storage;
     this.mappingMetadataCache = mappingMetadataCache;
-    this.holdingsCollectionService = holdingsCollectionService;
     this.eventPublisher = eventPublisher;
   }
 
@@ -108,6 +108,7 @@ public class UpdateMarcHoldingsEventHandler implements EventHandler {
       mappingMetadataCache.get(jobExecutionId, context)
         .map(mapMetadataOrFail())
         .compose(mappingMetadata -> mapHolding(payload, mappingMetadata))
+        .compose(holdings -> fillInstanceIdByHrid(payload, holdings, context))
         .compose(holdings -> processHolding(holdings, context, payload))
         .onSuccess(successHandler(payload, future))
         .onFailure(failureHandler(payload, future));
@@ -159,10 +160,13 @@ public class UpdateMarcHoldingsEventHandler implements EventHandler {
     try {
       var mappingRules = new JsonObject(mappingMetadata.getMappingRules());
       var mappingParameters = Json.decodeValue(mappingMetadata.getMappingParams(), MappingParameters.class);
-      var parsedRecord = new JsonObject((String) new JsonObject(getMarcHoldingRecordAsString(payload))
-        .mapTo(Record.class).getParsedRecord().getContent());
+      var marcRecord = new JsonObject(getMarcHoldingRecordAsString(payload)).mapTo(Record.class);
+      var parsedRecord = retrieveParsedContent(marcRecord.getParsedRecord());
+      String holdingsId = marcRecord.getExternalIdsHolder().getHoldingsId();
+      LOGGER.info("Holdings update with holdingId: {}", holdingsId);
       RecordMapper<Holdings> recordMapper = RecordMapperBuilder.buildMapper(MARC_HOLDINGS.value());
       var holdings = recordMapper.mapRecord(parsedRecord, mappingParameters, mappingRules);
+      holdings.setId(holdingsId);
       return Future.succeededFuture(holdings);
     } catch (Exception e) {
       LOGGER.error("Failed to map Record to Holdings", e);
@@ -170,39 +174,34 @@ public class UpdateMarcHoldingsEventHandler implements EventHandler {
     }
   }
 
+  private JsonObject retrieveParsedContent(ParsedRecord parsedRecord) {
+    return parsedRecord.getContent() instanceof String
+      ? new JsonObject(parsedRecord.getContent().toString())
+      : JsonObject.mapFrom(parsedRecord.getContent());
+  }
+
   private Future<HoldingsRecord> processHolding(Holdings holdings, Context context, DataImportEventPayload payload) {
-    var collection = storage.getHoldingsRecordCollection(context);
-
+    var holdingsRecordCollection = storage.getHoldingsRecordCollection(context);
     HoldingsRecord mappedRecord = Json.decodeValue(Json.encode(JsonObject.mapFrom(holdings)), HoldingsRecord.class);
-
     Promise<HoldingsRecord> promise = Promise.promise();
-    collection.findById(mappedRecord.getId())
-      .thenAccept(actualRecord -> updateHoldingsRecord(payload, context, mappedRecord, actualRecord, promise))
-      .thenAccept(ar -> collection.update(mappedRecord,
-        success -> {
-          holdings.setVersion(mappedRecord.getVersion());
-          holdings.setInstanceId(mappedRecord.getInstanceId());
-          payload.getContext().put(HOLDINGS.value(), Json.encode(holdings));
-          promise.complete(mappedRecord);
-        },
-        failure -> failureUpdateHandler(payload, mappedRecord.getId(), collection, promise, failure))
-      );
+    holdingsRecordCollection.findById(mappedRecord.getId())
+      .thenAccept(actualRecord -> {
+        mappedRecord.setVersion(actualRecord.getVersion());
+        holdingsRecordCollection.update(mappedRecord,
+          success -> {
+            holdings.setVersion(mappedRecord.getVersion());
+            holdings.setInstanceId(mappedRecord.getInstanceId());
+            payload.getContext().put(HOLDINGS.value(), Json.encode(holdings));
+            promise.complete(mappedRecord);
+          },
+          failure -> failureUpdateHandler(payload, mappedRecord.getId(), holdingsRecordCollection, promise, failure));
+      });
     return promise.future();
   }
 
-  private void updateHoldingsRecord(DataImportEventPayload payload, Context context,
-                                    HoldingsRecord mappedRecord,
-                                    HoldingsRecord actualRecord,
-                                    Promise<HoldingsRecord> promise) {
-    mappedRecord.setVersion(actualRecord.getVersion());
-    findInstanceIdByHrid(payload, mappedRecord, context)
-      .onSuccess(mappedRecord::setInstanceId)
-      .onFailure(promise::fail);
-  }
-
-  private Future<String> findInstanceIdByHrid(DataImportEventPayload dataImportEventPayload, HoldingsRecord mappedRecord, Context context) {
-    Promise<String> promise = Promise.promise();
-    String instanceId = mappedRecord.getInstanceId();
+  private Future<Holdings> fillInstanceIdByHrid(DataImportEventPayload dataImportEventPayload, Holdings holdings, Context context) {
+    Promise<Holdings> promise = Promise.promise();
+    String instanceId = holdings.getInstanceId();
     if (StringUtils.isBlank(instanceId)) {
       var rec = Json.decodeValue(getMarcHoldingRecordAsString(dataImportEventPayload), Record.class);
       var instanceHrid = getControlFieldValue(rec, INSTANCE_HRID_TAG);
@@ -211,24 +210,49 @@ public class UpdateMarcHoldingsEventHandler implements EventHandler {
         promise.fail(new EventProcessingException(FIELD_004_MARC_HOLDINGS_NOT_NULL));
       } else {
         var instanceCollection = storage.getInstanceCollection(context);
-        return holdingsCollectionService.findInstanceIdByHrid(instanceCollection, instanceHrid);
+        fillInstanceIdSearchingByHrid(instanceCollection, instanceHrid, holdings, promise);
       }
     } else {
-      promise.complete(instanceId);
+      promise.complete(holdings);
     }
     return promise.future();
+  }
+
+  private void fillInstanceIdSearchingByHrid(InstanceCollection instanceCollection,
+                                             String instanceHrid, Holdings holdings,
+                                             Promise<Holdings> promise) {
+    try {
+      instanceCollection.findByCql(format("hrid==%s", instanceHrid), PagingParameters.defaults(),
+        findResult -> {
+          if (findResult.getResult() != null && findResult.getResult().totalRecords == 1) {
+            var instanceIdFromDb = findResult.getResult().records.get(0).getId();
+            holdings.setInstanceId(instanceIdFromDb);
+            promise.complete(holdings);
+          }else{
+            promise.fail(new EventProcessingException("No instance id found for marc holdings with hrid: " + instanceHrid));
+          }
+        },
+        failure -> {
+          LOGGER.error(format(ERROR_HOLDING_MSG + ". StatusCode: %s. Message: %s", failure.getStatusCode(), failure.getReason()));
+          promise.fail(new EventProcessingException(failure.getReason()));
+        });
+    } catch (UnsupportedEncodingException e) {
+      LOGGER.error(ERROR_HOLDING_MSG, e);
+      promise.fail(e);
+    }
   }
 
   private void failureUpdateHandler(DataImportEventPayload payload, String id, HoldingsRecordCollection collection, Promise<HoldingsRecord> promise, Failure failure) {
     if (failure.getStatusCode() == HttpStatus.SC_CONFLICT) {
       processOLError(failure, payload, id, collection, promise);
     } else {
-      promise.fail(new DataImportException(format(CANNOT_UPDATE_HOLDING_ERROR_MESSAGE, failure.getReason(), failure.getStatusCode())));
+      promise.fail(new DataImportException(format(CANNOT_UPDATE_HOLDING_ERROR_MESSAGE,
+        id, payload.getJobExecutionId(), failure.getReason(), failure.getStatusCode())));
     }
   }
 
   private Handler<Throwable> failureHandler(DataImportEventPayload payload,
-                                            CompletableFuture<DataImportEventPayload> future) {
+    CompletableFuture<DataImportEventPayload> future) {
     return e -> {
       LOGGER.error(() -> constructMsg(format(ACTION_FAILED_MSG_PATTERN, UPDATE, HOLDINGS), payload), e);
       future.completeExceptionally(e);
@@ -236,7 +260,7 @@ public class UpdateMarcHoldingsEventHandler implements EventHandler {
   }
 
   private Handler<HoldingsRecord> successHandler(DataImportEventPayload payload,
-                                                 CompletableFuture<DataImportEventPayload> future) {
+    CompletableFuture<DataImportEventPayload> future) {
     return holdings -> {
       LOGGER.info(() -> constructMsg(format(ACTION_SUCCEED_MSG_PATTERN, UPDATE, HOLDINGS), payload));
       publishEvent(payload);

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateMarcHoldingsEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateMarcHoldingsEventHandler.java
@@ -252,7 +252,7 @@ public class UpdateMarcHoldingsEventHandler implements EventHandler {
   }
 
   private Handler<Throwable> failureHandler(DataImportEventPayload payload,
-    CompletableFuture<DataImportEventPayload> future) {
+                                            CompletableFuture<DataImportEventPayload> future) {
     return e -> {
       LOGGER.error(() -> constructMsg(format(ACTION_FAILED_MSG_PATTERN, UPDATE, HOLDINGS), payload), e);
       future.completeExceptionally(e);
@@ -260,7 +260,7 @@ public class UpdateMarcHoldingsEventHandler implements EventHandler {
   }
 
   private Handler<HoldingsRecord> successHandler(DataImportEventPayload payload,
-    CompletableFuture<DataImportEventPayload> future) {
+                                                 CompletableFuture<DataImportEventPayload> future) {
     return holdings -> {
       LOGGER.info(() -> constructMsg(format(ACTION_SUCCEED_MSG_PATTERN, UPDATE, HOLDINGS), payload));
       publishEvent(payload);

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateMarcHoldingsEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateMarcHoldingsEventHandlerTest.java
@@ -12,8 +12,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import static org.folio.ActionProfile.Action.MODIFY;
@@ -72,7 +70,6 @@ import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.domain.instances.InstanceCollection;
-import org.folio.inventory.services.HoldingsCollectionService;
 import org.folio.inventory.storage.Storage;
 import org.folio.processing.events.services.publisher.KafkaEventPublisher;
 import org.folio.processing.mapping.MappingManager;
@@ -123,8 +120,6 @@ public class UpdateMarcHoldingsEventHandlerTest {
   @Mock
   private HoldingsRecordCollection holdingsCollection;
 
-  @Mock
-  private HoldingsCollectionService holdingsCollectionService;
   @Mock
   private InstanceCollection instanceRecordCollection;
 
@@ -179,8 +174,6 @@ public class UpdateMarcHoldingsEventHandlerTest {
 
     CompletableFuture<DataImportEventPayload> future = eventHandler.handle(dataImportEventPayload);
     DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.SECONDS);
-
-    verify(publisher, times(1)).publish(dataImportEventPayload);
 
     assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
     assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
@@ -306,7 +299,6 @@ public class UpdateMarcHoldingsEventHandlerTest {
 
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
     assertThat(exception.getCause().getMessage(), containsString("Unexpected payload"));
-    verify(publisher, times(0)).publish(dataImportEventPayload);
   }
 
   @Test
@@ -412,7 +404,6 @@ public class UpdateMarcHoldingsEventHandlerTest {
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
     assertThat(exception.getCause().getMessage(),
       containsString("Current retry number 1 exceeded or equal given number 2 for the Holding update"));
-    verify(publisher, times(0)).publish(dataImportEventPayload);
   }
 
   @Test
@@ -445,7 +436,6 @@ public class UpdateMarcHoldingsEventHandlerTest {
     var future = eventHandler.handle(dataImportEventPayload);
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
     assertThat(exception.getCause().getMessage(), containsString("Error updating Holding by holdingId " + holdingsId));
-    verify(publisher, times(0)).publish(dataImportEventPayload);
   }
 
   @Test
@@ -489,7 +479,6 @@ public class UpdateMarcHoldingsEventHandlerTest {
 
     var future = eventHandler.handle(dataImportEventPayload);
     DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.SECONDS);
-    verify(publisher, times(2)).publish(actualDataImportEventPayload);
   }
 
   @Test
@@ -522,7 +511,6 @@ public class UpdateMarcHoldingsEventHandlerTest {
 
     ExecutionException exception = Assert.assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
     Assert.assertEquals("Error in default mapper.", exception.getCause().getMessage());
-    verify(publisher, times(0)).publish(dataImportEventPayload);
   }
 
   @Test
@@ -552,7 +540,6 @@ public class UpdateMarcHoldingsEventHandlerTest {
 
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
     assertThat(exception.getCause().getMessage(), containsString("Internal Server Error"));
-    verify(publisher, times(0)).publish(dataImportEventPayload);
   }
 
   @Test
@@ -585,7 +572,6 @@ public class UpdateMarcHoldingsEventHandlerTest {
 
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
     assertThat(exception.getCause().getMessage(), containsString("No instance id found for marc holdings with hrid: in00000000315"));
-    verify(publisher, times(0)).publish(dataImportEventPayload);
   }
 
   @Test
@@ -611,7 +597,6 @@ public class UpdateMarcHoldingsEventHandlerTest {
 
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
     assertThat(exception.getCause().getMessage(), containsString("Unsupported encoding."));
-    verify(publisher, times(0)).publish(dataImportEventPayload);
   }
 
 


### PR DESCRIPTION
## Purpose
_MARC-to-MARC Holdings update stacked_

## Approach

There were two reasons (in **UpdateMarcHoldingsEventHandler** class):
1) Incorrect holdingsId set when parsing payload into Holdings object, for this reason, it was not possible to load proper holding from inventory storage
2) After fixing first problem, we try to update holding sending PUT request to mod-inventory-storage, but required field instanceId was missing in the request body. The main root cause was incorrect chain used in completion stage, so two thenAccept methods were used which one was responsible to find and fill instanceId by hrid, second was responsible to send holding to mod-inventory-storage to update.
3) After updating holding, request was constantly sending to mod-inventory-storage 

To resolve above issues:
1) holdingsId extracted from marcRecord using getExternalIdsHolder().getHoldingsId() method and set to parsed holding;
2) refactored reactive chain flow so that it can be executed sequentially. (first finds intanceId and set it to holding, after that sends holding to update)
3) Removed event publishing

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
https://issues.folio.org/browse/MODINV-760