### PR TITLE
MODINV-826: Upgrade mod-inventory to Java 17

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
         cache: maven
     - run: mvn clean install -DskipTests
     - run: brew install postgresql@12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM folioci/alpine-jre-openjdk11:latest
+FROM folioci/alpine-jre-openjdk17:latest
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
 
 ENV VERTICLE_FILE mod-inventory.jar
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ buildMvn {
   mvnDeploy = 'yes'
   doKubeDeploy = true
   publishPreview = false
-  buildNode = 'jenkins-agent-java11'
+  buildNode = 'jenkins-agent-java17'
 
   doDocker = {
     buildJavaDocker {

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 20.1.0-SNAPSHOT 2023-XX-XX
+* [MODINV-826](https://issues.folio.org/browse/MODINV-826) Upgrade mod-inventory to Java 17
+
 ## 20.0.0 2023-02-20
 * Controlled Instance's field properly reflects updates made by user in MARC Authority's 1XX fields ([MODINV-773] (https://issues.folio.org/browse/MODINV-773))
 * POLine ID now set correctly when present in batch imports ([MODINV-774] (https://issues.folio.org/browse/MODINV-774))

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-isbn-util</artifactId>
-      <version>1.5.0</version>
+      <version>1.6.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.7.1</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -349,7 +349,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
**Purpose:** Upgrade mod-inventory to Java 17.

**Description:** updated folio-isbn-util, folio-kafka-wrapper dependencies with snapshot versions for the sake of testing since these modules also were migrated to Java 17