### PR TITLE
MULTIPLE

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/HoldingsItemMatcherFactory.java
+++ b/src/main/java/org/folio/inventory/dataimport/HoldingsItemMatcherFactory.java
@@ -1,0 +1,20 @@
+package org.folio.inventory.dataimport;
+
+import org.folio.processing.matching.loader.MatchValueLoader;
+import org.folio.processing.matching.matcher.HoldingsItemMatcher;
+import org.folio.processing.matching.matcher.Matcher;
+import org.folio.processing.matching.matcher.MatcherFactory;
+import org.folio.processing.matching.reader.MatchValueReader;
+import org.folio.rest.jaxrs.model.EntityType;
+
+public class HoldingsItemMatcherFactory implements MatcherFactory {
+  @Override
+  public Matcher createMatcher(MatchValueReader matchValueReader, MatchValueLoader matchValueLoader) {
+    return new HoldingsItemMatcher(matchValueReader, matchValueLoader);
+  }
+
+  @Override
+  public boolean isEligibleForEntityType(EntityType entityType) {
+    return EntityType.HOLDINGS == entityType || EntityType.ITEM == entityType;
+  }
+}

--- a/src/main/java/org/folio/inventory/dataimport/HoldingsMapperFactory.java
+++ b/src/main/java/org/folio/inventory/dataimport/HoldingsMapperFactory.java
@@ -1,0 +1,30 @@
+package org.folio.inventory.dataimport;
+
+import org.folio.ActionProfile;
+import org.folio.DataImportEventPayload;
+import org.folio.processing.mapping.mapper.Mapper;
+import org.folio.processing.mapping.mapper.mappers.HoldingsMapper;
+import org.folio.processing.mapping.mapper.mappers.MapperFactory;
+import org.folio.processing.mapping.mapper.reader.Reader;
+import org.folio.processing.mapping.mapper.writer.Writer;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+
+import java.util.LinkedHashMap;
+
+public class HoldingsMapperFactory implements MapperFactory {
+
+  public static final String EXISTING_RECORD_TYPE = "existingRecordType";
+
+  @Override
+  public Mapper createMapper(Reader reader, Writer writer) {
+    return new HoldingsMapper(reader, writer);
+  }
+
+  @Override
+  public boolean isEligiblePayload(DataImportEventPayload eventPayload) {
+    LinkedHashMap<String, String> map = (LinkedHashMap<String, String>) eventPayload.getCurrentNode().getContent();
+    String existingRecordType = map.get(EXISTING_RECORD_TYPE);
+    return (ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE.equals(eventPayload.getCurrentNode().getContentType()))
+      && (existingRecordType.equals(ActionProfile.FolioRecord.HOLDINGS.value()));
+  }
+}

--- a/src/main/java/org/folio/inventory/dataimport/ItemsMapperFactory.java
+++ b/src/main/java/org/folio/inventory/dataimport/ItemsMapperFactory.java
@@ -1,0 +1,30 @@
+package org.folio.inventory.dataimport;
+
+import org.folio.ActionProfile;
+import org.folio.DataImportEventPayload;
+import org.folio.processing.mapping.mapper.Mapper;
+import org.folio.processing.mapping.mapper.mappers.ItemMapper;
+import org.folio.processing.mapping.mapper.mappers.MapperFactory;
+import org.folio.processing.mapping.mapper.reader.Reader;
+import org.folio.processing.mapping.mapper.writer.Writer;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+
+import java.util.LinkedHashMap;
+
+public class ItemsMapperFactory implements MapperFactory {
+
+  public static final String EXISTING_RECORD_TYPE = "existingRecordType";
+
+  @Override
+  public Mapper createMapper(Reader reader, Writer writer) {
+    return new ItemMapper(reader, writer);
+  }
+
+  @Override
+  public boolean isEligiblePayload(DataImportEventPayload eventPayload) {
+    LinkedHashMap<String, String> map = (LinkedHashMap<String, String>) eventPayload.getCurrentNode().getContent();
+    String existingRecordType = map.get(EXISTING_RECORD_TYPE);
+    return (ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE.equals(eventPayload.getCurrentNode().getContentType()))
+      && (existingRecordType.equals(ActionProfile.FolioRecord.ITEM.value()));
+  }
+}

--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -18,6 +18,7 @@ import org.folio.inventory.dataimport.HoldingWriterFactory;
 import org.folio.inventory.dataimport.HoldingsMapperFactory;
 import org.folio.inventory.dataimport.InstanceWriterFactory;
 import org.folio.inventory.dataimport.ItemWriterFactory;
+import org.folio.inventory.dataimport.ItemsMapperFactory;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.cache.ProfileSnapshotCache;
 import org.folio.inventory.dataimport.handlers.actions.CreateAuthorityEventHandler;
@@ -162,6 +163,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     MappingManager.registerWriterFactory(new HoldingWriterFactory());
     MappingManager.registerWriterFactory(new InstanceWriterFactory());
     MappingManager.registerMapperFactory(new HoldingsMapperFactory());
+    MappingManager.registerMapperFactory(new ItemsMapperFactory());
 
     PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper = new PrecedingSucceedingTitlesHelper(WebClient.wrap(client));
     EventManager.registerEventHandler(new MatchInstanceEventHandler(mappingMetadataCache));

--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -15,6 +15,7 @@ import org.folio.inventory.common.Context;
 import org.folio.inventory.common.dao.EntityIdStorageDaoImpl;
 import org.folio.inventory.common.dao.PostgresClientFactory;
 import org.folio.inventory.dataimport.HoldingWriterFactory;
+import org.folio.inventory.dataimport.HoldingsMapperFactory;
 import org.folio.inventory.dataimport.InstanceWriterFactory;
 import org.folio.inventory.dataimport.ItemWriterFactory;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
@@ -160,6 +161,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     MappingManager.registerWriterFactory(new ItemWriterFactory());
     MappingManager.registerWriterFactory(new HoldingWriterFactory());
     MappingManager.registerWriterFactory(new InstanceWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
 
     PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper = new PrecedingSucceedingTitlesHelper(WebClient.wrap(client));
     EventManager.registerEventHandler(new MatchInstanceEventHandler(mappingMetadataCache));

--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -15,6 +15,7 @@ import org.folio.inventory.common.Context;
 import org.folio.inventory.common.dao.EntityIdStorageDaoImpl;
 import org.folio.inventory.common.dao.PostgresClientFactory;
 import org.folio.inventory.dataimport.HoldingWriterFactory;
+import org.folio.inventory.dataimport.HoldingsItemMatcherFactory;
 import org.folio.inventory.dataimport.HoldingsMapperFactory;
 import org.folio.inventory.dataimport.InstanceWriterFactory;
 import org.folio.inventory.dataimport.ItemWriterFactory;
@@ -66,6 +67,7 @@ import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.mapper.reader.record.marc.MarcBibReaderFactory;
 import org.folio.processing.mapping.mapper.reader.record.marc.MarcHoldingsReaderFactory;
+import org.folio.processing.matching.MatchingManager;
 import org.folio.processing.matching.loader.MatchValueLoaderFactory;
 import org.folio.processing.matching.reader.MarcValueReaderImpl;
 import org.folio.processing.matching.reader.MatchValueReaderFactory;
@@ -164,6 +166,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     MappingManager.registerWriterFactory(new InstanceWriterFactory());
     MappingManager.registerMapperFactory(new HoldingsMapperFactory());
     MappingManager.registerMapperFactory(new ItemsMapperFactory());
+    MatchingManager.registerMatcherFactory(new HoldingsItemMatcherFactory());
 
     PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper = new PrecedingSucceedingTitlesHelper(WebClient.wrap(client));
     EventManager.registerEventHandler(new MatchInstanceEventHandler(mappingMetadataCache));

--- a/src/main/java/org/folio/inventory/dataimport/entities/PartialError.java
+++ b/src/main/java/org/folio/inventory/dataimport/entities/PartialError.java
@@ -1,0 +1,27 @@
+package org.folio.inventory.dataimport.entities;
+
+public class PartialError {
+  private String id;
+  private String error;
+
+  public PartialError(String id, String error) {
+    this.id = id;
+    this.error = error;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getError() {
+    return error;
+  }
+
+  public void setError(String error) {
+    this.error = error;
+  }
+}

--- a/src/main/java/org/folio/inventory/dataimport/entities/PartialError.java
+++ b/src/main/java/org/folio/inventory/dataimport/entities/PartialError.java
@@ -3,6 +3,7 @@ package org.folio.inventory.dataimport.entities;
 public class PartialError {
   private String id;
   private String error;
+  private String holdingId;
 
   public PartialError(String id, String error) {
     this.id = id;
@@ -23,5 +24,13 @@ public class PartialError {
 
   public void setError(String error) {
     this.error = error;
+  }
+
+  public String getHoldingId() {
+    return holdingId;
+  }
+
+  public void setHoldingId(String holdingId) {
+    this.holdingId = holdingId;
   }
 }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
@@ -1,8 +1,10 @@
 package org.folio.inventory.dataimport.handlers.actions;
 
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -12,6 +14,7 @@ import org.folio.DataImportEventPayload;
 import org.folio.HoldingsRecord;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.dataimport.entities.PartialError;
 import org.folio.inventory.dataimport.services.OrderHelperService;
 import org.folio.inventory.dataimport.util.ParsedRecordUtil;
 import org.folio.inventory.domain.HoldingsRecordCollection;
@@ -27,14 +30,15 @@ import org.folio.processing.mapping.mapper.MappingContext;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.Record;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.logging.log4j.util.Strings.isNotEmpty;
 import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
 import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
@@ -50,14 +54,14 @@ public class CreateHoldingEventHandler implements EventHandler {
   private static final String RECORD_ID_HEADER = "recordId";
   private static final String CHUNK_ID_HEADER = "chunkId";
   private static final String HOLDINGS_PATH_FIELD = "holdings";
-  private static final String PERMANENT_LOCATION_ID_FIELD = "permanentLocationId";
-  private static final String PERMANENT_LOCATION_ID_ERROR_MESSAGE = "Can`t create Holding entity: 'permanentLocationId' is empty";
   private static final String CREATE_HOLDING_ERROR_MESSAGE = "Failed to create Holdings";
   private static final String CONTEXT_EMPTY_ERROR_MESSAGE = "Can`t create Holding entity: context is empty or doesn`t exists";
   private static final String PAYLOAD_DATA_HAS_NO_INSTANCE_ID_ERROR_MSG = "Failed to extract instanceId from instance entity or parsed record";
   private static final String MAPPING_METADATA_NOT_FOUND_MSG = "MappingMetadata snapshot was not found by jobExecutionId '%s'. RecordId: '%s', chunkId: '%s' ";
   static final String ACTION_HAS_NO_MAPPING_MSG = "Action profile to create a Holding entity requires a mapping profile";
   private static final String FOLIO_SOURCE_ID = "f32d531e-df79-46b3-8932-cdd35f7a2264";
+  private static final String ERRORS = "ERRORS";
+  private static final String BLANK = "";
   private final Storage storage;
   private final MappingMetadataCache mappingMetadataCache;
   private final IdStorageService idStorageService;
@@ -105,27 +109,28 @@ public class CreateHoldingEventHandler implements EventHandler {
               prepareEvent(dataImportEventPayload);
               MappingParameters mappingParameters = Json.decodeValue(mappingMetadataDto.getMappingParams(), MappingParameters.class);
               MappingManager.map(dataImportEventPayload, new MappingContext().withMappingParameters(mappingParameters));
-
-              JsonObject holdingAsJson = new JsonObject(payloadContext.get(HOLDINGS.value()));
-              if (holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD) != null) {
-                holdingAsJson = holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD);
+              JsonArray holdingsList = new JsonArray(payloadContext.get(HOLDINGS.value()));
+              for (int i = 0; i < holdingsList.size(); i++) {
+                JsonObject holdingAsJson = holdingsList.getJsonObject(i);
+                if (holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD) != null) {
+                  holdingAsJson = holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD);
+                  holdingsList.set(i, holdingAsJson);
+                }
+                holdingAsJson.put("id", (i == 0) ? holdingsId : UUID.randomUUID().toString());
+                holdingAsJson.put("sourceId", FOLIO_SOURCE_ID);
+                fillInstanceIdIfNeeded(dataImportEventPayload, holdingAsJson);
               }
-              holdingAsJson.put("id", holdingsId);
-              holdingAsJson.put("sourceId", FOLIO_SOURCE_ID);
-              fillInstanceIdIfNeeded(dataImportEventPayload, holdingAsJson);
-              checkIfPermanentLocationIdExists(holdingAsJson);
-              return Json.decodeValue(payloadContext.get(HOLDINGS.value()), HoldingsRecord.class);
+
+              dataImportEventPayload.getContext().put(HOLDINGS.value(), holdingsList.encode());
+              return List.of(Json.decodeValue(payloadContext.get(HOLDINGS.value()), HoldingsRecord[].class));
             })
-            .compose(holdingToCreate -> addHoldings(holdingToCreate, context))
+            .compose(holdingsToCreate -> addHoldings(holdingsToCreate, payloadContext, context))
             .onSuccess(createdHoldings -> {
-              LOGGER.info("Created Holding record by jobExecutionId: '{}' and recordId: '{}' and chunkId: '{}'",
+              LOGGER.info("Created Holdings records by jobExecutionId: '{}' and recordId: '{}' and chunkId: '{}'",
                 jobExecutionId, recordId, chunkId);
-              payloadContext.put(HOLDINGS.value(), Json.encodePrettily(createdHoldings));
+              payloadContext.put(HOLDINGS.value(), Json.encode(createdHoldings));
               orderHelperService.fillPayloadForOrderPostProcessingIfNeeded(dataImportEventPayload, DI_INVENTORY_HOLDING_CREATED, context)
-                .onComplete(result -> {
-                    future.complete(dataImportEventPayload);
-                  }
-                );
+                .onComplete(result -> future.complete(dataImportEventPayload));
             })
             .onFailure(e -> {
               if (!(e instanceof DuplicateEventException)) {
@@ -158,7 +163,7 @@ public class CreateHoldingEventHandler implements EventHandler {
 
   private void prepareEvent(DataImportEventPayload dataImportEventPayload) {
     dataImportEventPayload.getEventsChain().add(dataImportEventPayload.getEventType());
-    dataImportEventPayload.getContext().put(HOLDINGS.value(), new JsonObject().encode());
+    dataImportEventPayload.getContext().put(HOLDINGS.value(), new JsonArray().encode());
     dataImportEventPayload.setCurrentNode(dataImportEventPayload.getCurrentNode().getChildSnapshotWrappers().get(0));
   }
 
@@ -179,36 +184,53 @@ public class CreateHoldingEventHandler implements EventHandler {
       if (isBlank(instanceId)) {
         throw new EventProcessingException(PAYLOAD_DATA_HAS_NO_INSTANCE_ID_ERROR_MSG);
       }
-      fillInstanceId(dataImportEventPayload, holdingAsJson, instanceId);
+      fillInstanceId(holdingAsJson, instanceId);
     }
   }
 
-  private void checkIfPermanentLocationIdExists(JsonObject holdingAsJson) {
-    if (isEmpty(holdingAsJson.getString(PERMANENT_LOCATION_ID_FIELD))) {
-      throw new EventProcessingException(PERMANENT_LOCATION_ID_ERROR_MESSAGE);
-    }
-  }
-
-  private void fillInstanceId(DataImportEventPayload dataImportEventPayload, JsonObject holdingAsJson, String instanceId) {
+  private void fillInstanceId(JsonObject holdingAsJson, String instanceId) {
     holdingAsJson.put(INSTANCE_ID_FIELD, instanceId);
-    dataImportEventPayload.getContext().put(HOLDINGS.value(), holdingAsJson.encode());
   }
 
-  private Future<HoldingsRecord> addHoldings(HoldingsRecord holdings, Context context) {
-    Promise<HoldingsRecord> promise = Promise.promise();
+  private Future<List<HoldingsRecord>> addHoldings(List<HoldingsRecord> holdingsList, HashMap<String, String> payloadContext, Context context) {
+    Promise<List<HoldingsRecord>> holdingsPromise = Promise.promise();
+    List<HoldingsRecord> createdHoldingsRecord = new ArrayList<>();
+    List<PartialError> errors = new ArrayList<>();
+    List<Future> createHoldingsRecordFutures = new ArrayList<>();
+
     HoldingsRecordCollection holdingsRecordCollection = storage.getHoldingsRecordCollection(context);
-    holdingsRecordCollection.add(holdings,
-      success -> promise.complete(success.getResult()),
-      failure -> {
-        //for now there is a solution via error-message contains. It will be improved via another solution by https://issues.folio.org/browse/RMB-899.
-        if (isNotBlank(failure.getReason()) && failure.getReason().contains(UNIQUE_ID_ERROR_MESSAGE)) {
-          LOGGER.info("Duplicated event received by InstanceId: {}. Ignoring...", holdings.getId());
-          promise.fail(new DuplicateEventException(format("Duplicated event by Holding id: %s", holdings.getId())));
+    holdingsList.forEach(holdings -> {
+      Promise<Void> createPromise = Promise.promise();
+      createHoldingsRecordFutures.add(createPromise.future());
+      holdingsRecordCollection.add(holdings,
+        success -> {
+          createdHoldingsRecord.add(success.getResult());
+          createPromise.complete();
+        },
+        failure -> {
+          errors.add(new PartialError(holdings.getId() != null ? holdings.getId() : BLANK, failure.getReason()));
+          if (isNotBlank(failure.getReason()) && failure.getReason().contains(UNIQUE_ID_ERROR_MESSAGE)) {
+            LOGGER.info("Duplicated event received by Holding id: {}. Ignoring...", holdings.getId());
+            createPromise.fail(new DuplicateEventException(format("Duplicated event by Holding id: %s", holdings.getId())));
+          } else {
+            LOGGER.warn(format("Error posting Holdings cause %s, status code %s", failure.getReason(), failure.getStatusCode()));
+            createPromise.complete();
+          }
+        });
+    });
+    CompositeFuture.all(createHoldingsRecordFutures).onComplete(ar -> {
+      if (ar.succeeded()) {
+        String errorsAsStringJson = Json.encode(errors);
+        if (createdHoldingsRecord.size() > 0) {
+          payloadContext.put(ERRORS, errorsAsStringJson);
+          holdingsPromise.complete(createdHoldingsRecord);
         } else {
-          LOGGER.error(format("Error posting Holdings cause %s, status code %s", failure.getReason(), failure.getStatusCode()));
-          promise.fail(failure.getReason());
+          holdingsPromise.fail(errorsAsStringJson);
         }
-      });
-    return promise.future();
+      } else {
+        holdingsPromise.fail(ar.cause());
+      }
+    });
+    return holdingsPromise.future();
   }
 }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -161,7 +161,10 @@ public class CreateItemEventHandler implements EventHandler {
                 })
                 .onFailure(cause -> {
                   String itemId = itemAsJson.getString(ITEM_ID_FIELD) != null ? itemAsJson.getString(ITEM_ID_FIELD) : BLANK;
-                  multipleItemsCreateErrors.add(new PartialError(itemId, cause.getMessage()));
+                  String holdingId = itemAsJson.getString(HOLDINGS_RECORD_ID_FIELD) != null ? itemAsJson.getString(HOLDINGS_RECORD_ID_FIELD) : BLANK;
+                  PartialError partialError = new PartialError(itemId, cause.getMessage());
+                  partialError.setHoldingId(holdingId);
+                  multipleItemsCreateErrors.add(partialError);
                   if (cause instanceof DuplicateEventException) {
                     createItemPromise.fail(cause);
                   } else {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -1,8 +1,10 @@
 package org.folio.inventory.dataimport.handlers.actions;
 
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -12,9 +14,9 @@ import org.folio.DataImportEventPayload;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.api.request.PagingParameters;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.dataimport.entities.PartialError;
 import org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil;
 import org.folio.inventory.dataimport.services.OrderHelperService;
-import org.folio.inventory.dataimport.util.ParsedRecordUtil;
 import org.folio.inventory.domain.items.CirculationNote;
 import org.folio.inventory.domain.items.Item;
 import org.folio.inventory.domain.items.ItemCollection;
@@ -32,16 +34,17 @@ import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.processing.mapping.mapper.MappingContext;
 import org.folio.rest.jaxrs.model.EntityType;
-import org.folio.rest.jaxrs.model.Record;
 
 import java.io.UnsupportedEncodingException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -60,7 +63,8 @@ import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTI
 public class CreateItemEventHandler implements EventHandler {
 
   private static final String PAYLOAD_HAS_NO_DATA_MSG = "Failed to handle event payload, cause event payload context does not contain MARC_BIBLIOGRAPHIC data";
-  private static final String PAYLOAD_DATA_HAS_NO_HOLDING_ID_MSG = "Failed to extract holdingsRecordId from holdingsRecord entity or parsed record";
+  private static final String PAYLOAD_DATA_HAS_NO_HOLDINGS = "Failed to extract holdingsRecord from payload";
+  private static final String HOLDING_PERMANENT_LOCATION_SHOULD_NOT_BE_BLANK = "Holding permanent location id should not be blank";
   private static final String PAYLOAD_DATA_HAS_NO_PO_LINE_ID_MSG = "Failed to extract poLineId from poLine entity";
   private static final String MAPPING_METADATA_NOT_FOUND_MSG = "MappingMetadata snapshot was not found by jobExecutionId '%s'. RecordId: '%s', chunkId: '%s' ";
   static final String ACTION_HAS_NO_MAPPING_MSG = "Action profile to create an Item requires a mapping profile";
@@ -71,6 +75,10 @@ public class CreateItemEventHandler implements EventHandler {
   public static final String PO_LINE_ID_FIELD = "id";
   private static final String RECORD_ID_HEADER = "recordId";
   private static final String CHUNK_ID_HEADER = "chunkId";
+  private static final String ERRORS = "ERRORS";
+  private static final String HOLDING_PERMANENT_LOCATION_ID = "permanentLocationId";
+  private static final String HOLDING_IDENTIFIERS = "HOLDINGS_IDENTIFIERS";
+  private static final String BLANK = "";
   private static final Map<String, String> validNotes = Map.of(
     "Check in note", "Check in",
     "Check out note", "Check out");
@@ -115,7 +123,7 @@ public class CreateItemEventHandler implements EventHandler {
 
       dataImportEventPayload.getEventsChain().add(dataImportEventPayload.getEventType());
       dataImportEventPayload.setCurrentNode(dataImportEventPayload.getCurrentNode().getChildSnapshotWrappers().get(0));
-      dataImportEventPayload.getContext().put(ITEM.value(), new JsonObject().encode());
+      dataImportEventPayload.getContext().put(ITEM.value(), new JsonArray().encode());
 
       String jobExecutionId = dataImportEventPayload.getJobExecutionId();
       String recordId = dataImportEventPayload.getContext().get(RECORD_ID_HEADER);
@@ -124,7 +132,7 @@ public class CreateItemEventHandler implements EventHandler {
 
       Future<RecordToEntity> recordToItemFuture = idStorageService.store(recordId, UUID.randomUUID().toString(), dataImportEventPayload.getTenant());
       recordToItemFuture.onSuccess(res -> {
-        String itemId = res.getEntityId();
+        String deduplicationItemId = res.getEntityId();
         Context context = EventHandlingUtil.constructContext(dataImportEventPayload.getTenant(), dataImportEventPayload.getToken(), dataImportEventPayload.getOkapiUrl());
         ItemCollection itemCollection = storage.getItemCollection(context);
 
@@ -135,30 +143,58 @@ public class CreateItemEventHandler implements EventHandler {
           .map(mappingMetadataDto -> {
             MappingParameters mappingParameters = Json.decodeValue(mappingMetadataDto.getMappingParams(), MappingParameters.class);
             MappingManager.map(dataImportEventPayload, new MappingContext().withMappingParameters(mappingParameters));
-            return processMappingResult(dataImportEventPayload, itemId);
+            return processMappingResult(dataImportEventPayload, deduplicationItemId);
           })
-          .compose(mappedItemJson -> {
-            List<String> errors = validateItem(mappedItemJson, requiredFields);
-            if (!errors.isEmpty()) {
-              String msg = format("Mapped Item is invalid: %s, by jobExecutionId: '%s' and recordId: '%s' and chunkId: '%s' ", errors,
-                jobExecutionId, recordId, chunkId);
-              LOG.error(msg);
-              return Future.failedFuture(msg);
-            }
+          .compose(mappedItemList -> {
+            Promise<List<Item>> createMultipleItemsPromise = Promise.promise();
+            List<PartialError> multipleItemsCreateErrors = new ArrayList<>();
+            List<Future> createItemsFutures = new ArrayList<>();
+            List<Item> createdItems = new ArrayList<>();
 
-            Item mappedItem = ItemUtil.jsonToItem(mappedItemJson);
-            return isItemBarcodeUnique(mappedItemJson.getString("barcode"), itemCollection)
-              .compose(isUnique -> isUnique
-                ? addItem(mappedItem, itemCollection)
-                : Future.failedFuture(format("Barcode must be unique, %s is already assigned to another item", mappedItemJson.getString("barcode"))));
+            mappedItemList.forEach(e -> {
+              JsonObject itemAsJson = getItemFromJson((JsonObject) e);
+              Promise<Item> createItemPromise = Promise.promise();
+              processSingleItem(jobExecutionId, recordId, chunkId, itemCollection, itemAsJson)
+                .onSuccess(item -> {
+                  createdItems.add(item);
+                  createItemPromise.complete();
+                })
+                .onFailure(cause -> {
+                  String itemId = itemAsJson.getString(ITEM_ID_FIELD) != null ? itemAsJson.getString(ITEM_ID_FIELD) : BLANK;
+                  multipleItemsCreateErrors.add(new PartialError(itemId, cause.getMessage()));
+                  if (cause instanceof DuplicateEventException) {
+                    createItemPromise.fail(cause);
+                  } else {
+                    createItemPromise.complete();
+                  }
+                });
+
+              createItemsFutures.add(createItemPromise.future());
+            });
+
+            CompositeFuture.all(createItemsFutures).onComplete(ar -> {
+              if (payloadContext.containsKey(ERRORS) || !multipleItemsCreateErrors.isEmpty()) {
+                payloadContext.put(ERRORS, Json.encode(multipleItemsCreateErrors));
+              }
+              if (ar.succeeded()) {
+                String multipleItemsCreateErrorsAsStringJson = Json.encode(multipleItemsCreateErrors);
+                if (createdItems.size() > 0) {
+                  payloadContext.put(ERRORS, multipleItemsCreateErrorsAsStringJson);
+                  createMultipleItemsPromise.complete(createdItems);
+                } else {
+                  createMultipleItemsPromise.fail(multipleItemsCreateErrorsAsStringJson);
+                }
+              } else {
+                createMultipleItemsPromise.fail(ar.cause());
+              }
+            });
+            return createMultipleItemsPromise.future();
           })
           .onComplete(ar -> {
             if (ar.succeeded()) {
               dataImportEventPayload.getContext().put(ITEM.value(), Json.encode(ar.result()));
               orderHelperService.fillPayloadForOrderPostProcessingIfNeeded(dataImportEventPayload, DI_INVENTORY_ITEM_CREATED, context)
-                .onComplete(result -> {
-                    future.complete(dataImportEventPayload);
-                  }
+                .onComplete(result -> future.complete(dataImportEventPayload)
                 );
             } else {
               if (!(ar.cause() instanceof DuplicateEventException)) {
@@ -180,15 +216,41 @@ public class CreateItemEventHandler implements EventHandler {
     return future;
   }
 
-  private JsonObject processMappingResult(DataImportEventPayload dataImportEventPayload, String itemId) {
-    JsonObject itemAsJson = new JsonObject(dataImportEventPayload.getContext().get(ITEM.value()));
-    if (itemAsJson.getJsonObject(ITEM_PATH_FIELD) != null) {
-      itemAsJson = itemAsJson.getJsonObject(ITEM_PATH_FIELD);
+  private Future<Item> processSingleItem(String jobExecutionId, String recordId, String chunkId, ItemCollection itemCollection, JsonObject mappedItemJson) {
+    List<String> errors = validateItem(mappedItemJson, requiredFields);
+    if (!errors.isEmpty()) {
+      String msg = format("Mapped Item is invalid: %s, by jobExecutionId: '%s' and recordId: '%s' and chunkId: '%s' ", errors,
+        jobExecutionId, recordId, chunkId);
+      LOG.warn(msg);
+      return Future.failedFuture(msg);
     }
-    fillPoLineIdIfNecessary(dataImportEventPayload, itemAsJson);
-    fillHoldingsRecordIdIfNecessary(dataImportEventPayload, itemAsJson);
-    itemAsJson.put(ITEM_ID_FIELD, itemId);
-    return itemAsJson;
+    Item mappedItem = ItemUtil.jsonToItem(mappedItemJson);
+    return isItemBarcodeUnique(mappedItemJson.getString("barcode"), itemCollection)
+      .compose(isUnique -> isUnique
+        ? addItem(mappedItem, itemCollection)
+        : Future.failedFuture(format("Barcode must be unique, %s is already assigned to another item", mappedItemJson.getString("barcode"))));
+  }
+
+  private JsonArray processMappingResult(DataImportEventPayload dataImportEventPayload, String deduplicationItemId) {
+    JsonArray items = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
+    JsonArray mappedItems = new JsonArray();
+    JsonArray holdingsIdentifiers = new JsonArray(dataImportEventPayload.getContext().remove(HOLDING_IDENTIFIERS));
+    String holdingsAsString = dataImportEventPayload.getContext().get(EntityType.HOLDINGS.value());
+
+    for (int i = 0; i < items.size(); i++) {
+      JsonObject itemAsJson = getItemFromJson(items.getJsonObject(i));
+      String holdingPermanentLocation = holdingsIdentifiers.size() > i ? holdingsIdentifiers.getString(i) : null;
+      fillPoLineIdIfNecessary(dataImportEventPayload, itemAsJson);
+      if (fillHoldingsRecordIdIfNecessary(itemAsJson, holdingsAsString, holdingPermanentLocation)) {
+        mappedItems.add(itemAsJson);
+      }
+    }
+
+    for (int i = 0; i < mappedItems.size(); i++) {
+      JsonObject itemAsJson = getItemFromJson(mappedItems.getJsonObject(i));
+      itemAsJson.put(ITEM_ID_FIELD, (i == 0) ? deduplicationItemId : UUID.randomUUID().toString());
+    }
+    return mappedItems;
   }
 
   @Override
@@ -217,26 +279,37 @@ public class CreateItemEventHandler implements EventHandler {
     }
   }
 
-  private void fillHoldingsRecordIdIfNecessary(DataImportEventPayload dataImportEventPayload, JsonObject itemAsJson) {
+  private boolean fillHoldingsRecordIdIfNecessary(JsonObject itemAsJson, String holdingsAsString, String holdingPermanentLocation) {
     if (isBlank(itemAsJson.getString(HOLDINGS_RECORD_ID_FIELD))) {
-      String holdingsId = null;
-      String holdingAsString = dataImportEventPayload.getContext().get(EntityType.HOLDINGS.value());
-
-      if (StringUtils.isNotEmpty(holdingAsString)) {
-        JsonObject holdingsRecord = new JsonObject(holdingAsString);
-        holdingsId = holdingsRecord.getString(HOLDING_ID_FIELD);
+      String holdingId;
+      if (StringUtils.isNotEmpty(holdingsAsString)) {
+        holdingId = getHoldingByPermanentLocation(holdingsAsString, holdingPermanentLocation);
+      } else {
+        LOG.warn(PAYLOAD_DATA_HAS_NO_HOLDINGS);
+        throw new EventProcessingException(PAYLOAD_DATA_HAS_NO_HOLDINGS);
       }
-      if (isBlank(holdingsId)) {
-        String recordAsString = dataImportEventPayload.getContext().get(EntityType.MARC_BIBLIOGRAPHIC.value());
-        Record record = Json.decodeValue(recordAsString, Record.class);
-        holdingsId = ParsedRecordUtil.getAdditionalSubfieldValue(record.getParsedRecord(), ParsedRecordUtil.AdditionalSubfields.H);
-      }
-      if (isBlank(holdingsId)) {
-        LOG.error(PAYLOAD_DATA_HAS_NO_HOLDING_ID_MSG);
-        throw new EventProcessingException(PAYLOAD_DATA_HAS_NO_HOLDING_ID_MSG);
-      }
-      itemAsJson.put(HOLDINGS_RECORD_ID_FIELD, holdingsId);
+      if (holdingId == null) return false;
+      itemAsJson.put(HOLDINGS_RECORD_ID_FIELD, holdingId);
     }
+    return true;
+  }
+
+  private static String getHoldingByPermanentLocation(String holdingsAsString, String holdingPermanentLocation) {
+    JsonArray holdingsRecords = new JsonArray(holdingsAsString);
+    if (holdingsRecords.size() == 1) {
+      return holdingsRecords.getJsonObject(0).getString(HOLDING_ID_FIELD);
+    }
+
+    if (holdingPermanentLocation == null) {
+      LOG.debug("getHoldingByPermanentLocation:: " + HOLDING_PERMANENT_LOCATION_SHOULD_NOT_BE_BLANK);
+      return null;
+    }
+
+    Optional<JsonObject> correspondingHolding = holdingsRecords.stream()
+      .map(e -> (JsonObject) e)
+      .filter(holding -> StringUtils.equals(holding.getString(HOLDING_PERMANENT_LOCATION_ID), holdingPermanentLocation)).findFirst();
+
+    return correspondingHolding.map(entries -> entries.getString(HOLDING_ID_FIELD)).orElse(null);
   }
 
   private void validateStatusName(JsonObject itemAsJson, List<String> errors) {
@@ -291,10 +364,17 @@ public class CreateItemEventHandler implements EventHandler {
           LOG.info("addItem:: Duplicated event received by ItemId: {}. Ignoring...", item.getId());
           promise.fail(new DuplicateEventException(format("Duplicated event by Item id: %s", item.getId())));
         } else {
-          LOG.error(format("addItem:: Error posting Item cause %s, status code %s", failure.getReason(), failure.getStatusCode()));
+          LOG.warn(format("addItem:: Error posting Item cause %s, status code %s", failure.getReason(), failure.getStatusCode()));
           promise.fail(failure.getReason());
         }
       });
     return promise.future();
+  }
+
+  private JsonObject getItemFromJson(JsonObject itemAsJson) {
+    if (itemAsJson.getJsonObject(ITEM_PATH_FIELD) != null) {
+      return itemAsJson.getJsonObject(ITEM_PATH_FIELD);
+    }
+    return itemAsJson;
   }
 }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
@@ -135,8 +135,8 @@ public class UpdateHoldingEventHandler implements EventHandler {
             updatedHoldingsRecordFutures.add(updatePromise.future());
             holdingsRecordCollection.update(holding,
               success -> {
-                constructDataImportEventPayload(updatePromise, dataImportEventPayload, list, context, errors);
                 updatedHoldingsRecord.add(holding);
+                constructDataImportEventPayload(updatePromise, dataImportEventPayload, list, context, errors);
               },
               failure -> {
                 errors.add(new PartialError(holding.getId() != null ? holding.getId() : BLANK, failure.getReason()));
@@ -228,7 +228,7 @@ public class UpdateHoldingEventHandler implements EventHandler {
     JsonArray holdingsJsonArray = new JsonArray(dataImportEventPayload.getContext().get(HOLDINGS.value()));
     for (int i = 0; i < holdingsJsonArray.size(); i++) {
       JsonObject holdingAsJson = holdingsJsonArray.getJsonObject(i);
-      holdingAsJson = holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD);
+      holdingAsJson = holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD) != null ? holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD) : holdingAsJson;
       holdingsJsonArray.set(i, new JsonObject().put(HOLDINGS_PATH_FIELD, holdingAsJson));
     }
     dataImportEventPayload.getContext().put(HOLDINGS.value(), holdingsJsonArray.encode());

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
@@ -1,6 +1,10 @@
 package org.folio.inventory.dataimport.handlers.actions;
 
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import org.apache.commons.lang3.StringUtils;
@@ -12,8 +16,8 @@ import org.folio.DataImportEventPayload;
 import org.folio.HoldingsRecord;
 import org.folio.dbschema.ObjectMapperTool;
 import org.folio.inventory.common.Context;
-import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.dataimport.entities.PartialError;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.domain.items.ItemCollection;
 import org.folio.inventory.storage.Storage;
@@ -25,12 +29,13 @@ import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingPa
 import org.folio.processing.mapping.mapper.MappingContext;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import static java.lang.String.format;
-import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.ActionProfile.Action.UPDATE;
 import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
@@ -63,9 +68,11 @@ public class UpdateHoldingEventHandler implements EventHandler {
   private static final String CURRENT_NODE_PROPERTY = "CURRENT_NODE";
   private static final String CANNOT_UPDATE_HOLDING_ERROR_MESSAGE = "Error updating Holding by holdingId '%s' and jobExecution '%s' recordId '%s' chunkId '%s' - %s, status code %s";
   private static final String CANNOT_GET_ACTUAL_ITEM_MESSAGE = "Cannot get actual Item after successfully updating holdings, by ITEM id: '%s' - '%s', status code '%s'";
-
+  private static final String BLANK = "";
+  private static final String ERRORS = "ERRORS";
   private final Storage storage;
   private final MappingMetadataCache mappingMetadataCache;
+  boolean isPayloadConstructed = false;
 
   public UpdateHoldingEventHandler(Storage storage, MappingMetadataCache mappingMetadataCache) {
     this.storage = storage;
@@ -91,21 +98,16 @@ public class UpdateHoldingEventHandler implements EventHandler {
       }
 
       LOGGER.info("Processing UpdateHoldingEventHandler starting with jobExecutionId: {}.", dataImportEventPayload.getJobExecutionId());
+      List<PartialError> errors = new ArrayList<>();
 
-      HoldingsRecord tmpHoldingsRecord = retrieveHolding(dataImportEventPayload.getContext());
-
-      String holdingId = tmpHoldingsRecord.getId();
-      String hrid = tmpHoldingsRecord.getHrid();
-      String instanceId = tmpHoldingsRecord.getInstanceId();
-      String permanentLocationId = tmpHoldingsRecord.getPermanentLocationId();
-      if (StringUtils.isAnyBlank(hrid, instanceId, permanentLocationId, holdingId)) {
-        LOGGER.warn("Can`t update Holding entity hrid: {}, instanceId: {}, permanentLocationId: {}, holdingId: {}", hrid, instanceId, permanentLocationId, holdingId);
-        throw new EventProcessingException(EMPTY_REQUIRED_FIELDS_ERROR_MESSAGE);
+      validateRequiredHoldingsFields(dataImportEventPayload, errors);
+      if (!errors.isEmpty()) {
+        dataImportEventPayload.getContext().put(ERRORS, Json.encode(errors));
+        future.complete(dataImportEventPayload);
+        return future;
       }
-
       Context context = constructContext(dataImportEventPayload.getTenant(), dataImportEventPayload.getToken(), dataImportEventPayload.getOkapiUrl());
       String jobExecutionId = dataImportEventPayload.getJobExecutionId();
-
       String recordId = dataImportEventPayload.getContext().get(RECORD_ID_HEADER);
       String chunkId = dataImportEventPayload.getContext().get(CHUNK_ID_HEADER);
       LOGGER.info("Update holding with jobExecutionId: {} , recordId: {} , chunkId: {}", jobExecutionId, recordId, chunkId);
@@ -119,20 +121,50 @@ public class UpdateHoldingEventHandler implements EventHandler {
           MappingParameters mappingParameters = Json.decodeValue(mappingMetadataDto.getMappingParams(), MappingParameters.class);
           MappingManager.map(dataImportEventPayload, new MappingContext().withMappingParameters(mappingParameters));
 
-          HoldingsRecordCollection holdingsRecords = storage.getHoldingsRecordCollection(context);
-          HoldingsRecord holding = retrieveHolding(dataImportEventPayload.getContext());
+          HoldingsRecordCollection holdingsRecordsCollection = storage.getHoldingsRecordCollection(context);
+          List<HoldingsRecord> updatedHoldingsRecord = new ArrayList<>();
+          List<Future> updatedHoldingsRecordFutures = new ArrayList<>();
+          isPayloadConstructed = false;
+          convertHoldings(dataImportEventPayload);
+          List<HoldingsRecord> list = List.of(Json.decodeValue(dataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord[].class));
 
-          holdingsRecords.update(holding, holdingSuccess -> constructDataImportEventPayload(future, dataImportEventPayload, holding, context),
-            failure -> {
-              if (failure.getStatusCode() == HttpStatus.SC_CONFLICT) {
-                processOLError(dataImportEventPayload, future, holdingsRecords, holding, failure);
-              } else {
-                dataImportEventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
-                LOGGER.error(format(CANNOT_UPDATE_HOLDING_ERROR_MESSAGE, holding.getId(), jobExecutionId, recordId, chunkId, failure.getReason(), failure.getStatusCode()));
-                future.completeExceptionally(new EventProcessingException(format(UPDATE_HOLDING_ERROR_MESSAGE, jobExecutionId,
-                  recordId, chunkId)));
-              }
-            });
+          HoldingsRecordCollection holdingsRecordCollection = storage.getHoldingsRecordCollection(context);
+          List<HoldingsRecord> expiredHoldings = new ArrayList<>();
+          for (HoldingsRecord holding : list) {
+            Promise<Void> updatePromise = Promise.promise();
+            updatedHoldingsRecordFutures.add(updatePromise.future());
+            holdingsRecordCollection.update(holding,
+              success -> {
+                constructDataImportEventPayload(updatePromise, dataImportEventPayload, list, context, errors);
+                updatedHoldingsRecord.add(holding);
+              },
+              failure -> {
+                errors.add(new PartialError(holding.getId() != null ? holding.getId() : BLANK, failure.getReason()));
+                if (failure.getStatusCode() == HttpStatus.SC_CONFLICT) {
+                  expiredHoldings.add(holding);
+                  updatePromise.complete();
+                } else {
+                  dataImportEventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
+                  LOGGER.error(format(CANNOT_UPDATE_HOLDING_ERROR_MESSAGE, holding.getId(), jobExecutionId, recordId, chunkId, failure.getReason(), failure.getStatusCode()));
+                  updatePromise.fail(new EventProcessingException(format(UPDATE_HOLDING_ERROR_MESSAGE, jobExecutionId,
+                    recordId, chunkId)));
+                }
+              });
+          }
+          CompositeFuture.all(updatedHoldingsRecordFutures).onComplete(ar -> {
+            if (!expiredHoldings.isEmpty()) {
+              processOLError(dataImportEventPayload, future, holdingsRecordsCollection, expiredHoldings.get(0), errors);
+            }
+            if (dataImportEventPayload.getContext().containsKey(ERRORS) || !errors.isEmpty()) {
+              dataImportEventPayload.getContext().put(ERRORS, Json.encode(errors));
+            }
+            if (ar.succeeded()) {
+              dataImportEventPayload.getContext().put(HOLDINGS.value(), Json.encode(updatedHoldingsRecord));
+              future.complete(dataImportEventPayload);
+            } else {
+              future.completeExceptionally(ar.cause());
+            }
+          });
         })
         .onFailure(e -> {
           LOGGER.error("Error updating inventory Holdings by jobExecutionId: '{}'", jobExecutionId, e);
@@ -145,6 +177,38 @@ public class UpdateHoldingEventHandler implements EventHandler {
     return future;
   }
 
+  private static void convertHoldings(DataImportEventPayload dataImportEventPayload) {
+    JsonArray holdingsJsonArray = new JsonArray(dataImportEventPayload.getContext().get(HOLDINGS.value()));
+    for (int i = 0; i < holdingsJsonArray.size(); i++) {
+      JsonObject holdingAsJson = holdingsJsonArray.getJsonObject(i);
+      if (holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD) != null) {
+        holdingAsJson = holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD);
+        holdingsJsonArray.set(i, holdingAsJson);
+      }
+    }
+    dataImportEventPayload.getContext().put(HOLDINGS.value(), holdingsJsonArray.encode());
+  }
+
+  private static void validateRequiredHoldingsFields(DataImportEventPayload dataImportEventPayload, List<PartialError> errors) {
+    JsonArray holdingsList = new JsonArray(dataImportEventPayload.getContext().get(HOLDINGS.value()));
+    for (int i = 0; i < holdingsList.size(); i++) {
+
+      JsonObject holdingAsJson = holdingsList.getJsonObject(i);
+      if (holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD) != null) {
+        holdingAsJson = holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD);
+        HoldingsRecord tmpHoldingsRecord = Json.decodeValue(String.valueOf(holdingAsJson), HoldingsRecord.class);
+        String holdingId = tmpHoldingsRecord.getId();
+        String hrid = tmpHoldingsRecord.getHrid();
+        String instanceId = tmpHoldingsRecord.getInstanceId();
+        String permanentLocationId = tmpHoldingsRecord.getPermanentLocationId();
+        if (StringUtils.isAnyBlank(hrid, instanceId, permanentLocationId, holdingId)) {
+          LOGGER.warn("Can`t update Holding entity hrid: {}, instanceId: {}, permanentLocationId: {}, holdingId: {}", hrid, instanceId, permanentLocationId, holdingId);
+          errors.add(new PartialError(holdingId != null ? holdingId : BLANK, EMPTY_REQUIRED_FIELDS_ERROR_MESSAGE));
+        }
+      }
+    }
+  }
+
   @Override
   public boolean isEligible(DataImportEventPayload dataImportEventPayload) {
     if (dataImportEventPayload.getCurrentNode() != null && ACTION_PROFILE == dataImportEventPayload.getCurrentNode().getContentType()) {
@@ -154,47 +218,62 @@ public class UpdateHoldingEventHandler implements EventHandler {
     return false;
   }
 
-  private HoldingsRecord retrieveHolding(HashMap<String, String> context) {
-    return (isNull(new JsonObject(context.get(HOLDINGS.value())).getJsonObject(HOLDINGS_PATH_FIELD))) ?
-      Json.decodeValue(context.get(HOLDINGS.value()), HoldingsRecord.class) :
-      Json.decodeValue(String.valueOf(new JsonObject(context.get(HOLDINGS.value())).getJsonObject(HOLDINGS_PATH_FIELD)), HoldingsRecord.class);
-  }
-
   private void prepareEvent(DataImportEventPayload dataImportEventPayload) {
     dataImportEventPayload.getContext().put(CURRENT_EVENT_TYPE_PROPERTY, dataImportEventPayload.getEventType());
     dataImportEventPayload.getContext().put(CURRENT_NODE_PROPERTY, Json.encode(dataImportEventPayload.getCurrentNode()));
     dataImportEventPayload.getContext().put(CURRENT_HOLDING_PROPERTY, Json.encode(dataImportEventPayload.getContext().get(HOLDINGS.value())));
 
     dataImportEventPayload.getEventsChain().add(dataImportEventPayload.getEventType());
-    JsonObject jsonHoldings = new JsonObject(dataImportEventPayload.getContext().get(HOLDINGS.value()));
-    dataImportEventPayload.getContext().put(HOLDINGS.value(), new JsonObject().put(HOLDINGS_PATH_FIELD, jsonHoldings).encode());
+
+    JsonArray holdingsJsonArray = new JsonArray(dataImportEventPayload.getContext().get(HOLDINGS.value()));
+    for (int i = 0; i < holdingsJsonArray.size(); i++) {
+      JsonObject holdingAsJson = holdingsJsonArray.getJsonObject(i);
+      holdingAsJson = holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD);
+      holdingsJsonArray.set(i, new JsonObject().put(HOLDINGS_PATH_FIELD, holdingAsJson));
+    }
+    dataImportEventPayload.getContext().put(HOLDINGS.value(), holdingsJsonArray.encode());
     dataImportEventPayload.setCurrentNode(dataImportEventPayload.getCurrentNode().getChildSnapshotWrappers().get(0));
   }
 
-  private void processOLError(DataImportEventPayload dataImportEventPayload, CompletableFuture<DataImportEventPayload> future, HoldingsRecordCollection holdingsRecords, HoldingsRecord holding, Failure failure) {
-    int currentRetryNumber = dataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER)  == null ? 0 : Integer.parseInt(dataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER));
+  private void processOLError(DataImportEventPayload dataImportEventPayload, CompletableFuture<DataImportEventPayload> future, HoldingsRecordCollection holdingsRecords, HoldingsRecord holding, List<PartialError> errors) {
+    int currentRetryNumber = dataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER) == null ? 0 : Integer.parseInt(dataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER));
     if (currentRetryNumber < MAX_RETRIES_COUNT) {
       dataImportEventPayload.getContext().put(CURRENT_RETRY_NUMBER, String.valueOf(currentRetryNumber + 1));
-      LOGGER.warn("Error updating Holding by id '{}' - '{}', status code '{}'. Retry UpdateHoldingEventHandler handler...", holding.getId(), failure.getReason(), failure.getStatusCode());
+      LOGGER.warn("Error updating Holding by id '{}'. Retry UpdateHoldingEventHandler handler...", holding.getId());
       holdingsRecords.findById(holding.getId())
-        .thenAccept(actualInstance -> prepareDataAndReInvokeCurrentHandler(dataImportEventPayload, future, actualInstance))
+        .thenAccept(actuaHoldings -> prepareDataAndReInvokeCurrentHandler(dataImportEventPayload, future, actuaHoldings))
         .exceptionally(e -> {
           dataImportEventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
           String errMessage = format("Cannot get actual Holding by id: '%s' for jobExecutionId '%s'. Error: %s ", holding.getId(), dataImportEventPayload.getJobExecutionId(), e.getCause());
           LOGGER.error(errMessage);
-          future.completeExceptionally(new EventProcessingException(errMessage));
+          errors.add(new PartialError(holding.getId() != null ? holding.getId() : BLANK, errMessage));
+          future.complete(dataImportEventPayload);
           return null;
         });
     } else {
       dataImportEventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
       String errMessage = format("Current retry number %s exceeded or equal given number %s for the Holding update for jobExecutionId '%s' ", MAX_RETRIES_COUNT, currentRetryNumber, dataImportEventPayload.getJobExecutionId());
       LOGGER.error(errMessage);
-      future.completeExceptionally(new EventProcessingException(errMessage));
+      errors.add(new PartialError(holding.getId() != null ? holding.getId() : BLANK, errMessage));
+      future.complete(dataImportEventPayload);
     }
   }
 
   private void prepareDataAndReInvokeCurrentHandler(DataImportEventPayload dataImportEventPayload, CompletableFuture<DataImportEventPayload> future, HoldingsRecord actualHolding) {
-    dataImportEventPayload.getContext().put(HOLDINGS.value(), Json.encode(JsonObject.mapFrom(actualHolding)));
+    List<HoldingsRecord> holdingsList = List.of(Json.decodeValue(dataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord[].class));
+    List<HoldingsRecord> updatedHoldingsList = new ArrayList<>(holdingsList);
+    for (int i = 0; i < holdingsList.size(); i++) {
+      HoldingsRecord holdingsRecord = holdingsList.get(i);
+      if (holdingsRecord.getId().equals(actualHolding.getId())) {
+        updatedHoldingsList.set(i, actualHolding);
+      }
+    }
+
+    JsonArray resultedHoldings = new JsonArray();
+    for (HoldingsRecord currentHolding : updatedHoldingsList) {
+      resultedHoldings.add(new JsonObject().put("holdings", new JsonObject(Json.encode(currentHolding))));
+    }
+    dataImportEventPayload.getContext().put(HOLDINGS.value(), Json.encode(resultedHoldings)); // Convert to Array (find by id specific Holdings in array and update just current entity by id and reinvoke one more time)
     dataImportEventPayload.getEventsChain().remove(dataImportEventPayload.getContext().get(CURRENT_EVENT_TYPE_PROPERTY));
     try {
       dataImportEventPayload.setCurrentNode(ObjectMapperTool.getMapper().readValue(dataImportEventPayload.getContext().get(CURRENT_NODE_PROPERTY), ProfileSnapshotWrapper.class));
@@ -205,39 +284,48 @@ public class UpdateHoldingEventHandler implements EventHandler {
     dataImportEventPayload.getContext().remove(CURRENT_NODE_PROPERTY);
     dataImportEventPayload.getContext().remove(CURRENT_HOLDING_PROPERTY);
     handle(dataImportEventPayload).whenComplete((res, e) -> {
-      if (e != null) {
-        future.completeExceptionally(new EventProcessingException(e.getMessage()));
-      } else {
-        future.complete(dataImportEventPayload);
-      }
+      future.complete(dataImportEventPayload);
     });
   }
 
-  private void constructDataImportEventPayload(CompletableFuture<DataImportEventPayload> future, DataImportEventPayload dataImportEventPayload, HoldingsRecord holding, Context context) {
-    HashMap<String, String> payloadContext = dataImportEventPayload.getContext();
-    payloadContext.put(HOLDINGS.value(), Json.encodePrettily(holding));
-    if(payloadContext.containsKey(ITEM.value())) {
-      ItemCollection itemCollection = storage.getItemCollection(context);
-      updateDataImportEventPayloadItem(future, dataImportEventPayload, itemCollection);
+  private void constructDataImportEventPayload(Promise<Void> promise, DataImportEventPayload dataImportEventPayload, List<HoldingsRecord> holdings, Context context, List<PartialError> errors) {
+    if (!isPayloadConstructed) {
+      isPayloadConstructed = true;
+      HashMap<String, String> payloadContext = dataImportEventPayload.getContext();
+      payloadContext.put(HOLDINGS.value(), Json.encodePrettily(holdings));
+      if (payloadContext.containsKey(ITEM.value())) {
+        ItemCollection itemCollection = storage.getItemCollection(context);
+        updateDataImportEventPayloadItem(promise, dataImportEventPayload, itemCollection, errors);
+      } else {
+        promise.complete();
+      }
     } else {
-      future.complete(dataImportEventPayload);
+      promise.complete();
     }
   }
 
-  private void updateDataImportEventPayloadItem(CompletableFuture<DataImportEventPayload> future, DataImportEventPayload dataImportEventPayload, ItemCollection itemCollection) {
-    JsonObject oldItemAsJson = new JsonObject(dataImportEventPayload.getContext().get(ITEM.value()));
-    String itemId = oldItemAsJson.getString(ITEM_ID_HEADER);
-    itemCollection.findById(itemId, findResult -> {
-      if(Objects.nonNull(findResult)) {
-        JsonObject itemAsJson = new JsonObject(ItemUtil.mapToMappingResultRepresentation(findResult.getResult()));
-        dataImportEventPayload.getContext().put(ITEM.value(), Json.encode(itemAsJson));
-      }
-      future.complete(dataImportEventPayload);
-    }, failure -> {
-      EventProcessingException processingException =
-        new EventProcessingException(format(CANNOT_GET_ACTUAL_ITEM_MESSAGE, itemId, failure.getReason(), failure.getStatusCode()));
-      LOGGER.error(processingException);
-      future.completeExceptionally(processingException);
-    });
+  private void updateDataImportEventPayloadItem(Promise<Void> future, DataImportEventPayload dataImportEventPayload, ItemCollection itemCollection, List<PartialError> errors) {
+    JsonArray oldItemsAsJson = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
+    JsonArray resultedItemsList = new JsonArray();
+
+    for (int i = 0; i < oldItemsAsJson.size(); i++) {
+      JsonObject singleItemAsJson = oldItemsAsJson.getJsonObject(i);
+      String itemId = singleItemAsJson.getJsonObject("item").getString(ITEM_ID_HEADER);
+      itemCollection.findById(itemId, findResult -> {
+        if (Objects.nonNull(findResult)) {
+          JsonObject itemAsJson = new JsonObject(ItemUtil.mapToMappingResultRepresentation(findResult.getResult()));
+          resultedItemsList.add(itemAsJson);
+          dataImportEventPayload.getContext().put(ITEM.value(), Json.encode(itemAsJson));
+        }
+        future.complete();
+      }, failure -> {
+        errors.add(new PartialError(itemId != null ? itemId : BLANK, failure.getReason()));
+        EventProcessingException processingException =
+          new EventProcessingException(format(CANNOT_GET_ACTUAL_ITEM_MESSAGE, itemId, failure.getReason(), failure.getStatusCode()));
+        LOGGER.error(processingException);
+        future.complete();
+      });
+    }
+    dataImportEventPayload.getContext().put(ITEM.value(), resultedItemsList.encode());
   }
 }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -17,15 +17,19 @@ import java.io.UnsupportedEncodingException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.json.JsonArray;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
@@ -36,8 +40,8 @@ import org.folio.MappingMetadataDto;
 import org.folio.dbschema.ObjectMapperTool;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.api.request.PagingParameters;
-import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.dataimport.entities.PartialError;
 import org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.domain.items.Item;
@@ -63,8 +67,7 @@ import io.vertx.core.json.JsonObject;
 
 public class UpdateItemEventHandler implements EventHandler {
 
-  private static final Logger LOG = LogManager.getLogger(UpdateItemEventHandler.class);
-
+  private static final Logger LOGGER = LogManager.getLogger(UpdateItemEventHandler.class);
   static final String ACTION_HAS_NO_MAPPING_MSG = "Action profile to update an Item requires a mapping profile";
   private static final String PAYLOAD_HAS_NO_DATA_MSG = "Failed to handle event payload, cause event payload context does not contain MARC_BIBLIOGRAPHIC data or ITEM to update";
   private static final String STATUS_UPDATE_ERROR_MSG = "Could not change item status '%s' to '%s'";
@@ -77,7 +80,11 @@ public class UpdateItemEventHandler implements EventHandler {
   private static final int MAX_RETRIES_COUNT = Integer.parseInt(System.getenv().getOrDefault("inventory.di.ol.retry.number", "1"));
   private static final String CURRENT_EVENT_TYPE_PROPERTY = "CURRENT_EVENT_TYPE";
   private static final String CURRENT_NODE_PROPERTY = "CURRENT_NODE";
-
+  private static final String ERRORS = "ERRORS";
+  private static final String BLANK = "";
+  private static final String MULTIPLE_HOLDINGS_FIELD = "MULTIPLE_HOLDINGS_FIELD";
+  private static final String TEMPORARY_MULTIPLE_HOLDINGS_FIELD = "TEMPORARY_MULTIPLE_HOLDINGS_FIELD";
+  public static final String ID_PATH_FIELD = "id";
   private final List<String> requiredFields = Arrays.asList("status.name", "materialType.id", "permanentLoanType.id", "holdingsRecordId");
   private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZone(ZoneOffset.UTC);
 
@@ -91,27 +98,24 @@ public class UpdateItemEventHandler implements EventHandler {
 
   @Override
   public CompletableFuture<DataImportEventPayload> handle(DataImportEventPayload dataImportEventPayload) {
-    logParametersEventHandler(LOG, dataImportEventPayload);
+    logParametersEventHandler(LOGGER, dataImportEventPayload);
     CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
     try {
       dataImportEventPayload.setEventType(DI_INVENTORY_ITEM_UPDATED.value());
 
       HashMap<String, String> payloadContext = dataImportEventPayload.getContext();
       if (isNull(payloadContext) || isBlank(payloadContext.get(MARC_BIBLIOGRAPHIC.value()))
-        || isBlank(payloadContext.get(ITEM.value()))) {
-        LOG.error(PAYLOAD_HAS_NO_DATA_MSG);
+        || isBlank(payloadContext.get(ITEM.value())) || new JsonArray(payloadContext.get(ITEM.value())).isEmpty()) {
+        LOGGER.error(PAYLOAD_HAS_NO_DATA_MSG);
         return CompletableFuture.failedFuture(new EventProcessingException(PAYLOAD_HAS_NO_DATA_MSG));
       }
       if (dataImportEventPayload.getCurrentNode().getChildSnapshotWrappers().isEmpty()) {
-        LOG.error(ACTION_HAS_NO_MAPPING_MSG);
+        LOGGER.error(ACTION_HAS_NO_MAPPING_MSG);
         return CompletableFuture.failedFuture(new EventProcessingException(ACTION_HAS_NO_MAPPING_MSG));
       }
-      LOG.info("Processing UpdateItemEventHandler starting with jobExecutionId: {}.", dataImportEventPayload.getJobExecutionId());
-
-      AtomicBoolean isProtectedStatusChanged = new AtomicBoolean();
+      LOGGER.info("Processing UpdateItemEventHandler starting with jobExecutionId: {}.", dataImportEventPayload.getJobExecutionId());
       Context context = EventHandlingUtil.constructContext(dataImportEventPayload.getTenant(), dataImportEventPayload.getToken(), dataImportEventPayload.getOkapiUrl());
       String jobExecutionId = dataImportEventPayload.getJobExecutionId();
-
       String recordId = dataImportEventPayload.getContext().get(RECORD_ID_HEADER);
       String chunkId = dataImportEventPayload.getContext().get(CHUNK_ID_HEADER);
 
@@ -119,53 +123,93 @@ public class UpdateItemEventHandler implements EventHandler {
         .map(parametersOptional -> parametersOptional
           .orElseThrow(() -> new EventProcessingException(format(MAPPING_METADATA_NOT_FOUND_MSG, jobExecutionId,
             recordId, chunkId))))
-        .compose(mappingMetadataDto -> {
-          String oldItemStatus = preparePayloadAndGetStatus(dataImportEventPayload, payloadContext, mappingMetadataDto);
-
-          JsonObject mappedItemAsJson = new JsonObject(payloadContext.get(ITEM.value()));
-          mappedItemAsJson = mappedItemAsJson.containsKey(ITEM_PATH_FIELD) ? mappedItemAsJson.getJsonObject(ITEM_PATH_FIELD) : mappedItemAsJson;
-
-          List<String> errors = validateItem(mappedItemAsJson, requiredFields);
-          if (!errors.isEmpty()) {
-            String msg = format("Mapped Instance is invalid: %s, by jobExecutionId: '%s' and recordId: '%s' and chunkId: '%s' ", errors,
-              jobExecutionId, recordId, chunkId);
-            LOG.error(msg);
-            return Future.failedFuture(msg);
+        .onSuccess(mappingMetadataDto -> {
+          if (dataImportEventPayload.getContext().containsKey(MULTIPLE_HOLDINGS_FIELD)) {
+            dataImportEventPayload.getContext().put(TEMPORARY_MULTIPLE_HOLDINGS_FIELD, dataImportEventPayload.getContext().get(MULTIPLE_HOLDINGS_FIELD));
           }
-
-          String newItemStatus = mappedItemAsJson.getJsonObject(STATUS_KEY).getString("name");
-          isProtectedStatusChanged.set(isProtectedStatusChanged(oldItemStatus, newItemStatus));
-          if (isProtectedStatusChanged.get()) {
-            mappedItemAsJson.getJsonObject(STATUS_KEY).put("name", oldItemStatus);
-          }
+          Map<String, String> oldItemStatuses = preparePayloadAndGetStatus(dataImportEventPayload, payloadContext, mappingMetadataDto);
+          MappingParameters mappingParameters = Json.decodeValue(mappingMetadataDto.getMappingParams(), MappingParameters.class);
+          MappingManager.map(dataImportEventPayload, new MappingContext().withMappingParameters(mappingParameters));
 
           ItemCollection itemCollection = storage.getItemCollection(context);
-          Item itemToUpdate = ItemUtil.jsonToItem(mappedItemAsJson);
-          return verifyItemBarcodeUniqueness(itemToUpdate, itemCollection)
-            .compose(v -> updateItemAndRetryIfOLExists(itemToUpdate, itemCollection, dataImportEventPayload))
-            .onSuccess(updatedItem -> {
+          List<Future> updatedItemsRecordFutures = new ArrayList<>();
+          List<Item> updatedItemEntities = new ArrayList<>();
+          List<PartialError> errors = new ArrayList<>();
+
+          JsonArray itemsJsonArray = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
+          List<Item> expiredItems = new ArrayList<>();
+          for (int i = 0; i < itemsJsonArray.size(); i++) {
+            Promise<Void> updatePromise = Promise.promise();
+            updatedItemsRecordFutures.add(updatePromise.future());
+            JsonObject mappedItemAsJson = itemsJsonArray.getJsonObject(i);
+            mappedItemAsJson = mappedItemAsJson.getJsonObject(ITEM_PATH_FIELD);
+            List<String> validationErrors = validateItem(mappedItemAsJson, requiredFields);
+            if (!validationErrors.isEmpty()) {
+              String msg = format("Mapped Instance is invalid: %s, by jobExecutionId: '%s' and recordId: '%s' and chunkId: '%s' ", validationErrors,
+                jobExecutionId, recordId, chunkId);
+              LOGGER.error(msg);
+              dataImportEventPayload.getContext().put(ERRORS, Json.encode(validationErrors));
+              errors.add(new PartialError(mappedItemAsJson.getString(ID_PATH_FIELD) != null ? mappedItemAsJson.getString(ID_PATH_FIELD) : BLANK, msg));
+              updatePromise.complete();
+            } else {
+              String newItemStatus = mappedItemAsJson.getJsonObject(STATUS_KEY).getString("name");
+              AtomicBoolean isProtectedStatusChanged = new AtomicBoolean();
+              isProtectedStatusChanged.set(isProtectedStatusChanged(oldItemStatuses.get(mappedItemAsJson.getString(ID_PATH_FIELD)), newItemStatus));
               if (isProtectedStatusChanged.get()) {
-                String msg = String.format(STATUS_UPDATE_ERROR_MSG, oldItemStatus, newItemStatus);
-                LOG.warn(msg);
-                dataImportEventPayload.getContext().put(ITEM.value(), ItemUtil.mapToJson(updatedItem).encode());
-                future.completeExceptionally(new EventProcessingException(msg));
-              } else {
-                addHoldingToPayloadIfNeeded(dataImportEventPayload, context, updatedItem)
-                  .onComplete(item -> {
-                    dataImportEventPayload.getContext().put(ITEM.value(), ItemUtil.mapToJson(updatedItem).encode());
-                    future.complete(dataImportEventPayload);
-                  });
+                mappedItemAsJson.getJsonObject(STATUS_KEY).put("name", oldItemStatuses.get(mappedItemAsJson.getString(ID_PATH_FIELD)));
               }
-            });
+
+              Item itemToUpdate = ItemUtil.jsonToItem(mappedItemAsJson);
+              verifyItemBarcodeUniqueness(itemToUpdate, itemCollection, updatePromise, errors)
+                .compose(v -> updateItemAndRetryIfOLExists(itemToUpdate, itemCollection, dataImportEventPayload, updatePromise, errors, expiredItems))
+                .onSuccess(updatedItem -> {
+                  if (isProtectedStatusChanged.get()) {
+                    String msg = format(STATUS_UPDATE_ERROR_MSG, oldItemStatuses.get(updatedItem.getId()), newItemStatus);
+                    LOGGER.warn(msg);
+                    updatedItemEntities.add(updatedItem);
+                    errors.add(new PartialError(updatedItem.getId() != null ? updatedItem.getId() : BLANK, msg));
+                    updatePromise.complete();
+                  } else {
+                    addHoldingToPayloadIfNeeded(dataImportEventPayload, context, updatedItem)
+                      .onComplete(item -> {
+                        updatedItemEntities.add(updatedItem);
+                        updatePromise.complete();
+                      });
+                  }
+                });
+            }
+          }
+
+          CompositeFuture.all(updatedItemsRecordFutures).onComplete(ar -> {
+            if (!expiredItems.isEmpty()) {
+              processOLError(dataImportEventPayload, future, itemCollection, expiredItems.get(0), errors);
+            }
+            if (dataImportEventPayload.getContext().containsKey(ERRORS) ||!errors.isEmpty()) {
+              dataImportEventPayload.getContext().put(ERRORS, Json.encode(errors));
+            }
+            if (ar.succeeded()) {
+              List<JsonObject> itemsAsJsons = new ArrayList<>();
+              for (Item updatedItemEntity : updatedItemEntities) {
+                itemsAsJsons.add(ItemUtil.mapToJson(updatedItemEntity));
+              }
+              dataImportEventPayload.getContext().put(ITEM.value(), Json.encode(itemsAsJsons));
+              future.complete(dataImportEventPayload);
+            } else {
+              future.completeExceptionally(ar.cause());
+            }
+            dataImportEventPayload.getContext().remove(TEMPORARY_MULTIPLE_HOLDINGS_FIELD);
+          });
         })
         .onFailure(e -> {
-          LOG.error("Failed to update inventory Item by jobExecutionId: '{}' and recordId: '{}' and chunkId: '{}' ", jobExecutionId,
+          LOGGER.error("Failed to update inventory Item by jobExecutionId: '{}' and recordId: '{}' and chunkId: '{}' ", jobExecutionId,
             recordId, chunkId, e);
           future.completeExceptionally(e);
+          dataImportEventPayload.getContext().remove(TEMPORARY_MULTIPLE_HOLDINGS_FIELD);
         });
     } catch (Exception e) {
-      LOG.error("Error updating inventory Item", e);
+      LOGGER.error("Error updating inventory Item", e);
       future.completeExceptionally(e);
+      dataImportEventPayload.getContext().remove(TEMPORARY_MULTIPLE_HOLDINGS_FIELD);
     }
     return future;
   }
@@ -180,13 +224,18 @@ public class UpdateItemEventHandler implements EventHandler {
   }
 
 
-  private String preparePayloadAndGetStatus(DataImportEventPayload dataImportEventPayload, HashMap<String, String> payloadContext, MappingMetadataDto mappingMetadataDto) {
-    JsonObject itemAsJson = new JsonObject(payloadContext.get(ITEM.value()));
-    String oldItemStatus = itemAsJson.getJsonObject(STATUS_KEY).getString("name");
+  private Map<String, String> preparePayloadAndGetStatus(DataImportEventPayload dataImportEventPayload, HashMap<String, String> payloadContext, MappingMetadataDto mappingMetadataDto) {
+    Map<String, String> itemOldStatuses = new HashMap<>();
+
+    JsonArray itemsJsonArray = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
+    for (int i = 0; i < itemsJsonArray.size(); i++) {
+      JsonObject itemAsJson = itemsJsonArray.getJsonObject(i);
+      itemAsJson = itemAsJson.getJsonObject(ITEM_PATH_FIELD);
+      itemOldStatuses.put(itemAsJson.getString(ID_PATH_FIELD), itemAsJson.getJsonObject(STATUS_KEY).getString("name"));
+    }
+    dataImportEventPayload.getContext().put(ITEM.value(), itemsJsonArray.encode());
     preparePayloadForMappingManager(dataImportEventPayload);
-    MappingParameters mappingParameters = Json.decodeValue(mappingMetadataDto.getMappingParams(), MappingParameters.class);
-    MappingManager.map(dataImportEventPayload, new MappingContext().withMappingParameters(mappingParameters));
-    return oldItemStatus;
+    return itemOldStatuses;
   }
 
   private Future<DataImportEventPayload> addHoldingToPayloadIfNeeded(DataImportEventPayload dataImportEventPayload, Context context, Item updatedItem) {
@@ -195,16 +244,16 @@ public class UpdateItemEventHandler implements EventHandler {
       HoldingsRecordCollection holdingsRecordCollection = storage.getHoldingsRecordCollection(context);
       holdingsRecordCollection.findById(updatedItem.getHoldingId(),
         success -> {
-          LOG.info("Successfully retrieved Holdings for the hotlink by id: {}", updatedItem.getHoldingId());
+          LOGGER.info("Successfully retrieved Holdings for the hotlink by id: {}", updatedItem.getHoldingId());
           dataImportEventPayload.getContext().put(HOLDINGS.value(), Json.encodePrettily(success.getResult()));
           promise.complete(dataImportEventPayload);
         },
         failure -> {
-          LOG.warn("Error retrieving Holdings for the hotlink by id {} cause {}, status code {}", updatedItem.getHoldingId(), failure.getReason(), failure.getStatusCode());
+          LOGGER.warn("Error retrieving Holdings for the hotlink by id {} cause {}, status code {}", updatedItem.getHoldingId(), failure.getReason(), failure.getStatusCode());
           promise.complete(dataImportEventPayload);
         });
     } else {
-      LOG.debug("Holdings already exists in payload with for the hotlink with id {}", updatedItem.getHoldingId());
+      LOGGER.debug("Holdings already exists in payload with for the hotlink with id {}", updatedItem.getHoldingId());
       promise.complete(dataImportEventPayload);
     }
     return promise.future();
@@ -218,8 +267,13 @@ public class UpdateItemEventHandler implements EventHandler {
     dataImportEventPayload.getContext().put(CURRENT_EVENT_TYPE_PROPERTY, dataImportEventPayload.getEventType());
     dataImportEventPayload.getContext().put(CURRENT_NODE_PROPERTY, Json.encode(dataImportEventPayload.getCurrentNode()));
 
-    JsonObject oldItemJson = new JsonObject(dataImportEventPayload.getContext().get(ITEM.value()));
-    dataImportEventPayload.getContext().put(ActionProfile.FolioRecord.ITEM.value(), new JsonObject().put(ITEM_PATH_FIELD, oldItemJson).encode());
+    JsonArray itemsJsonArray = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
+    for (int i = 0; i < itemsJsonArray.size(); i++) {
+      JsonObject itemAsJson = itemsJsonArray.getJsonObject(i);
+      itemAsJson = itemAsJson.getJsonObject(ITEM_PATH_FIELD);
+      itemsJsonArray.set(i, new JsonObject().put(ITEM_PATH_FIELD, itemAsJson));
+    }
+    dataImportEventPayload.getContext().put(ITEM.value(), itemsJsonArray.encode());
     dataImportEventPayload.getEventsChain().add(dataImportEventPayload.getEventType());
     dataImportEventPayload.setCurrentNode(dataImportEventPayload.getCurrentNode().getChildSnapshotWrappers().get(0));
   }
@@ -237,94 +291,128 @@ public class UpdateItemEventHandler implements EventHandler {
     }
   }
 
-  private Future<Boolean> verifyItemBarcodeUniqueness(Item item, ItemCollection itemCollection) {
-
+  private Future<Void> verifyItemBarcodeUniqueness(Item item, ItemCollection itemCollection, Promise<Void> updatePromise, List<PartialError> errors) {
     if (isEmpty(item.getBarcode())) {
-      return Future.succeededFuture(true);
+      return Future.succeededFuture();
     }
 
-    Promise<Boolean> promise = Promise.promise();
+    Promise<Void> promise = Promise.promise();
     try {
       itemCollection.findByCql(CqlHelper.barcodeIs(item.getBarcode()) + " AND id <> " + item.id, PagingParameters.defaults(),
         findResult -> {
           if (findResult.getResult().records.isEmpty()) {
-            promise.complete(findResult.getResult().records.isEmpty());
+            promise.complete();
           } else {
-            LOG.warn("Barcode must be unique, {} is already assigned to another item", item.getBarcode());
+            LOGGER.warn("Barcode must be unique, {} is already assigned to another item", item.getBarcode());
+            updatePromise.complete();
             promise.fail(format("Barcode must be unique, %s is already assigned to another item", item.getBarcode()));
+            errors.add(new PartialError(item.getId() != null ? item.getId() : BLANK, format("Barcode must be unique, %s is already assigned to another item", item.getBarcode())));
           }
         },
-        failure -> promise.fail(failure.getReason()));
+        failure -> {
+          promise.fail(failure.getReason());
+          updatePromise.complete();
+          errors.add(new PartialError(item.getId() != null ? item.getId() : BLANK, failure.getReason()));
+        });
     } catch (UnsupportedEncodingException e) {
       String msg = format("Failed to find items by barcode '%s'", item.getBarcode());
-      LOG.error(msg, e);
+      LOGGER.error(msg, e);
       promise.fail(msg);
+      updatePromise.complete();
+      errors.add(new PartialError(item.getId() != null ? item.getId() : BLANK, format("Failed to find items by barcode '%s'", item.getBarcode())));
     }
     return promise.future();
   }
 
-  private Future<Item> updateItemAndRetryIfOLExists(Item item, ItemCollection itemCollection, DataImportEventPayload eventPayload) {
+  private Future<Item> updateItemAndRetryIfOLExists(Item item, ItemCollection itemCollection, DataImportEventPayload eventPayload, Promise<Void> updatePromise, List<PartialError> errors, List<Item> expiredItems) {
     Promise<Item> promise = Promise.promise();
     item.getCirculationNotes().forEach(note -> note
       .withId(UUID.randomUUID().toString())
       .withSource(null)
       .withDate(dateTimeFormatter.format(ZonedDateTime.now())));
 
-    itemCollection.update(item, success -> promise.complete(item),
+    itemCollection.update(item, success -> {
+        promise.complete(item);
+      },
       failure -> {
+        errors.add(new PartialError(item.getId() != null ? item.getId() : BLANK, failure.getReason()));
         if (failure.getStatusCode() == HttpStatus.SC_CONFLICT) {
-          processOLError(item, itemCollection, eventPayload, promise, failure);
+          expiredItems.add(item);
+          updatePromise.complete();
+          promise.fail(failure.getReason());
         } else {
+          updatePromise.complete();
           eventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
-          LOG.error(format("Error updating Item - %s, status code %s", failure.getReason(), failure.getStatusCode()));
+          LOGGER.error(format("Error updating Item - %s, status code %s", failure.getReason(), failure.getStatusCode()));
           promise.fail(failure.getReason());
         }
       });
     return promise.future();
   }
 
-
-  private void processOLError(Item instance, ItemCollection itemCollection, DataImportEventPayload eventPayload, Promise<Item> promise, Failure failure) {
-    int currentRetryNumber = eventPayload.getContext().get(CURRENT_RETRY_NUMBER) == null ? 0 : Integer.parseInt(eventPayload.getContext().get(CURRENT_RETRY_NUMBER));
+  private void processOLError(DataImportEventPayload dataImportEventPayload, CompletableFuture<DataImportEventPayload> future, ItemCollection itemCollection, Item item, List<PartialError> errors) {
+    int currentRetryNumber = dataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER) == null ? 0 : Integer.parseInt(dataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER));
     if (currentRetryNumber < MAX_RETRIES_COUNT) {
-      eventPayload.getContext().put(CURRENT_RETRY_NUMBER, String.valueOf(currentRetryNumber + 1));
-      LOG.warn("OL error updating Item - {}, status code {}. Retry UpdateItemEventHandler handler...", failure.getReason(), failure.getStatusCode());
-      getActualItemAndReInvokeCurrentHandler(instance, itemCollection, promise, eventPayload);
+      dataImportEventPayload.getContext().put(CURRENT_RETRY_NUMBER, String.valueOf(currentRetryNumber + 1));
+      LOGGER.warn("Error updating Item by id '{}'. Retry UpdateItemEventHandler handler...", item.getId());
+      itemCollection.findById(item.getId())
+        .thenAccept(actuaItem -> prepareDataAndReInvokeCurrentHandler(dataImportEventPayload, future, actuaItem))
+        .exceptionally(e -> {
+          dataImportEventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
+          String errMessage = format("Cannot get actual Item by id: '%s' for jobExecutionId '%s'. Error: %s ", item.getId(), dataImportEventPayload.getJobExecutionId(), e.getCause());
+          LOGGER.error(errMessage);
+          errors.add(new PartialError(item.getId() != null ? item.getId() : BLANK, errMessage));
+          future.complete(dataImportEventPayload);
+          return null;
+        });
     } else {
-      eventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
-      String errMessage = format("Current retry number %s exceeded or equal given number %s for the Item update for jobExecutionId '%s'", MAX_RETRIES_COUNT, currentRetryNumber, eventPayload.getJobExecutionId());
-      LOG.error(errMessage);
-      promise.fail(errMessage);
+      dataImportEventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
+      String errMessage = format("Current retry number %s exceeded or equal given number %s for the Item update for jobExecutionId '%s' ", MAX_RETRIES_COUNT, currentRetryNumber, dataImportEventPayload.getJobExecutionId());
+      LOGGER.error(errMessage);
+      errors.add(new PartialError(item.getId() != null ? item.getId() : BLANK, errMessage));
+      future.complete(dataImportEventPayload);
     }
   }
 
+  private void prepareDataAndReInvokeCurrentHandler(DataImportEventPayload dataImportEventPayload, CompletableFuture<DataImportEventPayload> future, Item actualItem) {
+    JsonArray resultedItems = updateActualItemAndConvertItemListAsJsonArray(dataImportEventPayload, actualItem);
+    dataImportEventPayload.getContext().put(ITEM.value(), Json.encode(resultedItems));
+    dataImportEventPayload.getEventsChain().remove(dataImportEventPayload.getContext().get(CURRENT_EVENT_TYPE_PROPERTY));
+    try {
+      dataImportEventPayload.setCurrentNode(ObjectMapperTool.getMapper().readValue(dataImportEventPayload.getContext().get(CURRENT_NODE_PROPERTY), ProfileSnapshotWrapper.class));
+    } catch (JsonProcessingException e) {
+      LOGGER.error("Cannot map from CURRENT_NODE value", e);
+    }
+    dataImportEventPayload.getContext().remove(CURRENT_EVENT_TYPE_PROPERTY);
+    dataImportEventPayload.getContext().remove(CURRENT_NODE_PROPERTY);
+    dataImportEventPayload.getContext().put(MULTIPLE_HOLDINGS_FIELD, dataImportEventPayload.getContext().get(TEMPORARY_MULTIPLE_HOLDINGS_FIELD));
+    dataImportEventPayload.getContext().remove(TEMPORARY_MULTIPLE_HOLDINGS_FIELD);
+    handle(dataImportEventPayload).whenComplete((res, e) -> {
+      future.complete(dataImportEventPayload);
+    });
+  }
 
-  private void getActualItemAndReInvokeCurrentHandler(Item item, ItemCollection itemCollection, Promise<Item> promise, DataImportEventPayload eventPayload) {
-    itemCollection.findById(item.getId())
-      .thenAccept(actualItem -> {
-        JsonObject itemAsJson = new JsonObject(ItemUtil.mapToMappingResultRepresentation(actualItem));
-        eventPayload.getContext().put(ITEM.value(), Json.encode(itemAsJson));
-        eventPayload.getEventsChain().remove(eventPayload.getContext().get(CURRENT_EVENT_TYPE_PROPERTY));
-        try {
-          eventPayload.setCurrentNode(ObjectMapperTool.getMapper().readValue(eventPayload.getContext().get(CURRENT_NODE_PROPERTY), ProfileSnapshotWrapper.class));
-        } catch (JsonProcessingException e) {
-          LOG.error("Cannot map from CURRENT_NODE value", e);
-        }
-        eventPayload.getContext().remove(CURRENT_EVENT_TYPE_PROPERTY);
-        eventPayload.getContext().remove(CURRENT_NODE_PROPERTY);
-        handle(eventPayload).whenComplete((res, e) -> {
-          if (e != null) {
-            promise.fail(e.getMessage());
-          } else {
-            promise.complete(item);
-          }
-        });
-      })
-      .exceptionally(e -> {
-        eventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
-        LOG.error(format("Cannot get actual Item by id: %s", e.getCause()));
-        promise.fail(format("Cannot get actual Item by id: %s", e.getCause()));
-        return null;
-      });
+  private static JsonArray updateActualItemAndConvertItemListAsJsonArray(DataImportEventPayload dataImportEventPayload, Item actualItem) {
+    List<Item> initialItemList = new ArrayList<>();
+    JsonArray itemsJsonArray = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
+    for (int i = 0; i < itemsJsonArray.size(); i++) {
+      Item currentItem = ItemUtil.jsonToItem(itemsJsonArray.getJsonObject(i).getJsonObject(ITEM_PATH_FIELD));
+      initialItemList.add(currentItem);
+    }
+    List<Item> itemsList = new ArrayList<>(initialItemList);
+
+    List<Item> updatedItemsList = new ArrayList<>(itemsList);
+    for (int i = 0; i < itemsList.size(); i++) {
+      Item item = itemsList.get(i);
+      if (item.getId().equals(actualItem.getId())) {
+        updatedItemsList.set(i, actualItem);
+      }
+    }
+
+    JsonArray resultedItems = new JsonArray();
+    for (Item currentItem : updatedItemsList) {
+      resultedItems.add(new JsonObject().put(ITEM_PATH_FIELD, new JsonObject(ItemUtil.mapToMappingResultRepresentation(currentItem))));
+    }
+    return resultedItems;
   }
 }

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
@@ -3,6 +3,7 @@ package org.folio.inventory.dataimport.handlers.actions;
 import com.google.common.collect.Lists;
 import io.vertx.core.Future;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.folio.ActionProfile;
@@ -16,7 +17,9 @@ import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.common.domain.MultipleRecords;
 import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.dataimport.HoldingWriterFactory;
+import org.folio.inventory.dataimport.HoldingsMapperFactory;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.dataimport.entities.PartialError;
 import org.folio.inventory.dataimport.services.OrderHelperServiceImpl;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.domain.instances.Instance;
@@ -49,6 +52,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -66,20 +70,25 @@ import static org.folio.inventory.dataimport.util.DataImportConstants.UNIQUE_ID_
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 public class CreateHoldingEventHandlerTest {
 
-  private static final String PARSED_CONTENT_WITH_INSTANCE_ID = "{ \"leader\": \"01314nam  22003851a 4500\", \"fields\":[ {\"001\":\"ybp7406411\"}, {\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } } ] }";
-  private static final String PARSED_CONTENT_WITHOUT_INSTANCE_ID = "{ \"leader\":\"01314nam  22003851a 4500\", \"fields\":[ { \"001\":\"ybp7406411\" } ] }";
+  private static final String PARSED_CONTENT_WITH_INSTANCE_ID = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"945\":{\"subfields\":[{\"a\":\"OM\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"a\":\"AM\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"a\":\"asdf\"},{\"h\":\"fcd64ce1-6995-48f0-840e-89ffa2288371\"}],\"ind1\":\" \",\"ind2\":\" \"}}, {\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } }]}";
+  private static final String PARSED_CONTENT_WITHOUT_INSTANCE_ID = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"945\":{\"subfields\":[{\"a\":\"OM\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"a\":\"AM\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"a\":\"asdf\"},{\"h\":\"fcd64ce1-6995-48f0-840e-89ffa2288371\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
   private static final String FOLIO_SOURCE_ID = "f32d531e-df79-46b3-8932-cdd35f7a2264";
   private static final String RECORD_ID = UUID.randomUUID().toString();
   private static final String ITEM_ID = UUID.randomUUID().toString();
+  private static final String ERRORS = "ERRORS";
+  private static Reader fakeReader;
+  private static final String permanentLocationId = UUID.randomUUID().toString();
 
   @Mock
   private Storage storage;
@@ -112,7 +121,7 @@ public class CreateHoldingEventHandlerTest {
     .withExistingRecordType(EntityType.HOLDINGS)
     .withMappingDetails(new MappingDetail()
       .withMappingFields(Collections.singletonList(
-        new MappingRule().withPath("permanentLocationId").withValue("permanentLocationExpression").withEnabled("true"))));
+        new MappingRule().withName("permanentLocationId").withPath("permanentLocationId").withValue("945$h").withEnabled("true"))));
 
   private ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
     .withId(UUID.randomUUID().toString())
@@ -162,22 +171,59 @@ public class CreateHoldingEventHandlerTest {
         .withMappingParams(Json.encode(new MappingParameters())))));
 
     when(orderHelperService.fillPayloadForOrderPostProcessingIfNeeded(any(), any(), any())).thenReturn(Future.succeededFuture());
-  }
-
-  @Test
-  public void shouldProcessEvent() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = Mockito.mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
+    fakeReader = Mockito.mock(Reader.class);
     when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
     when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-
     when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
 
     MappingManager.registerReaderFactory(fakeReaderFactory);
     MappingManager.registerWriterFactory(new HoldingWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
+  }
+
+  @Test
+  public void shouldProcessEvent() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    String instanceId = String.valueOf(UUID.randomUUID());
+    Instance instance = new Instance(instanceId, "5", String.valueOf(UUID.randomUUID()),
+      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+    context.put(ERRORS, Json.encode(new PartialError(null, "testError")));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createHoldingEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+
+    Assert.assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    JsonObject holding = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getJsonObject(0);
+    JsonArray errors = new JsonArray(actualDataImportEventPayload.getContext().get(ERRORS));
+    Assert.assertEquals(0, errors.size());
+    Assert.assertNotNull(holding.getString("id"));
+    Assert.assertEquals(instanceId, holding.getString("instanceId"));
+    Assert.assertEquals(permanentLocationId, holding.getString("permanentLocationId"));
+    Assert.assertEquals(FOLIO_SOURCE_ID, holding.getString("sourceId"));
+  }
+
+  @Test
+  public void shouldProcessEventAndReturnPartialErrorsInContext() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    String errorMsg = "testError";
+    doAnswer(invocationOnMock -> {
+      Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+      failureHandler.accept(new Failure(errorMsg, 400));
+      return null;
+    }).when(holdingsRecordsCollection).add(argThat(holdingsRecord -> holdingsRecord.getPermanentLocationId().equals(permanentLocationId)), any(), any());
+
+    List<String> locations = List.of(permanentLocationId, UUID.randomUUID().toString());
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(locations.get(0)), StringValue.of(locations.get(1)));
 
     String instanceId = String.valueOf(UUID.randomUUID());
     Instance instance = new Instance(instanceId, "5", String.valueOf(UUID.randomUUID()),
@@ -199,27 +245,105 @@ public class CreateHoldingEventHandlerTest {
 
     Assert.assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
-    Assert.assertEquals(instanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
-    Assert.assertEquals(permanentLocationId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
-    Assert.assertEquals(FOLIO_SOURCE_ID, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("sourceId"));
+    JsonArray holdings = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    JsonArray errors = new JsonArray(actualDataImportEventPayload.getContext().get(ERRORS));
+    Assert.assertEquals(1, holdings.size());
+    Assert.assertEquals(1, errors.size());
+    JsonObject partialError = errors.getJsonObject(0);
+    Assert.assertEquals(errorMsg, partialError.getString("error"));
+    Assert.assertEquals(ITEM_ID, partialError.getString("id"));
+  }
+
+  @Test
+  public void shouldProcessEventAndCreateMultipleHoldings() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    List<String> locations = List.of(permanentLocationId, UUID.randomUUID().toString());
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(locations.get(0)), StringValue.of(locations.get(1)));
+    String instanceId = String.valueOf(UUID.randomUUID());
+    Instance instance = new Instance(instanceId, "5", String.valueOf(UUID.randomUUID()),
+      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createHoldingEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+
+    Assert.assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    Assert.assertNull(actualDataImportEventPayload.getContext().get(ERRORS));
+    JsonArray holdingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    Assert.assertEquals(2, holdingsList.size());
+
+    for (int i = 0; i < holdingsList.size(); i++) {
+      JsonObject holdingsAsJson = holdingsList.getJsonObject(i);
+      Assert.assertNotNull(holdingsAsJson.getString("id"));
+      Assert.assertEquals(instanceId, holdingsAsJson.getString("instanceId"));
+      Assert.assertEquals(locations.get(i), holdingsAsJson.getString("permanentLocationId"));
+      Assert.assertEquals(FOLIO_SOURCE_ID, holdingsAsJson.getString("sourceId"));
+    }
+  }
+
+  @Test
+  public void shouldProcessEventAndCreateMultipleHoldingsAndPopulatePartialErrorsForFailedHoldings() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    String permanentLocationId2 = UUID.randomUUID().toString();
+
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId), StringValue.of(permanentLocationId2));
+
+    String testError = "testError";
+
+    doAnswer(invocationOnMock -> {
+      Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+      failureHandler.accept(new Failure(testError, 400));
+      return null;
+    }).when(holdingsRecordsCollection).add(argThat(holdingsRecord -> holdingsRecord.getPermanentLocationId().equals(permanentLocationId2)), any(), any());
+
+    String instanceId = String.valueOf(UUID.randomUUID());
+    Instance instance = new Instance(instanceId, "5", String.valueOf(UUID.randomUUID()),
+      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createHoldingEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+
+    Assert.assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    JsonArray holdingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    Assert.assertEquals(1, holdingsList.size());
+    JsonArray errors = new JsonArray(actualDataImportEventPayload.getContext().get(ERRORS));
+    Assert.assertEquals(1, errors.size());
+    JsonObject partialError = errors.getJsonObject(0);
+    Assert.assertEquals(testError, partialError.getString("error"));
+    Assert.assertNotEquals(ITEM_ID, partialError.getString("id"));
+
+    holdingsList.forEach(holdings -> {
+      JsonObject holdingsAsJson = (JsonObject) holdings;
+      Assert.assertNotNull(holdingsAsJson.getString("id"));
+      Assert.assertEquals(instanceId, holdingsAsJson.getString("instanceId"));
+      Assert.assertEquals(permanentLocationId, holdingsAsJson.getString("permanentLocationId"));
+      Assert.assertEquals(FOLIO_SOURCE_ID, holdingsAsJson.getString("sourceId"));
+    });
   }
 
   @Test
   public void shouldProcessEventIfInstanceIdIsNotExistsInInstanceInContextButExistsInMarcBibliographicParsedRecords() throws InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = Mockito.mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
-    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-
-    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-
-    MappingManager.registerReaderFactory(fakeReaderFactory);
-    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-
     String expectedInstanceId = UUID.randomUUID().toString();
     JsonObject instanceAsJson = new JsonObject().put("id", expectedInstanceId);
 
@@ -241,27 +365,15 @@ public class CreateHoldingEventHandlerTest {
 
     Assert.assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
-    Assert.assertEquals(expectedInstanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
-    Assert.assertEquals(permanentLocationId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
-    Assert.assertEquals(FOLIO_SOURCE_ID, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("sourceId"));
+    JsonObject holding = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getJsonObject(0);
+    Assert.assertNotNull(holding.getString("id"));
+    Assert.assertEquals(expectedInstanceId, holding.getString("instanceId"));
+    Assert.assertEquals(permanentLocationId, holding.getString("permanentLocationId"));
+    Assert.assertEquals(FOLIO_SOURCE_ID, holding.getString("sourceId"));
   }
 
   @Test
   public void shouldProcessEventIfInstanceIdIsEmptyInInstanceInContextButExistsInMarcBibliographicParsedRecords() throws InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = Mockito.mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
-    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-
-    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-
-    MappingManager.registerReaderFactory(fakeReaderFactory);
-    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
 
     HashMap<String, String> context = new HashMap<>();
@@ -279,31 +391,78 @@ public class CreateHoldingEventHandlerTest {
 
     Assert.assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
-    Assert.assertEquals(permanentLocationId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
-    Assert.assertEquals(FOLIO_SOURCE_ID, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("sourceId"));
+    JsonObject holding = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getJsonObject(0);
+    Assert.assertNotNull(holding.getString("id"));
+    Assert.assertEquals(permanentLocationId, holding.getString("permanentLocationId"));
+    Assert.assertEquals(FOLIO_SOURCE_ID, holding.getString("sourceId"));
   }
 
-  @Test(expected = Exception.class)
+  @Test
+  public void shouldProcessEventIfPermanentLocationIdIsNotExistsInContext() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(""));
+
+    String instanceId = String.valueOf(UUID.randomUUID());
+    Instance instance = new Instance(instanceId, "8", String.valueOf(UUID.randomUUID()),
+      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createHoldingEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+
+    Assert.assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    JsonArray holdings = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    assertEquals(1, holdings.size());
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void shouldNotProcessEventIfNoHoldingsSuccessfullyCreated() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    String errorMsg = "testError";
+    doAnswer(invocationOnMock -> {
+      Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+      failureHandler.accept(new Failure(errorMsg, 400));
+      return null;
+    }).when(holdingsRecordsCollection).add(any(), any(), any());
+
+    List<String> locations = List.of(permanentLocationId, UUID.randomUUID().toString());
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(locations.get(0)), StringValue.of(locations.get(1)));
+
+    String instanceId = String.valueOf(UUID.randomUUID());
+    Instance instance = new Instance(instanceId, "5", String.valueOf(UUID.randomUUID()),
+      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = createHoldingEventHandler.handle(dataImportEventPayload);
+    future.get(5, TimeUnit.MILLISECONDS);
+  }
+
+  @Test(expected = ExecutionException.class)
   public void shouldNotProcessEventEvenIfDuplicatedInventoryStorageErrorExists() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = Mockito.mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
-    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-
-    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-
     doAnswer(invocationOnMock -> {
       Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
       failureHandler.accept(new Failure(UNIQUE_ID_ERROR_MESSAGE, 400));
       return null;
     }).when(holdingsRecordsCollection).add(any(), any(), any());
-
-    MappingManager.registerReaderFactory(fakeReaderFactory);
-    MappingManager.registerWriterFactory(new HoldingWriterFactory());
 
     String instanceId = String.valueOf(UUID.randomUUID());
     Instance instance = new Instance(instanceId, "5", String.valueOf(UUID.randomUUID()),
@@ -324,22 +483,8 @@ public class CreateHoldingEventHandlerTest {
     future.get(5, TimeUnit.SECONDS);
   }
 
-
   @Test(expected = ExecutionException.class)
-  public void shouldNotProcessEventIfInstanceIdIsNotExistsInInstanceInContextAndNotExistsInParsedRecords() throws InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = Mockito.mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
-    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-
-    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-
-    MappingManager.registerReaderFactory(fakeReaderFactory);
-    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-
+  public void shouldNotProcessEventIfInstanceIdIsNotExistsInInstanceInContextAndNotExistsInParsedRecords() throws InterruptedException, ExecutionException, TimeoutException  {
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITHOUT_INSTANCE_ID));
 
     HashMap<String, String> context = new HashMap<>();
@@ -357,22 +502,8 @@ public class CreateHoldingEventHandlerTest {
     future.get(5, TimeUnit.MILLISECONDS);
   }
 
-
   @Test(expected = ExecutionException.class)
   public void shouldNotProcessEventIfInstanceIdIsNotExistsInInstanceInContextAndMarcBibliographicNotExists() throws InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = Mockito.mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
-    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-
-    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-
-    MappingManager.registerReaderFactory(fakeReaderFactory);
-    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-
     String instanceId = String.valueOf(UUID.randomUUID());
     Record record = new Record().withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId));
 
@@ -393,19 +524,6 @@ public class CreateHoldingEventHandlerTest {
 
   @Test(expected = ExecutionException.class)
   public void shouldNotProcessEventIfNoContextMarcBibliographic() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = Mockito.mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
-    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-
-    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-
-    MappingManager.registerReaderFactory(fakeReaderFactory);
-    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-
     String instanceId = String.valueOf(UUID.randomUUID());
     Instance instance = new Instance(instanceId, "9", String.valueOf(UUID.randomUUID()),
       String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
@@ -424,19 +542,6 @@ public class CreateHoldingEventHandlerTest {
 
   @Test(expected = ExecutionException.class)
   public void shouldNotProcessEventIfContextIsNull() throws InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = Mockito.mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
-    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-
-    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-
-    MappingManager.registerReaderFactory(fakeReaderFactory);
-    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
       .withContext(null)
@@ -449,19 +554,6 @@ public class CreateHoldingEventHandlerTest {
 
   @Test(expected = ExecutionException.class)
   public void shouldNotProcessEventIfContextIsEmpty() throws InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = Mockito.mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
-    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-
-    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-
-    MappingManager.registerReaderFactory(fakeReaderFactory);
-    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
       .withContext(new HashMap<>())
@@ -473,41 +565,7 @@ public class CreateHoldingEventHandlerTest {
   }
 
   @Test(expected = ExecutionException.class)
-  public void shouldNotProcessEventIfPermanentLocationIdIsNotExistsInContext() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = Mockito.mock(Reader.class);
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(""));
-
-    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-
-    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-
-    MappingManager.registerReaderFactory(fakeReaderFactory);
-    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-
-    String instanceId = String.valueOf(UUID.randomUUID());
-    Instance instance = new Instance(instanceId, "8", String.valueOf(UUID.randomUUID()),
-      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
-    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
-    HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
-    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
-
-    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
-      .withJobExecutionId(UUID.randomUUID().toString())
-      .withContext(context)
-      .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-
-    CompletableFuture<DataImportEventPayload> future = createHoldingEventHandler.handle(dataImportEventPayload);
-    future.get(5, TimeUnit.MILLISECONDS);
-  }
-
-  @Test(expected = ExecutionException.class)
   public void shouldNotProcessEventIfHoldingRecordIsInvalid() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = Mockito.mock(Reader.class);
-
     MappingProfile mappingProfile = new MappingProfile()
       .withId(UUID.randomUUID().toString())
       .withName("Prelim item from MARC")
@@ -535,13 +593,6 @@ public class CreateHoldingEventHandlerTest {
               .withContent(JsonObject.mapFrom(mappingProfile).getMap())))));
 
     when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(UUID.randomUUID().toString()), StringValue.of(UUID.randomUUID().toString()));
-
-    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-
-    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-
-    MappingManager.registerReaderFactory(fakeReaderFactory);
-    MappingManager.registerWriterFactory(new HoldingWriterFactory());
 
     String instanceId = String.valueOf(UUID.randomUUID());
     Instance instance = new Instance(instanceId, "7", String.valueOf(UUID.randomUUID()),

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
@@ -450,6 +450,7 @@ public class CreateItemEventHandlerTest {
     Assert.assertEquals(1, errors.size());
     Assert.assertEquals(errors.getJsonObject(0).getString("id"), ITEM_ID);
     Assert.assertEquals(errors.getJsonObject(0).getString("error"), testError);
+    Assert.assertEquals(errors.getJsonObject(0).getString("holdingId"), expectedHoldingId1);
 
     JsonObject createdItem = createdItems.getJsonObject(0);
     Assert.assertNotNull(createdItem.getJsonObject("status").getString("name"));

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
@@ -370,7 +370,7 @@ public class CreateItemEventHandlerTest {
     Assert.assertEquals(2, createdItems.size());
     Assert.assertEquals(EMPTY_JSON_ARRAY, eventPayload.getContext().get(ERRORS));
 
-    Assert.assertEquals(createdItems.getJsonObject(0).getString("id"), ITEM_ID);
+    Assert.assertEquals(ITEM_ID, createdItems.getJsonObject(0).getString("id"));
     for (int i = 0; i < createdItems.size(); i++) {
       JsonObject createdItem = createdItems.getJsonObject(i);
       Assert.assertNotNull(createdItem.getJsonObject("status").getString("name"));
@@ -448,7 +448,7 @@ public class CreateItemEventHandlerTest {
     JsonArray errors = new JsonArray(eventPayload.getContext().get(ERRORS));
     Assert.assertEquals(1, createdItems.size());
     Assert.assertEquals(1, errors.size());
-    Assert.assertEquals(errors.getJsonObject(0).getString("id"), ITEM_ID);
+    Assert.assertEquals(ITEM_ID, errors.getJsonObject(0).getString("id"));
     Assert.assertEquals(errors.getJsonObject(0).getString("error"), testError);
     Assert.assertEquals(errors.getJsonObject(0).getString("holdingId"), expectedHoldingId1);
 

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -1,15 +1,21 @@
 package org.folio.inventory.dataimport.handlers.actions;
 
+import com.google.common.collect.Lists;
 import io.vertx.core.Future;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
+import org.folio.HoldingsRecord;
+import org.folio.JobProfile;
 import org.folio.MappingMetadataDto;
-import org.folio.*;
+import org.folio.MappingProfile;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.dataimport.HoldingWriterFactory;
+import org.folio.inventory.dataimport.HoldingsMapperFactory;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.domain.instances.Instance;
@@ -21,16 +27,24 @@ import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingPa
 import org.folio.processing.mapping.mapper.reader.Reader;
 import org.folio.processing.mapping.mapper.reader.record.marc.MarcBibReaderFactory;
 import org.folio.processing.value.StringValue;
+import org.folio.rest.jaxrs.model.EntityType;
+import org.folio.rest.jaxrs.model.MappingDetail;
+import org.folio.rest.jaxrs.model.MappingRule;
 import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
-import org.folio.rest.jaxrs.model.*;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.*;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -39,21 +53,31 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
-import static org.folio.ActionProfile.FolioRecord.*;
+import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
+import static org.folio.ActionProfile.FolioRecord.ITEM;
+import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_MATCHED;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_UPDATED;
 import static org.folio.inventory.dataimport.handlers.actions.UpdateHoldingEventHandler.ACTION_HAS_NO_MAPPING_MSG;
 import static org.folio.inventory.domain.items.ItemStatusName.AVAILABLE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.*;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class UpdateHoldingEventHandlerTest {
-
   private static final String PARSED_CONTENT_WITH_INSTANCE_ID = "{ \"leader\": \"01314nam  22003851a 4500\", \"fields\":[ {\"001\":\"ybp7406411\"}, {\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } } ] }";
+  private static final String PARSED_CONTENT_WITH_INSTANCE_ID_AND_MULTIPLE_HOLDINGS = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"945\":{\"ind1\":\"\",\"ind2\":\"\",\"subfields\":[{\"h\":\"Online\"}]}},{\"945\":{\"ind1\":\"\",\"ind2\":\"\",\"subfields\":[{\"h\":\"Online 2\"}]}},{\"999\":{\"ind1\":\"f\",\"ind2\":\"f\",\"subfields\":[{\"i\":\"957985c6-97e3-4038-b0e7-343ecd0b8120\"}]}}]}";
+
+  private static final String ERRORS = "ERRORS";
+
+  private static final String permanentLocationId = UUID.randomUUID().toString();
 
   @Mock
   private Storage storage;
@@ -73,7 +97,7 @@ public class UpdateHoldingEventHandlerTest {
 
   private ActionProfile actionProfile = new ActionProfile()
     .withId(UUID.randomUUID().toString())
-    .withName("Create preliminary Item")
+    .withName("Update preliminary Holdings")
     .withAction(ActionProfile.Action.UPDATE)
     .withFolioRecord(HOLDINGS);
 
@@ -84,7 +108,7 @@ public class UpdateHoldingEventHandlerTest {
     .withExistingRecordType(EntityType.HOLDINGS)
     .withMappingDetails(new MappingDetail()
       .withMappingFields(Collections.singletonList(
-        new MappingRule().withPath("permanentLocationId").withValue("permanentLocationExpression").withEnabled("true"))));
+        new MappingRule().withName("permanentLocationId").withPath("holdings.permanentLocationId[]").withValue("\"\\\"Main Library\\\"\"").withEnabled("true"))));
 
   private ProfileSnapshotWrapper profileSnapshotWrapper = new ProfileSnapshotWrapper()
     .withId(UUID.randomUUID().toString())
@@ -102,12 +126,50 @@ public class UpdateHoldingEventHandlerTest {
             .withContentType(MAPPING_PROFILE)
             .withContent(JsonObject.mapFrom(mappingProfile).getMap())))));
 
+  private JobProfile jobProfileForMultipleHoldings = new JobProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Replace MARC Bibs")
+    .withDataType(JobProfile.DataType.MARC);
+
+  private ActionProfile actionProfileForMultipleHoldings = new ActionProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Update preliminary Holdings")
+    .withAction(ActionProfile.Action.UPDATE)
+    .withFolioRecord(HOLDINGS);
+
+  private MappingProfile mappingProfileForMultipleHoldings = new MappingProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Prelim item from MARC")
+    .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+    .withExistingRecordType(EntityType.HOLDINGS)
+    .withMappingDetails(new MappingDetail()
+      .withMappingFields(Collections.singletonList(
+        new MappingRule().withName("permanentLocationId").withPath("holdings.permanentLocationId").withValue("945$h").withEnabled("true"))));
+
+  private ProfileSnapshotWrapper profileSnapshotWrapperForMultipleHoldings = new ProfileSnapshotWrapper()
+    .withId(UUID.randomUUID().toString())
+    .withProfileId(jobProfileForMultipleHoldings.getId())
+    .withContentType(JOB_PROFILE)
+    .withContent(jobProfileForMultipleHoldings)
+    .withChildSnapshotWrappers(Collections.singletonList(
+      new ProfileSnapshotWrapper()
+        .withProfileId(actionProfileForMultipleHoldings.getId())
+        .withContentType(ACTION_PROFILE)
+        .withContent(actionProfileForMultipleHoldings)
+        .withChildSnapshotWrappers(Collections.singletonList(
+          new ProfileSnapshotWrapper()
+            .withProfileId(mappingProfileForMultipleHoldings.getId())
+            .withContentType(MAPPING_PROFILE)
+            .withContent(JsonObject.mapFrom(mappingProfileForMultipleHoldings).getMap())))));
+
   private UpdateHoldingEventHandler updateHoldingEventHandler;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     MappingManager.clearReaderFactories();
+    MappingManager.clearMapperFactories();
+    MappingManager.clearWriterFactories();
     updateHoldingEventHandler = new UpdateHoldingEventHandler(storage, mappingMetadataCache);
 
     doAnswer(invocationOnMock -> {
@@ -127,7 +189,7 @@ public class UpdateHoldingEventHandlerTest {
   public void shouldProcessEvent() throws InterruptedException, ExecutionException, TimeoutException {
     Reader fakeReader = Mockito.mock(Reader.class);
 
-    String permanentLocationId = UUID.randomUUID().toString();
+    String permanentLocationId = "a1e7c35d-4835-430a-ba3c-f93d5f3cde5a";
 
     when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
 
@@ -138,39 +200,55 @@ public class UpdateHoldingEventHandlerTest {
 
     MappingManager.registerReaderFactory(fakeReaderFactory);
     MappingManager.registerWriterFactory(new HoldingWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
 
-    String instanceId = String.valueOf(UUID.randomUUID());
+    String instanceId = UUID.randomUUID().toString();
     String holdingId = UUID.randomUUID().toString();
-    String hrid = UUID.randomUUID().toString();
+    String secondId = UUID.randomUUID().toString();
+    String firstHrid = UUID.randomUUID().toString();
+    String secondHrid = UUID.randomUUID().toString();
 
-    HoldingsRecord holdingsRecord = new HoldingsRecord()
+    HoldingsRecord firstHoldingsRecord = new HoldingsRecord()
       .withId(holdingId)
       .withInstanceId(instanceId)
-      .withHrid(hrid)
+      .withHrid(firstHrid)
       .withPermanentLocationId(permanentLocationId);
 
-    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HoldingsRecord secondHoldingsRecord = new HoldingsRecord()
+      .withId(secondId)
+      .withInstanceId(instanceId)
+      .withHrid(secondHrid)
+      .withPermanentLocationId(permanentLocationId);
+
+    JsonArray holdingsList = new JsonArray();
+    holdingsList.add(new JsonObject().put("holdings", firstHoldingsRecord));
+    holdingsList.add(new JsonObject().put("holdings", secondHoldingsRecord));
+
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID_AND_MULTIPLE_HOLDINGS));
     HashMap<String, String> context = new HashMap<>();
-    context.put(HOLDINGS.value(), Json.encode(holdingsRecord));
+    context.put(HOLDINGS.value(), Json.encode(holdingsList));
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(context)
-      .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withProfileSnapshot(profileSnapshotWrapperForMultipleHoldings)
+      .withCurrentNode(profileSnapshotWrapperForMultipleHoldings.getChildSnapshotWrappers().get(0));
 
     CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
     DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
 
     Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
-    Assert.assertEquals(instanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
-    Assert.assertEquals(permanentLocationId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
-    Assert.assertEquals(hrid, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("hrid"));
-    Assert.assertEquals(holdingId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
+    JsonArray resultedHoldingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    Assert.assertEquals(resultedHoldingsList.size(), 1);
+    JsonObject resultedHoldings = resultedHoldingsList.getJsonObject(0);
+    Assert.assertNotNull(resultedHoldings.getString("id"));
+    Assert.assertEquals(instanceId, resultedHoldings.getString("instanceId"));
+    Assert.assertEquals(permanentLocationId, resultedHoldings.getString("permanentLocationId"));
+    Assert.assertEquals(firstHrid, resultedHoldings.getString("hrid"));
+    Assert.assertEquals(holdingId, resultedHoldings.getString("id"));
   }
 
   @Test
@@ -183,7 +261,6 @@ public class UpdateHoldingEventHandlerTest {
 
     when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
     when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
-
     JsonObject existingItemJson = new JsonObject()
       .put("id", UUID.randomUUID().toString())
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
@@ -200,59 +277,190 @@ public class UpdateHoldingEventHandlerTest {
 
     MappingManager.registerReaderFactory(fakeReaderFactory);
     MappingManager.registerWriterFactory(new HoldingWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
 
-    String instanceId = String.valueOf(UUID.randomUUID());
+    String instanceId = UUID.randomUUID().toString();
     String holdingId = UUID.randomUUID().toString();
-    String hrid = UUID.randomUUID().toString();
+    String secondId = UUID.randomUUID().toString();
+    String firstHrid = UUID.randomUUID().toString();
+    String secondHrid = UUID.randomUUID().toString();
 
-    HoldingsRecord holdingsRecord = new HoldingsRecord()
+    HoldingsRecord firstHoldingsRecord = new HoldingsRecord()
       .withId(holdingId)
       .withInstanceId(instanceId)
-      .withHrid(hrid)
+      .withHrid(firstHrid)
       .withPermanentLocationId(permanentLocationId);
+
+    HoldingsRecord secondHoldingsRecord = new HoldingsRecord()
+      .withId(secondId)
+      .withInstanceId(instanceId)
+      .withHrid(secondHrid)
+      .withPermanentLocationId(permanentLocationId);
+
+    JsonArray holdingsList = new JsonArray();
+    holdingsList.add(new JsonObject().put("holdings", firstHoldingsRecord));
+    holdingsList.add(new JsonObject().put("holdings", secondHoldingsRecord));
 
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
-    context.put(HOLDINGS.value(), Json.encode(holdingsRecord));
-    context.put(ITEM.value(), Json.encode(existingItemJson));
+    context.put(HOLDINGS.value(), Json.encode(holdingsList));
+    context.put(ITEM.value(), Json.encode(Lists.newArrayList(new JsonObject().put("item", existingItemJson))));
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(context)
-      .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withProfileSnapshot(profileSnapshotWrapperForMultipleHoldings)
+      .withCurrentNode(profileSnapshotWrapperForMultipleHoldings.getChildSnapshotWrappers().get(0));
 
     CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
     DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
 
     Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    Assert.assertNotNull(new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
-    Assert.assertEquals(instanceId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("instanceId"));
-    Assert.assertEquals(permanentLocationId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("permanentLocationId"));
-    Assert.assertEquals(hrid, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("hrid"));
-    Assert.assertEquals(holdingId, new JsonObject(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).getString("id"));
+    JsonArray resultedHoldingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    Assert.assertEquals(resultedHoldingsList.size(), 1);
+    JsonObject resultedHoldings = resultedHoldingsList.getJsonObject(0);
+    Assert.assertNotNull(resultedHoldings.getString("id"));
+    Assert.assertEquals(instanceId, resultedHoldings.getString("instanceId"));
+    Assert.assertEquals(permanentLocationId, resultedHoldings.getString("permanentLocationId"));
+    Assert.assertEquals(firstHrid, resultedHoldings.getString("hrid"));
+    Assert.assertEquals(holdingId, resultedHoldings.getString("id"));
   }
 
-  @Test(expected = ExecutionException.class)
-  public void shouldNotProcessHoldingAndInstanceEvent() throws InterruptedException, ExecutionException, TimeoutException {
+  @Test
+  public void shouldProcessEventAndUpdateMultipleHoldings() throws InterruptedException, ExecutionException, TimeoutException {
     Reader fakeReader = Mockito.mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
     when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
-    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
 
+    String firstPermanentLocationId = UUID.randomUUID().toString();
+    String secondPermanentLocationId = UUID.randomUUID().toString();
+    List<String> locations = List.of(firstPermanentLocationId, secondPermanentLocationId);
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(locations.get(0)), StringValue.of(locations.get(1)));
+
+    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    when(storage.getItemCollection(any())).thenReturn(itemCollection);
+
+    MappingManager.registerReaderFactory(fakeReaderFactory);
+    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
+
+    String instanceId = UUID.randomUUID().toString();
+    String holdingId = UUID.randomUUID().toString();
+    String secondId = UUID.randomUUID().toString();
+    String firstHrid = UUID.randomUUID().toString();
+    String secondHrid = UUID.randomUUID().toString();
+
+    HoldingsRecord firstHoldingsRecord = new HoldingsRecord()
+      .withId(holdingId)
+      .withInstanceId(instanceId)
+      .withHrid(firstHrid)
+      .withPermanentLocationId(permanentLocationId);
+
+    HoldingsRecord secondHoldingsRecord = new HoldingsRecord()
+      .withId(secondId)
+      .withInstanceId(instanceId)
+      .withHrid(secondHrid)
+      .withPermanentLocationId(permanentLocationId);
+
+    JsonArray holdingsList = new JsonArray();
+    holdingsList.add(new JsonObject().put("holdings", firstHoldingsRecord));
+    holdingsList.add(new JsonObject().put("holdings", secondHoldingsRecord));
+
+
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID_AND_MULTIPLE_HOLDINGS));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), Json.encode(holdingsList));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapperForMultipleHoldings)
+      .withCurrentNode(profileSnapshotWrapperForMultipleHoldings.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+
+    Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    JsonArray resultedHoldingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    Assert.assertEquals(resultedHoldingsList.size(), 2);
+    JsonObject firstResultedHoldings = resultedHoldingsList.getJsonObject(0);
+    Assert.assertNotNull(firstResultedHoldings.getString("id"));
+    Assert.assertEquals(instanceId, firstResultedHoldings.getString("instanceId"));
+    Assert.assertEquals(firstPermanentLocationId, firstResultedHoldings.getString("permanentLocationId"));
+    Assert.assertEquals(firstHrid, firstResultedHoldings.getString("hrid"));
+    Assert.assertEquals(holdingId, firstResultedHoldings.getString("id"));
+    JsonObject secondResultedHoldings = resultedHoldingsList.getJsonObject(1);
+    Assert.assertNotNull(secondResultedHoldings.getString("id"));
+    Assert.assertEquals(instanceId, secondResultedHoldings.getString("instanceId"));
+    Assert.assertEquals(secondPermanentLocationId, secondResultedHoldings.getString("permanentLocationId"));
+    Assert.assertEquals(secondHrid, secondResultedHoldings.getString("hrid"));
+    Assert.assertEquals(secondId, secondResultedHoldings.getString("id"));
+  }
+
+  @Test
+  public void shouldProcessHoldingAndItemEventButWithPartialErrorIfItemUpdateFailed() throws InterruptedException, ExecutionException, TimeoutException {
+    Reader fakeReader = Mockito.mock(Reader.class);
+    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+
+    String firstPermanentLocationId = UUID.randomUUID().toString();
+    String secondPermanentLocationId = UUID.randomUUID().toString();
+    List<String> locations = List.of(firstPermanentLocationId, secondPermanentLocationId);
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(locations.get(0)), StringValue.of(locations.get(1)));
+
+    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    when(storage.getItemCollection(any())).thenReturn(itemCollection);
+
+    String itemId = UUID.randomUUID().toString();
     JsonObject existingItemJson = new JsonObject()
-      .put("id", UUID.randomUUID().toString())
+      .put("id", itemId)
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
       .put("materialType", new JsonObject().put("id", UUID.randomUUID().toString()))
       .put("permanentLoanType", new JsonObject().put("id", UUID.randomUUID().toString()))
       .put("holdingsRecordId", UUID.randomUUID().toString());
+
+    MappingManager.registerReaderFactory(fakeReaderFactory);
+    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
+
+    String instanceId = UUID.randomUUID().toString();
+    String firstId = UUID.randomUUID().toString();
+    String secondId = UUID.randomUUID().toString();
+    String firstHrid = UUID.randomUUID().toString();
+    String secondHrid = UUID.randomUUID().toString();
+
+    HoldingsRecord firstHoldingsRecord = new HoldingsRecord()
+      .withId(firstId)
+      .withInstanceId(instanceId)
+      .withHrid(firstHrid)
+      .withPermanentLocationId(permanentLocationId);
+
+    HoldingsRecord secondHoldingsRecord = new HoldingsRecord()
+      .withId(secondId)
+      .withInstanceId(instanceId)
+      .withHrid(secondHrid)
+      .withPermanentLocationId(permanentLocationId);
+
+    JsonArray holdingsList = new JsonArray();
+    holdingsList.add(new JsonObject().put("holdings", firstHoldingsRecord));
+    holdingsList.add(new JsonObject().put("holdings", secondHoldingsRecord));
+
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), Json.encode(holdingsList));
+    context.put(ITEM.value(), Json.encode(Lists.newArrayList(new JsonObject().put("item", existingItemJson))));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapperForMultipleHoldings)
+      .withCurrentNode(profileSnapshotWrapperForMultipleHoldings.getChildSnapshotWrappers().get(0));
 
     doAnswer(invocationOnMock -> {
       Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
@@ -261,58 +469,66 @@ public class UpdateHoldingEventHandlerTest {
     }).when(itemCollection).findById(anyString(), any(Consumer.class), any(Consumer.class));
     when(storage.getItemCollection(ArgumentMatchers.any(Context.class))).thenReturn(itemCollection);
 
-    MappingManager.registerReaderFactory(fakeReaderFactory);
-    MappingManager.registerWriterFactory(new HoldingWriterFactory());
-
-    String instanceId = String.valueOf(UUID.randomUUID());
-    String holdingId = UUID.randomUUID().toString();
-    String hrid = UUID.randomUUID().toString();
-
-    HoldingsRecord holdingsRecord = new HoldingsRecord()
-      .withId(holdingId)
-      .withInstanceId(instanceId)
-      .withHrid(hrid)
-      .withPermanentLocationId(permanentLocationId);
-
-    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
-    HashMap<String, String> context = new HashMap<>();
-    context.put(HOLDINGS.value(), Json.encode(holdingsRecord));
-    context.put(ITEM.value(), Json.encode(existingItemJson));
-    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
-
-    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
-      .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
-      .withJobExecutionId(UUID.randomUUID().toString())
-      .withContext(context)
-      .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
-
     CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
-    future.get(5, TimeUnit.SECONDS);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+
+    Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    JsonArray resultedHoldingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    Assert.assertEquals(resultedHoldingsList.size(), 2);
+    JsonObject firstResultedHoldings = resultedHoldingsList.getJsonObject(0);
+    Assert.assertNotNull(firstResultedHoldings.getString("id"));
+    Assert.assertEquals(instanceId, firstResultedHoldings.getString("instanceId"));
+    Assert.assertEquals(firstPermanentLocationId, firstResultedHoldings.getString("permanentLocationId"));
+    Assert.assertEquals(firstHrid, firstResultedHoldings.getString("hrid"));
+    Assert.assertEquals(firstId, firstResultedHoldings.getString("id"));
+    JsonObject secondResultedHoldings = resultedHoldingsList.getJsonObject(1);
+    Assert.assertNotNull(secondResultedHoldings.getString("id"));
+    Assert.assertEquals(instanceId, secondResultedHoldings.getString("instanceId"));
+    Assert.assertEquals(secondPermanentLocationId, secondResultedHoldings.getString("permanentLocationId"));
+    Assert.assertEquals(secondHrid, secondResultedHoldings.getString("hrid"));
+    Assert.assertEquals(secondId, secondResultedHoldings.getString("id"));
+
+    JsonArray errors = new JsonArray(actualDataImportEventPayload.getContext().get(ERRORS));
+    Assert.assertEquals(1, errors.size());
+    JsonObject partialError = errors.getJsonObject(0);
+    Assert.assertEquals("Internal Server Error", partialError.getString("error"));
+    Assert.assertEquals(itemId, partialError.getString("id"));
+
   }
 
-  @Test(expected = ExecutionException.class)
-  public void shouldNotProcessEventIfOLErrorExist() throws InterruptedException, ExecutionException, TimeoutException {
+  @Test
+  public void shouldNotMapHoldingsAndAndFillPartialErrorsIfOptimisticLockingExists() throws InterruptedException, ExecutionException, TimeoutException {
     Reader fakeReader = mock(Reader.class);
 
     String permanentLocationId = UUID.randomUUID().toString();
+    String instanceId = UUID.randomUUID().toString();
+    String firstId = UUID.randomUUID().toString();
+    String secondId = UUID.randomUUID().toString();
+    String firstHrid = UUID.randomUUID().toString();
+    String secondHrid = UUID.randomUUID().toString();
 
-    String instanceId = String.valueOf(UUID.randomUUID());
-    String holdingId = UUID.randomUUID().toString();
-    String hrid = UUID.randomUUID().toString();
-
-    HoldingsRecord holdingsRecord = new HoldingsRecord()
-      .withId(holdingId)
+    HoldingsRecord firstHoldingsRecord = new HoldingsRecord()
+      .withId(firstId)
       .withInstanceId(instanceId)
-      .withHrid(hrid)
+      .withHrid(firstHrid)
       .withPermanentLocationId(permanentLocationId);
 
+    HoldingsRecord secondHoldingsRecord = new HoldingsRecord()
+      .withId(secondId)
+      .withInstanceId(instanceId)
+      .withHrid(secondHrid)
+      .withPermanentLocationId(permanentLocationId);
+
+    JsonArray holdingsList = new JsonArray();
+    holdingsList.add(new JsonObject().put("holdings", firstHoldingsRecord));
+    holdingsList.add(new JsonObject().put("holdings", secondHoldingsRecord));
 
     when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
 
-    HoldingsRecord returnedHoldings = new HoldingsRecord().withId(holdingId).withHrid(hrid).withInstanceId(instanceId).withPermanentLocationId(permanentLocationId).withVersion(1);
+    HoldingsRecord returnedHoldings = new HoldingsRecord().withId(firstId).withHrid(firstHrid).withInstanceId(instanceId).withPermanentLocationId(permanentLocationId).withVersion(1);
 
-    when(holdingsRecordsCollection.findById(anyString())).thenReturn(CompletableFuture.completedFuture(returnedHoldings));
+    when(holdingsRecordsCollection.findById(firstId)).thenReturn(CompletableFuture.completedFuture(returnedHoldings));
 
     doAnswer(invocationOnMock -> {
       Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
@@ -327,137 +543,212 @@ public class UpdateHoldingEventHandlerTest {
     MappingManager.registerReaderFactory(fakeReaderFactory);
     MappingManager.registerWriterFactory(new HoldingWriterFactory());
 
-
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
-    context.put(HOLDINGS.value(), Json.encode(holdingsRecord));
+    context.put(HOLDINGS.value(), Json.encode(holdingsList));
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(context)
-      .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withProfileSnapshot(profileSnapshotWrapperForMultipleHoldings)
+      .withCurrentNode(profileSnapshotWrapperForMultipleHoldings.getChildSnapshotWrappers().get(0));
 
     CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
-    future.get(5, TimeUnit.MILLISECONDS);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+
+    Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertEquals(0, new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value())).size());
+    JsonArray errors = new JsonArray(actualDataImportEventPayload.getContext().get(ERRORS));
+    Assert.assertEquals(2, errors.size());
+    JsonObject firstPartialError = errors.getJsonObject(0);
+    Assert.assertNotNull(firstPartialError.getString("error"));
+    Assert.assertEquals(firstId, firstPartialError.getString("id"));
+    JsonObject secondPartialError = errors.getJsonObject(1);
+    Assert.assertNotNull(secondPartialError.getString("error"));
+    Assert.assertEquals(secondId, secondPartialError.getString("id"));
   }
 
-  @Test(expected = ExecutionException.class)
+  @Test
   public void shouldNotProcessEventIfHoldingIdIsNotExistsInContext() throws InterruptedException, ExecutionException, TimeoutException {
     Reader fakeReader = Mockito.mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
     when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
 
+    String firstPermanentLocationId = UUID.randomUUID().toString();
+    String secondPermanentLocationId = UUID.randomUUID().toString();
+    List<String> locations = List.of(firstPermanentLocationId, secondPermanentLocationId);
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(locations.get(0)), StringValue.of(locations.get(1)));
+
     when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    when(storage.getItemCollection(any())).thenReturn(itemCollection);
 
     MappingManager.registerReaderFactory(fakeReaderFactory);
     MappingManager.registerWriterFactory(new HoldingWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
 
-    String hrid = UUID.randomUUID().toString();
-    String instanceId = String.valueOf(UUID.randomUUID());
+    String instanceId = UUID.randomUUID().toString();
+    String firstHrid = UUID.randomUUID().toString();
+    String secondHrid = UUID.randomUUID().toString();
 
-    HoldingsRecord holdingsRecord = new HoldingsRecord()
+    HoldingsRecord firstHoldingsRecord = new HoldingsRecord()
       .withInstanceId(instanceId)
-      .withHrid(hrid)
+      .withHrid(firstHrid)
       .withPermanentLocationId(permanentLocationId);
 
-    HashMap<String, String> context = new HashMap<>();
+    HoldingsRecord secondHoldingsRecord = new HoldingsRecord()
+      .withInstanceId(instanceId)
+      .withHrid(secondHrid)
+      .withPermanentLocationId(permanentLocationId);
+
+    JsonArray holdingsList = new JsonArray();
+    holdingsList.add(new JsonObject().put("holdings", firstHoldingsRecord));
+    holdingsList.add(new JsonObject().put("holdings", secondHoldingsRecord));
+
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), Json.encode(holdingsList));
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
-    context.put(HOLDINGS.value(), Json.encode(holdingsRecord));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(context)
-      .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withProfileSnapshot(profileSnapshotWrapperForMultipleHoldings)
+      .withCurrentNode(profileSnapshotWrapperForMultipleHoldings.getChildSnapshotWrappers().get(0));
 
     CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
-    future.get(5, TimeUnit.MILLISECONDS);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+
+    Assert.assertNotNull(dataImportEventPayload.getContext().get(HOLDINGS.value()));
+    JsonArray errors = new JsonArray(actualDataImportEventPayload.getContext().get(ERRORS));
+    Assert.assertEquals(2, errors.size());
+    JsonObject firstPartialError = errors.getJsonObject(0);
+    Assert.assertEquals("Can`t update Holding entity: one of required fields(hrid, permanentLocationId, instanceId) are empty!", firstPartialError.getString("error"));
+    JsonObject secondPartialError = errors.getJsonObject(1);
+    Assert.assertEquals("Can`t update Holding entity: one of required fields(hrid, permanentLocationId, instanceId) are empty!", secondPartialError.getString("error"));
   }
 
-
-  @Test(expected = ExecutionException.class)
+  @Test
   public void shouldNotProcessEventIfInstanceIdIsNotExistsInContext() throws InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
+    Reader fakeReader = Mockito.mock(Reader.class);
     when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
 
+    String firstPermanentLocationId = UUID.randomUUID().toString();
+    String secondPermanentLocationId = UUID.randomUUID().toString();
+    List<String> locations = List.of(firstPermanentLocationId, secondPermanentLocationId);
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(locations.get(0)), StringValue.of(locations.get(1)));
+
     when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    when(storage.getItemCollection(any())).thenReturn(itemCollection);
 
     MappingManager.registerReaderFactory(fakeReaderFactory);
     MappingManager.registerWriterFactory(new HoldingWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
 
-    String holdingId = UUID.randomUUID().toString();
-    String hrid = UUID.randomUUID().toString();
+    String instanceId = UUID.randomUUID().toString();
+    String firstId = UUID.randomUUID().toString();
+    String secondId = UUID.randomUUID().toString();
+    String firstHrid = UUID.randomUUID().toString();
+    String secondHrid = UUID.randomUUID().toString();
 
-    HoldingsRecord holdingsRecord = new HoldingsRecord()
-      .withId(holdingId)
-      .withHrid(hrid)
+    HoldingsRecord firstHoldingsRecord = new HoldingsRecord()
+      .withId(firstId)
+      .withHrid(firstHrid)
       .withPermanentLocationId(permanentLocationId);
 
-    HashMap<String, String> context = new HashMap<>();
+    HoldingsRecord secondHoldingsRecord = new HoldingsRecord()
+      .withId(secondId)
+      .withHrid(secondHrid)
+      .withPermanentLocationId(permanentLocationId);
+
+    JsonArray holdingsList = new JsonArray();
+    holdingsList.add(new JsonObject().put("holdings", firstHoldingsRecord));
+    holdingsList.add(new JsonObject().put("holdings", secondHoldingsRecord));
+
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), Json.encode(holdingsList));
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
-    context.put(HOLDINGS.value(), Json.encode(holdingsRecord));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(context)
-      .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withProfileSnapshot(profileSnapshotWrapperForMultipleHoldings)
+      .withCurrentNode(profileSnapshotWrapperForMultipleHoldings.getChildSnapshotWrappers().get(0));
 
     CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
-    future.get(5, TimeUnit.MILLISECONDS);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+
+    Assert.assertNotNull(dataImportEventPayload.getContext().get(HOLDINGS.value()));
+    JsonArray errors = new JsonArray(actualDataImportEventPayload.getContext().get(ERRORS));
+    Assert.assertEquals(2, errors.size());
+    JsonObject firstPartialError = errors.getJsonObject(0);
+    Assert.assertEquals("Can`t update Holding entity: one of required fields(hrid, permanentLocationId, instanceId) are empty!", firstPartialError.getString("error"));
+    JsonObject secondPartialError = errors.getJsonObject(1);
+    Assert.assertEquals("Can`t update Holding entity: one of required fields(hrid, permanentLocationId, instanceId) are empty!", secondPartialError.getString("error"));
   }
 
-  @Test(expected = ExecutionException.class)
+  @Test
   public void shouldNotProcessEventIfPermanentLocationIdIsNotExistsInContext() throws InterruptedException, ExecutionException, TimeoutException {
-    Reader fakeReader = mock(Reader.class);
-
-    String permanentLocationId = UUID.randomUUID().toString();
-
-    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
-
+    Reader fakeReader = Mockito.mock(Reader.class);
     when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
 
+    String firstPermanentLocationId = UUID.randomUUID().toString();
+    String secondPermanentLocationId = UUID.randomUUID().toString();
+    List<String> locations = List.of(firstPermanentLocationId, secondPermanentLocationId);
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(locations.get(0)), StringValue.of(locations.get(1)));
+
     when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    when(storage.getItemCollection(any())).thenReturn(itemCollection);
 
     MappingManager.registerReaderFactory(fakeReaderFactory);
     MappingManager.registerWriterFactory(new HoldingWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
 
-    String holdingId = UUID.randomUUID().toString();
-    String hrid = UUID.randomUUID().toString();
-    String instanceId = String.valueOf(UUID.randomUUID());
+    String instanceId = UUID.randomUUID().toString();
+    String firstId = UUID.randomUUID().toString();
+    String secondId = UUID.randomUUID().toString();
+    String firstHrid = UUID.randomUUID().toString();
+    String secondHrid = UUID.randomUUID().toString();
 
-    HoldingsRecord holdingsRecord = new HoldingsRecord()
-      .withId(holdingId)
-      .withHrid(hrid)
+    HoldingsRecord firstHoldingsRecord = new HoldingsRecord()
+      .withId(firstId)
+      .withHrid(firstHrid)
       .withInstanceId(instanceId);
 
-    HashMap<String, String> context = new HashMap<>();
+    HoldingsRecord secondHoldingsRecord = new HoldingsRecord()
+      .withId(secondId)
+      .withHrid(secondHrid)
+      .withInstanceId(instanceId);
+
+    JsonArray holdingsList = new JsonArray();
+    holdingsList.add(new JsonObject().put("holdings", firstHoldingsRecord));
+    holdingsList.add(new JsonObject().put("holdings", secondHoldingsRecord));
+
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), Json.encode(holdingsList));
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
-    context.put(HOLDINGS.value(), Json.encode(holdingsRecord));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(context)
-      .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withProfileSnapshot(profileSnapshotWrapperForMultipleHoldings)
+      .withCurrentNode(profileSnapshotWrapperForMultipleHoldings.getChildSnapshotWrappers().get(0));
 
     CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
-    future.get(5, TimeUnit.MILLISECONDS);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+
+    Assert.assertNotNull(dataImportEventPayload.getContext().get(HOLDINGS.value()));
+    JsonArray errors = new JsonArray(actualDataImportEventPayload.getContext().get(ERRORS));
+    Assert.assertEquals(2, errors.size());
+    JsonObject firstPartialError = errors.getJsonObject(0);
+    Assert.assertEquals("Can`t update Holding entity: one of required fields(hrid, permanentLocationId, instanceId) are empty!", firstPartialError.getString("error"));
+    JsonObject secondPartialError = errors.getJsonObject(1);
+    Assert.assertEquals("Can`t update Holding entity: one of required fields(hrid, permanentLocationId, instanceId) are empty!", secondPartialError.getString("error"));
   }
 
   @Test(expected = ExecutionException.class)

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -246,7 +246,7 @@ public class UpdateHoldingEventHandlerTest {
     Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
     JsonArray resultedHoldingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    Assert.assertEquals(resultedHoldingsList.size(), 1);
+    Assert.assertEquals(1, resultedHoldingsList.size());
     JsonObject resultedHoldings = resultedHoldingsList.getJsonObject(0);
     Assert.assertNotNull(resultedHoldings.getString("id"));
     Assert.assertEquals(instanceId, resultedHoldings.getString("instanceId"));
@@ -391,7 +391,7 @@ public class UpdateHoldingEventHandlerTest {
     Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
     JsonArray resultedHoldingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    Assert.assertEquals(resultedHoldingsList.size(), 1);
+    Assert.assertEquals(1, resultedHoldingsList.size());
     JsonObject resultedHoldings = resultedHoldingsList.getJsonObject(0);
     Assert.assertNotNull(resultedHoldings.getString("id"));
     Assert.assertEquals(instanceId, resultedHoldings.getString("instanceId"));
@@ -458,7 +458,7 @@ public class UpdateHoldingEventHandlerTest {
     Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
     JsonArray resultedHoldingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    Assert.assertEquals(resultedHoldingsList.size(), 2);
+    Assert.assertEquals(2, resultedHoldingsList.size());
     JsonObject firstResultedHoldings = resultedHoldingsList.getJsonObject(0);
     Assert.assertNotNull(firstResultedHoldings.getString("id"));
     Assert.assertEquals(instanceId, firstResultedHoldings.getString("instanceId"));
@@ -546,7 +546,7 @@ public class UpdateHoldingEventHandlerTest {
     Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
     JsonArray resultedHoldingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    Assert.assertEquals(resultedHoldingsList.size(), 2);
+    Assert.assertEquals(2, resultedHoldingsList.size());
     JsonObject firstResultedHoldings = resultedHoldingsList.getJsonObject(0);
     Assert.assertNotNull(firstResultedHoldings.getString("id"));
     Assert.assertEquals(instanceId, firstResultedHoldings.getString("instanceId"));

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchItemEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchItemEventHandlerUnitTest.java
@@ -3,6 +3,7 @@ package org.folio.inventory.eventhandlers;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.folio.rest.jaxrs.model.EntityType.HOLDINGS;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
@@ -43,6 +44,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.inventory.dataimport.HoldingsItemMatcherFactory;
+import org.folio.processing.matching.MatchingManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -116,6 +119,7 @@ public class MatchItemEventHandlerUnitTest {
       .thenReturn(StringValue.of(ITEM_HRID));
     MatchValueReaderFactory.register(marcValueReader);
     MatchValueLoaderFactory.register(itemLoader);
+    MatchingManager.registerMatcherFactory(new HoldingsItemMatcherFactory());
 
     when(mappingMetadataCache.get(anyString(), any(Context.class)))
       .thenReturn(Future.succeededFuture(Optional.of(new MappingMetadataDto()
@@ -463,6 +467,7 @@ public class MatchItemEventHandlerUnitTest {
           .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
           .withMatchDetails(singletonList(new MatchDetail()
             .withMatchCriterion(EXACTLY_MATCHES)
+            .withExistingRecordType(HOLDINGS)
             .withExistingMatchExpression(new MatchExpression()
               .withDataValueType(VALUE_FROM_RECORD)
               .withFields(singletonList(


### PR DESCRIPTION
## Purpose
Implement logic fo create/update of multiple holdings/item
## Approach
[[MODINV-785]](https://github.com/folio-org/mod-inventory/pull/584) Update Create Holdings handler to support list of mapped holdings in context
[[MODINV-786]](https://github.com/folio-org/mod-inventory/pull/588) Update Create Item handler to support list of mapped items in context
[[MODINV-801]](https://github.com/folio-org/mod-inventory/pull/593) Change Update Holdings handler to support list of mapped holdings in context.
[[MODINV-802]](https://github.com/folio-org/mod-inventory/pull/595) Change Update Item handler to support list of mapped items in context
