### PR TITLE
MODINV-817: Shadow Instances - add support for Consortium source values

### DIFF
--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -50,6 +50,7 @@ import org.folio.inventory.support.http.server.JsonResponse;
 import org.folio.inventory.support.http.server.RedirectResponse;
 import org.folio.inventory.support.http.server.ServerErrorResponse;
 import org.folio.inventory.validation.InstancePrecedingSucceedingTitleValidators;
+import org.folio.inventory.validation.InstanceSourceTypeValidator;
 import org.folio.inventory.validation.InstancesValidators;
 import org.folio.rest.client.SourceStorageRecordsClient;
 
@@ -148,6 +149,7 @@ public class Instances extends AbstractInstances {
 
     completedFuture(newInstance)
       .thenCompose(InstancePrecedingSucceedingTitleValidators::refuseWhenUnconnectedHasNoTitle)
+      .thenCompose(InstanceSourceTypeValidator::refuseWhenIncorrectSource)
       .thenCompose(instance -> storage.getInstanceCollection(context).add(instance))
       .thenCompose(response -> {
         response.setParentInstances(newInstance.getParentInstances());

--- a/src/main/java/org/folio/inventory/validation/InstanceSourceTypeValidator.java
+++ b/src/main/java/org/folio/inventory/validation/InstanceSourceTypeValidator.java
@@ -18,13 +18,14 @@ public final class InstanceSourceTypeValidator {
   private InstanceSourceTypeValidator() {}
 
   public static CompletableFuture<Instance> refuseWhenIncorrectSource(Instance instance) {
-
-    final ValidationError incorrectSourceError = new ValidationError(
-      "Instance source is incorrect", "source", instance.getSource());
-
     return isSourceTypeCorrect(instance.getSource())
       ? completedFuture(instance)
-      : failedFuture(new UnprocessableEntityException(incorrectSourceError));
+      : failedFuture(new UnprocessableEntityException(getExceptionMessage(instance)));
+  }
+
+  private static ValidationError getExceptionMessage(Instance instance) {
+    return new ValidationError("Instance source is incorrect",
+      "source", instance.getSource());
   }
 
   private static boolean isSourceTypeCorrect(String sourceType) {

--- a/src/main/java/org/folio/inventory/validation/InstanceSourceTypeValidator.java
+++ b/src/main/java/org/folio/inventory/validation/InstanceSourceTypeValidator.java
@@ -13,7 +13,7 @@ import static org.folio.inventory.support.CompletableFutures.failedFuture;
 
 public final class InstanceSourceTypeValidator {
 
-  private final static String[] INSTANCE_SOURCE_TYPES = {"MARC", "FOLIO", "CONSORTIUM-MARC", "CONSORTIUM-FOLIO"};
+  private static final String[] INSTANCE_SOURCE_TYPES = {"MARC", "FOLIO", "CONSORTIUM-MARC", "CONSORTIUM-FOLIO"};
 
   private InstanceSourceTypeValidator() {}
 

--- a/src/main/java/org/folio/inventory/validation/InstanceSourceTypeValidator.java
+++ b/src/main/java/org/folio/inventory/validation/InstanceSourceTypeValidator.java
@@ -1,0 +1,34 @@
+package org.folio.inventory.validation;
+
+import org.folio.inventory.domain.instances.Instance;
+import org.folio.inventory.exceptions.UnprocessableEntityException;
+import org.folio.inventory.support.http.server.ValidationError;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.logging.log4j.util.Strings.isNotBlank;
+import static org.folio.inventory.support.CompletableFutures.failedFuture;
+
+public final class InstanceSourceTypeValidator {
+
+  private final static String[] INSTANCE_SOURCE_TYPES = {"MARC", "FOLIO", "CONSORTIUM-MARC", "CONSORTIUM-FOLIO"};
+
+  private InstanceSourceTypeValidator() {}
+
+  public static CompletableFuture<Instance> refuseWhenIncorrectSource(Instance instance) {
+
+    final ValidationError incorrectSourceError = new ValidationError(
+      "Instance source is incorrect", "source", instance.getSource());
+
+    return isSourceTypeCorrect(instance.getSource())
+      ? completedFuture(instance)
+      : failedFuture(new UnprocessableEntityException(incorrectSourceError));
+  }
+
+  private static boolean isSourceTypeCorrect(String sourceType) {
+    return isNotBlank(sourceType) && Arrays.stream(INSTANCE_SOURCE_TYPES).anyMatch(sourceType::equals);
+  }
+
+}

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static support.matchers.ResponseMatchers.hasValidationError;
+import static api.support.InstanceSamples.INSTANCE_SOURCE;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -91,7 +92,7 @@ public class InstancesApiExamples extends ApiTests {
       .put("contributors", new JsonArray().add(new JsonObject()
         .put("contributorNameTypeId", ApiTestSuite.getPersonalContributorNameType())
         .put("name", "Chambers, Becky")))
-      .put("source", "Local")
+      .put("source", INSTANCE_SOURCE)
       .put("administrativeNotes", adminNote)
       .put("instanceTypeId", ApiTestSuite.getTextInstanceType())
       .put(TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray().add(tagNameOne)))
@@ -129,7 +130,7 @@ public class InstancesApiExamples extends ApiTests {
 
     assertThat(createdInstance.containsKey("id"), is(true));
     assertThat(createdInstance.getString("title"), is("Long Way to a Small Angry Planet"));
-    assertThat(createdInstance.getString("source"), is("Local"));
+    assertThat(createdInstance.getString("source"), is(INSTANCE_SOURCE));
     assertThat(createdInstance.getString("instanceTypeId"), is(ApiTestSuite.getTextInstanceType()));
 
     JsonObject firstIdentifier = createdInstance.getJsonArray("identifiers")
@@ -187,7 +188,7 @@ public class InstancesApiExamples extends ApiTests {
       .put("contributors", new JsonArray().add(new JsonObject()
         .put("contributorNameTypeId", ApiTestSuite.getPersonalContributorNameType())
         .put("name", "Chambers, Becky")))
-      .put("source", "Local")
+      .put("source", INSTANCE_SOURCE)
       .put("instanceTypeId", ApiTestSuite.getTextInstanceType());
 
     final var postCompleted = okapiClient
@@ -210,7 +211,7 @@ public class InstancesApiExamples extends ApiTests {
 
     assertThat(createdInstance.containsKey("id"), is(true));
     assertThat(createdInstance.getString("title"), is("Long Way to a Small Angry Planet"));
-    assertThat(createdInstance.getString("source"), is("Local"));
+    assertThat(createdInstance.getString("source"), is(INSTANCE_SOURCE));
     assertThat(createdInstance.getString("instanceTypeId"), is(ApiTestSuite.getTextInstanceType()));
 
     JsonObject firstIdentifier = createdInstance.getJsonArray("identifiers")
@@ -239,7 +240,7 @@ public class InstancesApiExamples extends ApiTests {
     JsonObject angryPlanetInstance = new JsonObject()
       .put("id", angryPlanetInstanceId)
       .put("title", "Long Way to a Small Angry Planet")
-      .put("source", "Local")
+      .put("source", INSTANCE_SOURCE)
       .put("instanceTypeId", ApiTestSuite.getTextInstanceType())
       .put(TAGS_KEY, new JsonObject().put(TAG_LIST_KEY, new JsonArray().add(tagNameOne).add(tagNameTwo)));
 
@@ -276,7 +277,7 @@ public class InstancesApiExamples extends ApiTests {
     JsonObject createdAngryPlanetInstance = getAngryPlanetInstanceResponse.getJson();
     assertEquals(createdAngryPlanetInstance.getString("id"), angryPlanetInstanceId);
     assertThat(createdAngryPlanetInstance.getString("title"), is("Long Way to a Small Angry Planet"));
-    assertThat(createdAngryPlanetInstance.getString("source"), is("Local"));
+    assertThat(createdAngryPlanetInstance.getString("source"), is(INSTANCE_SOURCE));
     assertThat(createdAngryPlanetInstance.getString("instanceTypeId"), is(ApiTestSuite.getTextInstanceType()));
 
     assertTrue(createdAngryPlanetInstance.containsKey(TAGS_KEY));
@@ -305,7 +306,7 @@ public class InstancesApiExamples extends ApiTests {
     String angryPlanetInstanceId = UUID.randomUUID().toString();
     JsonObject angryPlanetInstance = new JsonObject()
       .put("id", angryPlanetInstanceId)
-      .put("source", "Local")
+      .put("source", INSTANCE_SOURCE)
       .put("instanceTypeId", ApiTestSuite.getTextInstanceType());
     JsonObject request = new JsonObject();
     request.put("instances", new JsonArray().add(angryPlanetInstance));
@@ -330,7 +331,7 @@ public class InstancesApiExamples extends ApiTests {
     String angryPlanetInstanceId = UUID.randomUUID().toString();
     JsonObject angryPlanetInstance = new JsonObject()
       .put("id", angryPlanetInstanceId)
-      .put("source", "Local")
+      .put("source", INSTANCE_SOURCE)
       .put("instanceTypeId", ApiTestSuite.getTextInstanceType());
 
     String treasureIslandInstanceId = UUID.randomUUID().toString();

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -367,7 +367,6 @@ public class InstancesApiExamples extends ApiTests {
   @Test
   public void instanceTitleIsMandatory()
     throws InterruptedException,
-    MalformedURLException,
     TimeoutException,
     ExecutionException {
 
@@ -382,6 +381,31 @@ public class InstancesApiExamples extends ApiTests {
     assertThat(postResponse.getContentType(), is(ContentType.TEXT_PLAIN));
     assertThat(postResponse.getLocation(), is(nullValue()));
     assertThat(postResponse.getBody(), is("Title must be provided for an instance"));
+  }
+
+  @Test
+  public void cannotCreateAnInstanceWithIncorrectSource()
+    throws InterruptedException, TimeoutException, ExecutionException {
+
+    JsonObject newInstance = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("title", "The Long Way to a Small, Angry Planet")
+      .put("source", "INSTANCE_SOURCE")
+      .put("instanceTypeId", ApiTestSuite.getTextInstanceType());
+
+    final var postCompleted = okapiClient.post(
+      ApiRoot.instances(), newInstance);
+
+    Response postResponse = postCompleted.toCompletableFuture().get(5, SECONDS);
+
+    assertThat(postResponse.getStatusCode(), is(422));
+    assertThat(postResponse.getContentType(), is("application/json; charset=utf-8"));
+    assertThat(postResponse.getLocation(), is(nullValue()));
+
+    JsonObject responseJson = postResponse.getJson();
+    assertThat(responseJson.getJsonArray("errors").size(), is(1));
+    assertThat(responseJson.getJsonArray("errors").getJsonObject(0)
+      .getString("message"), is("Instance source is incorrect"));
   }
 
   @Test

--- a/src/test/java/api/support/InstanceSamples.java
+++ b/src/test/java/api/support/InstanceSamples.java
@@ -18,6 +18,9 @@ import static api.ApiTestSuite.getPersonalContributorNameType;
 import static api.ApiTestSuite.getTextInstanceType;
 
 public class InstanceSamples {
+
+  public static final String INSTANCE_SOURCE = "CONSORTIUM-MARC";
+
   public static JsonObject createInstanceRequest(
     UUID id,
     String title,
@@ -31,7 +34,7 @@ public class InstanceSamples {
       .put("identifiers", identifiers)
       .put("contributors", contributors)
       .put("notes", notes)
-      .put("source", "Local")
+      .put("source", INSTANCE_SOURCE)
       .put("instanceTypeId", getTextInstanceType());
   }
 

--- a/src/test/java/api/support/builders/InstanceRequestBuilder.java
+++ b/src/test/java/api/support/builders/InstanceRequestBuilder.java
@@ -6,6 +6,8 @@ import io.vertx.core.json.JsonObject;
 
 import java.util.UUID;
 
+import static api.support.InstanceSamples.INSTANCE_SOURCE;
+
 public class InstanceRequestBuilder extends AbstractBuilder {
   private final String title;
   private final String contributor;
@@ -31,7 +33,7 @@ public class InstanceRequestBuilder extends AbstractBuilder {
       .put("contributors", new JsonArray().add(new JsonObject()
         .put("contributorNameTypeId", ApiTestSuite.getPersonalContributorNameType())
         .put("name", contributor)))
-      .put("source", "Local")
+      .put("source", INSTANCE_SOURCE)
       .put("instanceTypeId", ApiTestSuite.getTextInstanceType());
   }
 


### PR DESCRIPTION
## Purpose
Shadow Instances are instances that live in a local tenant and share corresponding identifier with another instance in the central tenant of a consortium. Library staff will be able to creating holdings and items under a Shadow Instance but are not able to modify the Shadow Instance.

## Approach
Blocking creating Instances by API with other source values except MARC, FOLIO, CONSORTIUM-MARC, and CONSORTIUM-FOLIO.

## Learning
[MODINV-817](https://issues.folio.org/browse/MODINV-817)