### PR TITLE
MODINV-835 - Data Import 3rd update Action on Same Record Fails

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
@@ -56,7 +56,7 @@ public class UpdateHoldingEventHandler implements EventHandler {
   private static final String RECORD_ID_HEADER = "recordId";
   private static final String CHUNK_ID_HEADER = "chunkId";
   private static final String ITEM_ID_HEADER = "id";
-  private static final String CURRENT_RETRY_NUMBER = "CURRENT_RETRY_NUMBER";
+  static final String CURRENT_RETRY_NUMBER = "CURRENT_RETRY_NUMBER";
   private static final int MAX_RETRIES_COUNT = Integer.parseInt(System.getenv().getOrDefault("inventory.di.ol.retry.number", "1"));
   private static final String CURRENT_EVENT_TYPE_PROPERTY = "CURRENT_EVENT_TYPE";
   private static final String CURRENT_HOLDING_PROPERTY = "CURRENT_HOLDING";
@@ -177,7 +177,8 @@ public class UpdateHoldingEventHandler implements EventHandler {
       dataImportEventPayload.getContext().put(CURRENT_RETRY_NUMBER, String.valueOf(currentRetryNumber + 1));
       LOGGER.warn("Error updating Holding by id '{}' - '{}', status code '{}'. Retry UpdateHoldingEventHandler handler...", holding.getId(), failure.getReason(), failure.getStatusCode());
       holdingsRecords.findById(holding.getId())
-        .thenAccept(actualInstance -> prepareDataAndReInvokeCurrentHandler(dataImportEventPayload, future, actualInstance))
+        .thenAccept(actualHolding -> prepareDataAndReInvokeCurrentHandler(dataImportEventPayload, future, actualHolding))
+        .thenAccept(v -> dataImportEventPayload.getContext().remove(CURRENT_RETRY_NUMBER))
         .exceptionally(e -> {
           dataImportEventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
           String errMessage = format("Cannot get actual Holding by id: '%s' for jobExecutionId '%s'. Error: %s ", holding.getId(), dataImportEventPayload.getJobExecutionId(), e.getCause());

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -127,7 +127,7 @@ public class UpdateItemEventHandler implements EventHandler {
 
           List<String> errors = validateItem(mappedItemAsJson, requiredFields);
           if (!errors.isEmpty()) {
-            String msg = format("Mapped Instance is invalid: %s, by jobExecutionId: '%s' and recordId: '%s' and chunkId: '%s' ", errors,
+            String msg = format("Mapped Item is invalid: %s, by jobExecutionId: '%s' and recordId: '%s' and chunkId: '%s' ", errors,
               jobExecutionId, recordId, chunkId);
             LOG.error(msg);
             return Future.failedFuture(msg);
@@ -284,12 +284,12 @@ public class UpdateItemEventHandler implements EventHandler {
   }
 
 
-  private void processOLError(Item instance, ItemCollection itemCollection, DataImportEventPayload eventPayload, Promise<Item> promise, Failure failure) {
+  private void processOLError(Item item, ItemCollection itemCollection, DataImportEventPayload eventPayload, Promise<Item> promise, Failure failure) {
     int currentRetryNumber = eventPayload.getContext().get(CURRENT_RETRY_NUMBER) == null ? 0 : Integer.parseInt(eventPayload.getContext().get(CURRENT_RETRY_NUMBER));
     if (currentRetryNumber < MAX_RETRIES_COUNT) {
       eventPayload.getContext().put(CURRENT_RETRY_NUMBER, String.valueOf(currentRetryNumber + 1));
       LOG.warn("OL error updating Item - {}, status code {}. Retry UpdateItemEventHandler handler...", failure.getReason(), failure.getStatusCode());
-      getActualItemAndReInvokeCurrentHandler(instance, itemCollection, promise, eventPayload);
+      getActualItemAndReInvokeCurrentHandler(item, itemCollection, promise, eventPayload);
     } else {
       eventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
       String errMessage = format("Current retry number %s exceeded or equal given number %s for the Item update for jobExecutionId '%s'", MAX_RETRIES_COUNT, currentRetryNumber, eventPayload.getJobExecutionId());

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -39,10 +39,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
+import static java.lang.String.format;
 import static org.folio.ActionProfile.FolioRecord.*;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_MATCHED;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_UPDATED;
 import static org.folio.inventory.dataimport.handlers.actions.UpdateHoldingEventHandler.ACTION_HAS_NO_MAPPING_MSG;
+import static org.folio.inventory.dataimport.handlers.actions.UpdateHoldingEventHandler.CURRENT_RETRY_NUMBER;
 import static org.folio.inventory.domain.items.ItemStatusName.AVAILABLE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.*;
 import static org.junit.Assert.assertFalse;
@@ -171,6 +173,72 @@ public class UpdateHoldingEventHandlerTest {
     Assert.assertEquals(permanentLocationId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
     Assert.assertEquals(hrid, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("hrid"));
     Assert.assertEquals(holdingId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
+  }
+
+  @Test
+  public void shouldUpdateHoldingOnOLRetryAndRemoveRetryCounterFromPayload() throws InterruptedException, ExecutionException, TimeoutException {
+    Reader fakeReader = Mockito.mock(Reader.class);
+
+    String holdingId = UUID.randomUUID().toString();
+    String hrid = UUID.randomUUID().toString();
+    String instanceId = String.valueOf(UUID.randomUUID());
+    String permanentLocationId = UUID.randomUUID().toString();
+
+    HoldingsRecord actualHoldings = new HoldingsRecord()
+      .withId(holdingId)
+      .withHrid(hrid)
+      .withInstanceId(instanceId)
+      .withPermanentLocationId(permanentLocationId)
+      .withVersion(2);
+
+    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
+    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    when(storage.getItemCollection(any())).thenReturn(itemCollection);
+    when(holdingsRecordsCollection.findById(anyString())).thenReturn(CompletableFuture.completedFuture(actualHoldings));
+
+    doAnswer(invocationOnMock -> {
+      Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+      failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", holdingId), 409));
+      return null;
+    }).doAnswer(invocationOnMock -> {
+      HoldingsRecord holdingsRecord = invocationOnMock.getArgument(0);
+      Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
+      successHandler.accept(new Success<>(holdingsRecord));
+      return null;
+    }).when(holdingsRecordsCollection).update(any(), any(), any());
+
+    MappingManager.registerReaderFactory(fakeReaderFactory);
+    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+
+    HoldingsRecord holdingsRecord = new HoldingsRecord()
+      .withId(holdingId)
+      .withInstanceId(instanceId)
+      .withHrid(hrid)
+      .withPermanentLocationId(permanentLocationId);
+
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), Json.encode(holdingsRecord));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+    verify(holdingsRecordsCollection, times(2)).update(any(), any(), any());
+    verify(holdingsRecordsCollection).findById(holdingsRecord.getId());
+
+    Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertNull(actualDataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER));
+    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    HoldingsRecord updatedHoldings = Json.decodeValue(actualDataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord.class);
+    Assert.assertEquals(actualHoldings.getVersion(), updatedHoldings.getVersion());
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -235,10 +235,8 @@ public class UpdateHoldingEventHandlerTest {
     verify(holdingsRecordsCollection).findById(holdingsRecord.getId());
 
     Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
-    Assert.assertNull(actualDataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER));
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    HoldingsRecord updatedHoldings = Json.decodeValue(actualDataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord.class);
-    Assert.assertEquals(actualHoldings.getVersion(), updatedHoldings.getVersion());
+    Assert.assertNull(actualDataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER));
   }
 
   @Test


### PR DESCRIPTION
# Purpose
Some libraries prefer to have more discrete/granular mapping profiles linked to shared action profiles for updates.
Because they can use these action profiles in scope of one job profile instead of creating unique mapping profiles and individual action profiles that might be used only once.
Currently, when there are multiple action profiles for updating holding within one job profile, the 3rd action always fails.


## Approach
* remove OL retry counter from the event payload after a successful attempt to update holdings to avoid its influence on subsequent actions processing
* add test


## Learning
[MODINV-835](https://issues.folio.org/browse/MODINV-835)