### PR TITLE
[MODINV-786] Update Create Item handler to support list of mapped items in context

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/entities/PartialError.java
+++ b/src/main/java/org/folio/inventory/dataimport/entities/PartialError.java
@@ -1,0 +1,27 @@
+package org.folio.inventory.dataimport.entities;
+
+public class PartialError {
+  private String id;
+  private String error;
+
+  public PartialError(String id, String error) {
+    this.id = id;
+    this.error = error;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getError() {
+    return error;
+  }
+
+  public void setError(String error) {
+    this.error = error;
+  }
+}


### PR DESCRIPTION
## Purpose
Update CreateItemEventHandler to support a list of mapped holdings in context

## Approach 
Send separate requests for each item on create, do not throw exceptions for errors during the creation of items (except for DuplicationError) and store errors in payloadContext. Fill holding id by identifiers from payload contest

## Learning
Jira: https://issues.folio.org/browse/MODINV-786