### PR TITLE
MODINV-834: Upgrade folio-kafka-wrapper to 3.0.0 version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * Data Import 3rd update Action on Item Record Fails ([MODINV-842](https://issues.folio.org/browse/MODINV-842))
 * Adjust Create Instance handler to use existing Instance UUID ([MODINV-840](https://issues.folio.org/browse/MODINV-840))
 * Upgrade mod-inventory to Java 17 ([MODINV-826](https://issues.folio.org/browse/MODINV-826))
+* Upgrade folio-kafka-wrapper to 3.0.0 version ([MODINV-834](https://issues.folio.org/browse/MODINV-834))
 
 ## 20.0.0 2023-02-20
 * Controlled Instance's field properly reflects updates made by user in MARC Authority's 1XX fields ([MODINV-773] (https://issues.folio.org/browse/MODINV-773))


### PR DESCRIPTION
## Purpose
Upgrade folio-kafka-wrapper to 3.0.0 version

## Approach
Upgrade the version of folio-kafka-wrapper to 3.0.0. Check out the readme at https://github.com/folio-org/folio-kafka-wrapper/blob/master/README.md for usage.

Acceptance Criteria
- kafka records are built using KafkaProducerRecordBuilder
- topic names are generated using KafkaTopicNameHelper
