### PR TITLE
MODINV-863:  Add necessary interface into required interfaces in mod-inventory md

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -592,6 +592,10 @@
     {
       "id": "bound-with-parts-storage",
       "version": "1.0"
+    },
+    {
+      "id": "authority-storage",
+      "version": "2.0"
     }
   ],
   "optional": [


### PR DESCRIPTION
## Purpose
Add necessary interface into required interfaces in mod-inventory md


## Approach
[MODINV-863](https://issues.folio.org/browse/MODINV-863)