### PR TITLE
[MODINV-711] Add a warning block to the log when the module starts without consumers

### DIFF
--- a/src/main/java/org/folio/inventory/Launcher.java
+++ b/src/main/java/org/folio/inventory/Launcher.java
@@ -62,6 +62,9 @@ public class Launcher {
     if(Boolean.parseBoolean(kafkaConsumersToBeInitialized)){
       Map<String, Object> consumerVerticlesConfig = getConsumerVerticleConfig();
       startConsumerVerticles(consumerVerticlesConfig);
+    } else {
+      final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+      log.warn("\n*******\n*  WARNING: The module is running in Traffics Diversion mode (there is no Consumers to accept DI Kafka messages)\n*******");
     }
   }
 


### PR DESCRIPTION
### Purpose
Add a warning block to the log when the module starts without consumers
### Approach
Added a warning block to the log when the module starts without consumers