### PR TITLE
Support paging in /items-by-holdings-id API (MODINV-838)

### DIFF
--- a/ramls/inventory.raml
+++ b/ramls/inventory.raml
@@ -287,7 +287,8 @@ resourceTypes:
         schemaItem: item
         exampleItem: !include examples/items_get.json
     get:
-      is: [searchable: {description: "query by holdings record ID. This is a mandatory query parameter.
+      is: [pageable: {description: "The default page size is 200. Maximum page size is 10000."},
+        searchable: {description: "query by holdings record ID. This is a mandatory query parameter.
        An optional parameter, 'relations', can be passed outside of the query to restrict what
        Items are returned based on their type of relationship with the holdings record.
        Possible values of the 'relations' parameter are: 'onlyBoundWiths', 'onlyBoundWithsSkipDirectlyLinkedItem'",

--- a/src/main/java/org/folio/inventory/resources/ItemsByHoldingsRecordId.java
+++ b/src/main/java/org/folio/inventory/resources/ItemsByHoldingsRecordId.java
@@ -137,7 +137,7 @@ public class ItemsByHoldingsRecordId extends Items
     boolean skipDirectlyLinkedItem = relationsParam != null && relationsParam.equals(
       RELATION_PARAM_ONLY_BOUND_WITHS_SKIP_DIRECTLY_LINKED_ITEM );
 
-    boolean boundWithsFound = boundWithItemIds.isEmpty();
+    boolean boundWithsFound = !boundWithItemIds.isEmpty();
     if (boundWithsFound) {
       itemQuery = buildQueryByIds( boundWithItemIds );
       if (skipDirectlyLinkedItem)

--- a/src/main/java/org/folio/inventory/resources/ItemsByHoldingsRecordId.java
+++ b/src/main/java/org/folio/inventory/resources/ItemsByHoldingsRecordId.java
@@ -54,7 +54,6 @@ public class ItemsByHoldingsRecordId extends Items
    * for that method to retrieve the actual Item objects together with Items directly attached to the holdings record.
    */
   private void getBoundWithItems( RoutingContext routingContext) {
-    log.info("ID-NE: getBoundWithItems");
     WebContext context = new WebContext(routingContext);
 
     String queryByHoldingsRecordId = context.getStringParameter("query", null);

--- a/src/main/java/org/folio/inventory/resources/ItemsByHoldingsRecordId.java
+++ b/src/main/java/org/folio/inventory/resources/ItemsByHoldingsRecordId.java
@@ -97,11 +97,6 @@ public class ItemsByHoldingsRecordId extends Items
         100,
         0,
         response -> {
-          if (response.getJson().getInteger("totalRecords") > 100) {
-            log.error("Found over 100 bound-withs that all contained holdings record {}." +
-                " Can only process up to 100 bound-with copies.",
-              holdingsRecordId);
-          }
           List<String> boundWithItemIds = response.getJson()
             .getJsonArray("boundWithParts").stream()
             .map(part -> ((JsonObject) part).getString("itemId"))

--- a/src/test/java/api/BoundWithTests.java
+++ b/src/test/java/api/BoundWithTests.java
@@ -234,7 +234,7 @@ public class BoundWithTests extends ApiTests
     }
     Response itemsResponse = okapiClient.get(ApiTestSuite.apiRoot()+
         "/inventory/items-by-holdings-id?query=holdingsRecordId=="
-        +holdings1.getJson().getString( "id" ))
+        +holdings1.getJson().getString( "id" )+"&offset=0&limit=1200")
       .toCompletableFuture().get(5, SECONDS);
     assertThat("1100 items found for 'holdings1': ", itemsResponse.getJson().getInteger( "totalRecords" ), is(1100));
     assertThat("1100 items found for 'holdings1': ", itemsResponse.getJson().getJsonArray("items").size(), is(1100));

--- a/src/test/java/api/BoundWithTests.java
+++ b/src/test/java/api/BoundWithTests.java
@@ -192,7 +192,7 @@ public class BoundWithTests extends ApiTests
 
     Response itemsResponse2 = okapiClient.get(ApiTestSuite.apiRoot()+
       "/inventory/items-by-holdings-id?query=holdingsRecordId=="
-      +holdings1a.getJson().getString( "id" ))
+      +holdings1a.getJson().getString( "id" )+"&offset=0&limit=20000")
       .toCompletableFuture().get(5, SECONDS);
 
     assertThat("One and only one bound-with item is found: ", itemsResponse2.getJson().getInteger( "totalRecords" ), is(1));
@@ -215,7 +215,7 @@ public class BoundWithTests extends ApiTests
 
     Response itemsResponse5 = okapiClient.get(ApiTestSuite.apiRoot()+
       "/inventory/items-by-holdings-id?query=holdingsRecordId=="
-      +holdings3a.getJson().getString( "id" ))
+      +holdings3a.getJson().getString( "id" )+"&offset=string&limit=string")
       .toCompletableFuture().get(5, SECONDS);
     assertThat("One item is found for 'holdings3a' (non-bound-with) with relations criterion: ", itemsResponse5.getJson().getInteger( "totalRecords" ), is(1));
 
@@ -284,6 +284,14 @@ public class BoundWithTests extends ApiTests
 
     assertThat("Response code 400 (bad request) expected when not querying by holdingsRecordId",
       itemsResponse3.getStatusCode(), is(400));
+
+    Response itemsResponse4 = okapiClient.get(ApiTestSuite.apiRoot()+
+        "/inventory/items-by-holdings-id/?query=holdingsRecordId")
+      .toCompletableFuture().get(5, SECONDS);
+
+    assertThat("Response code 400 (bad request) expected when not querying by holdingsRecordId",
+      itemsResponse4.getStatusCode(), is(400));
+
   }
 
   @Test


### PR DESCRIPTION
This API causes significant problems for mod-inventory and UI Inventory when dealing with holdings records with extremely many (12000+) items. 

The PR would set a default page size of 200 items and a maximum page size of 10000 items. 

The PR also simplifies some bound-with logic that was more complicated than necessary, thus improving performance some. 