### PR TITLE
[MODINV-786] Update Create Item handler to support list of mapped items in context

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
@@ -1,7 +1,5 @@
 package org.folio.inventory.dataimport.handlers.actions;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -15,7 +13,6 @@ import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
 import org.folio.HoldingsRecord;
 import org.folio.inventory.common.Context;
-import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.entities.PartialError;
 import org.folio.inventory.dataimport.services.OrderHelperService;
@@ -42,7 +39,6 @@ import java.util.concurrent.CompletableFuture;
 import static java.lang.String.format;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.logging.log4j.util.Strings.isNotEmpty;
 import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
 import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
@@ -58,8 +54,6 @@ public class CreateHoldingEventHandler implements EventHandler {
   private static final String RECORD_ID_HEADER = "recordId";
   private static final String CHUNK_ID_HEADER = "chunkId";
   private static final String HOLDINGS_PATH_FIELD = "holdings";
-  private static final String PERMANENT_LOCATION_ID_FIELD = "permanentLocationId";
-  private static final String PERMANENT_LOCATION_ID_ERROR_MESSAGE = "Can`t create Holding entity: 'permanentLocationId' is empty";
   private static final String CREATE_HOLDING_ERROR_MESSAGE = "Failed to create Holdings";
   private static final String CONTEXT_EMPTY_ERROR_MESSAGE = "Can`t create Holding entity: context is empty or doesn`t exists";
   private static final String PAYLOAD_DATA_HAS_NO_INSTANCE_ID_ERROR_MSG = "Failed to extract instanceId from instance entity or parsed record";

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -177,7 +177,13 @@ public class CreateItemEventHandler implements EventHandler {
                 payloadContext.put(ERRORS, Json.encode(multipleItemsCreateErrors));
               }
               if (ar.succeeded()) {
-                createMultipleItemsPromise.complete(createdItems);
+                String multipleItemsCreateErrorsAsStringJson = Json.encode(multipleItemsCreateErrors);
+                if (createdItems.size() > 0) {
+                  payloadContext.put(ERRORS, multipleItemsCreateErrorsAsStringJson);
+                  createMultipleItemsPromise.complete(createdItems);
+                } else {
+                  createMultipleItemsPromise.fail(multipleItemsCreateErrorsAsStringJson);
+                }
               } else {
                 createMultipleItemsPromise.fail(ar.cause());
               }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -173,7 +173,9 @@ public class CreateItemEventHandler implements EventHandler {
             });
 
             CompositeFuture.all(createItemsFutures).onComplete(ar -> {
-              payloadContext.put(ERRORS, Json.encode(multipleItemsCreateErrors));
+              if (payloadContext.containsKey(ERRORS) || !multipleItemsCreateErrors.isEmpty()) {
+                payloadContext.put(ERRORS, Json.encode(multipleItemsCreateErrors));
+              }
               if (ar.succeeded()) {
                 createMultipleItemsPromise.complete(createdItems);
               } else {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -123,7 +123,7 @@ public class CreateItemEventHandler implements EventHandler {
 
       dataImportEventPayload.getEventsChain().add(dataImportEventPayload.getEventType());
       dataImportEventPayload.setCurrentNode(dataImportEventPayload.getCurrentNode().getChildSnapshotWrappers().get(0));
-      dataImportEventPayload.getContext().put(ITEM.value(), new JsonObject().encode());
+      dataImportEventPayload.getContext().put(ITEM.value(), new JsonArray().encode());
 
       String jobExecutionId = dataImportEventPayload.getJobExecutionId();
       String recordId = dataImportEventPayload.getContext().get(RECORD_ID_HEADER);

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -234,7 +234,7 @@ public class CreateItemEventHandler implements EventHandler {
   private JsonArray processMappingResult(DataImportEventPayload dataImportEventPayload, String deduplicationItemId) {
     JsonArray items = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
     JsonArray mappedItems = new JsonArray();
-    JsonArray holdingsIdentifiers = new JsonArray(dataImportEventPayload.getContext().get(HOLDING_IDENTIFIERS));
+    JsonArray holdingsIdentifiers = new JsonArray(dataImportEventPayload.getContext().remove(HOLDING_IDENTIFIERS));
     String holdingsAsString = dataImportEventPayload.getContext().get(EntityType.HOLDINGS.value());
 
     for (int i = 0; i < items.size(); i++) {

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
@@ -17,6 +17,7 @@ import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.dataimport.ItemWriterFactory;
 import org.folio.inventory.dataimport.ItemsMapperFactory;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.dataimport.entities.PartialError;
 import org.folio.inventory.dataimport.services.OrderHelperServiceImpl;
 import org.folio.inventory.domain.items.Item;
 import org.folio.inventory.domain.items.ItemCollection;
@@ -28,7 +29,6 @@ import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.processing.mapping.mapper.reader.Reader;
 import org.folio.processing.mapping.mapper.reader.record.marc.MarcBibReaderFactory;
-import org.folio.processing.value.ListValue;
 import org.folio.processing.value.StringValue;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.MappingDetail;
@@ -39,7 +39,6 @@ import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -223,9 +222,8 @@ public class CreateItemEventHandlerTest {
     Assert.assertNotNull(eventPayload.getContext().get(ITEM.value()));
 
     JsonArray createdItems = new JsonArray(eventPayload.getContext().get(ITEM.value()));
-    JsonArray errors = new JsonArray(eventPayload.getContext().get(ERRORS));
+    Assert.assertNull(eventPayload.getContext().get(ERRORS));
     Assert.assertEquals(1, createdItems.size());
-    Assert.assertEquals(0, errors.size());
     JsonObject createdItem = createdItems.getJsonObject(0);
     Assert.assertNotNull(createdItem.getJsonObject("status").getString("name"));
     Assert.assertNotNull(createdItem.getString("permanentLoanTypeId"));
@@ -293,9 +291,8 @@ public class CreateItemEventHandlerTest {
     Assert.assertNotNull(eventPayload.getContext().get(ITEM.value()));
 
     JsonArray createdItems = new JsonArray(eventPayload.getContext().get(ITEM.value()));
-    JsonArray errors = new JsonArray(eventPayload.getContext().get(ERRORS));
+    Assert.assertNull(eventPayload.getContext().get(ERRORS));
     Assert.assertEquals(2, createdItems.size());
-    Assert.assertEquals(0, errors.size());
 
     for (int i = 0; i < createdItems.size(); i++) {
       JsonObject createdItem = createdItems.getJsonObject(i);
@@ -374,9 +371,8 @@ public class CreateItemEventHandlerTest {
     Assert.assertNotNull(eventPayload.getContext().get(ITEM.value()));
 
     JsonArray createdItems = new JsonArray(eventPayload.getContext().get(ITEM.value()));
-    JsonArray errors = new JsonArray(eventPayload.getContext().get(ERRORS));
+    Assert.assertNull(eventPayload.getContext().get(ERRORS));
     Assert.assertEquals(2, createdItems.size());
-    Assert.assertEquals(0, errors.size());
 
     Assert.assertEquals(createdItems.getJsonObject(0).getString("id"), ITEM_ID);
     for (int i = 0; i < createdItems.size(); i++) {
@@ -526,9 +522,8 @@ public class CreateItemEventHandlerTest {
     Assert.assertNotNull(eventPayload.getContext().get(ITEM.value()));
 
     JsonArray createdItems = new JsonArray(eventPayload.getContext().get(ITEM.value()));
-    JsonArray errors = new JsonArray(eventPayload.getContext().get(ERRORS));
+    Assert.assertNull(eventPayload.getContext().get(ERRORS));
     Assert.assertEquals(2, createdItems.size());
-    Assert.assertEquals(0, errors.size());
 
     for (int i = 0; i < createdItems.size(); i++) {
       JsonObject createdItem = createdItems.getJsonObject(i);
@@ -561,6 +556,7 @@ public class CreateItemEventHandlerTest {
     payloadContext.put(EntityType.MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
     payloadContext.put(EntityType.HOLDINGS.value(), Json.encode(List.of(holdingAsJson)));
     payloadContext.put(HOLDINGS_IDENTIFIERS, Json.encode(List.of(PERMANENT_LOCATION_ID)));
+    payloadContext.put(ERRORS, Json.encode(new PartialError(null, "testError")));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
@@ -578,8 +574,8 @@ public class CreateItemEventHandlerTest {
 
     JsonArray createdItems = new JsonArray(eventPayload.getContext().get(ITEM.value()));
     JsonArray errors = new JsonArray(eventPayload.getContext().get(ERRORS));
-    Assert.assertEquals(1, createdItems.size());
     Assert.assertEquals(0, errors.size());
+    Assert.assertEquals(1, createdItems.size());
     JsonObject createdItem = createdItems.getJsonObject(0);
     Assert.assertNotNull(createdItem.getJsonObject("status").getString("name"));
     Assert.assertNotNull(createdItem.getString("permanentLoanTypeId"));


### PR DESCRIPTION
## Purpose
Update CreateItemEventHandler to support a list of mapped items in context

## Approach 
Send separate requests for each item on create, do not throw exceptions for errors during the creation of items (except for DuplicationError) and store errors in payloadContext.

## Learning
Jira: https://issues.folio.org/browse/MODINV-786