### PR TITLE
[MODDATAIMP-758]Imrove logging (hide SQL requests)

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/MarcBibModifiedPostProcessingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/MarcBibModifiedPostProcessingEventHandler.java
@@ -69,7 +69,7 @@ public class MarcBibModifiedPostProcessingEventHandler implements EventHandler {
         return CompletableFuture.failedFuture(new EventProcessingException(PAYLOAD_HAS_NO_DATA_MSG));
       }
 
-      LOGGER.info("Processing ReplaceInstanceEventHandler starting with jobExecutionId: {}.", dataImportEventPayload.getJobExecutionId());
+      LOGGER.info("Processing starting with jobExecutionId: {}.", dataImportEventPayload.getJobExecutionId());
 
       Record record = new JsonObject(payloadContext.get(MARC_BIBLIOGRAPHIC.value())).mapTo(Record.class);
       String instanceId = ParsedRecordUtil.getAdditionalSubfieldValue(record.getParsedRecord(), ParsedRecordUtil.AdditionalSubfields.I);

--- a/src/main/resources/log4j2-json.properties
+++ b/src/main/resources/log4j2-json.properties
@@ -1,0 +1,33 @@
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = JSONLayout
+appender.console.layout.compact = true
+appender.console.layout.eventEol = true
+appender.console.layout.stacktraceAsString = true
+
+packages = org.folio.okapi.common.logging
+appender.console.layout.requestId.type = KeyValuePair
+appender.console.layout.requestId.key = requestId
+appender.console.layout.requestId.value = $${FolioLoggingContext:requestid}
+
+appender.console.layout.tenantId.type = KeyValuePair
+appender.console.layout.tenantId.key = tenantId
+appender.console.layout.tenantId.value = $${FolioLoggingContext:tenantid}
+
+appender.console.layout.userId.type = KeyValuePair
+appender.console.layout.userId.key = userId
+appender.console.layout.userId.value = $${FolioLoggingContext:userid}
+
+appender.console.layout.moduleId.type = KeyValuePair
+appender.console.layout.moduleId.key = moduleId
+appender.console.layout.moduleId.value = $${FolioLoggingContext:moduleid}
+
+rootLogger.level = info
+rootLogger.appenderRefs = info
+rootLogger.appenderRef.stdout.ref = STDOUT
+
+logger.folio_persist.name = org.folio.rest.persist
+logger.folio_persist.level = ERROR
+logger.folio_persist.appenderRef.stdout.ref = STDOUT

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,17 @@
+appenders = console
+
+packages = org.folio.okapi.common.logging
+
+appender.console.type = Console
+appender.console.name = STDOUT
+
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
+
+rootLogger.level = info
+rootLogger.appenderRefs = info
+rootLogger.appenderRef.stdout.ref = STDOUT
+
+logger.folio_persist.name = org.folio.rest.persist
+logger.folio_persist.level = ERROR
+logger.folio_persist.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
https://issues.folio.org/browse/MODDATAIMP-758HAide SQL requests (org.folio.rest.persist.PostgresClient) from log files for the next modules:

mod-data-import
mod-source-record-storage
mod-data-import-converter-storage
mod-inventory-storage
This class logs SQL queries at the INFO level, which leads to a very large size of log files.

SRS: a lot of messages like this:
2023-01-05 09:28:12.246 WARN AbstractConfig The configuration 'ssl.protocol' was supplied but isn't a known config.
....
2023-01-05 09:28:12.246 WARN AbstractConfig The configuration 'ssl.truststore.type' was supplied but isn't a known config.

SRM: move to TRACE level or decrease defaultRules json
2023-01-05 01:55:50.850 [vert.x-eventloop-thread-1] [572525/proxy;692150/tenant] [diku] [] [mod_source_record_manager] DEBUG ppingRuleServiceImpl saveRulesIfNotExist:: recordType MARC_BIB, defaultRules {
"001": [
{

add recordId, or jobExecutionId, or other attributes to sendEventToKafka:
2023-01-05 12:46:12.034 DEBUG EventHandlingUtil sendEventToKafka:: Starting to send event to Kafka for eventType: DI_MARC_FOR_UPDATE_RECEIVED
2023-01-05 12:46:12.035 INFO EventHandlingUtil logSendingSucceeded:: Event with type: DI_MARC_FOR_UPDATE_RECEIVED and recordId: b17ea14c-c53a-44fa-baec-abc973d3cc45 was sent to kafka

mod-inventory: a lot of messages like this:
2023-01-05 01:44:27.078 WARN AbstractConfig [1498eqId] The configuration 'ssl.keystore.type' was supplied but isn't a known config.
...
2023-01-05 01:44:27.078 WARN AbstractConfig [1498eqId] The configuration 'ssl.truststore.location' was supplied but isn't a known config.

hide messages below:
2023-01-05 01:44:27.158 INFO AbstractConfig [1578eqId] ConsumerConfig values:
2023-01-05 01:44:31.805 INFO GroupResponseHandler [6225eqId] [Consumer clientId=consumer-DI_SRS_MARC_HOLDING_RECORD_CREATED.mod-inventory-19.1.0-82....
2023-01-05 01:54:58.456 INFO Metadata [632876eqId] [Consumer clientId=consumer-srs.marc-bib.mod-inventory-19.1.0-10, groupId=srs.marc-bib.mod-inventory-19.1.0] Resetting the last seen epoch of partition
2023-01-05 01:54:58.470 INFO ConsumerCoordinator [632890eqId] [Consumer clientId=consumer-srs.marc-bib.mod-inventory-19.1.0-10, groupId=srs.marc-bib.mod-inventory-19.1.0] Revoke previously assigned partitions