### PR TITLE
MODINV-773 Controlled Instance's field doesn't reflect the updates made by user in MARC Authority's 1XX

### DIFF
--- a/src/main/java/org/folio/inventory/domain/dto/InstanceEvent.java
+++ b/src/main/java/org/folio/inventory/domain/dto/InstanceEvent.java
@@ -6,12 +6,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"jobId", "record", "type", "tenant", "ts"})
 public class InstanceEvent {
   @JsonProperty("jobId")
   private String jobId;
+  @JsonProperty("linkIds")
+  private List<Integer> linkIds = new LinkedList<>();
   @JsonProperty("record")
   private String record;
   @JsonProperty("type")
@@ -31,6 +35,19 @@ public class InstanceEvent {
 
   public InstanceEvent withJobId(String jobId) {
     this.jobId = jobId;
+    return this;
+  }
+
+  public List<Integer> getLinkIds() {
+    return linkIds;
+  }
+
+  public void setLinkIds(List<Integer> linkIds) {
+    this.linkIds = linkIds;
+  }
+
+  public InstanceEvent withLinkIds(List<Integer> linkIds) {
+    this.linkIds = linkIds;
     return this;
   }
 

--- a/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandlerTest.java
@@ -15,6 +15,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -99,6 +100,7 @@ public class MarcBibUpdateKafkaHandlerTest {
     Async async = context.async();
     InstanceEvent payload = new InstanceEvent()
       .withRecord(Json.encode(record))
+      .withLinkIds(List.of(1, 2, 3))
       .withType(InstanceEvent.EventType.UPDATE)
       .withTenant("diku")
       .withJobId(UUID.randomUUID().toString());


### PR DESCRIPTION
## Purpose
Update schema to fix parsing exception

## Approach
- add `linkIds` field to schema

## Learning
[MODINV-773](https://issues.folio.org/browse/MODINV-773)