### PR TITLE
MODINV-872: add cache to get consortium data configurations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 20.1.0-SNAPSHOT 2023-XX-XX
+* Add cache to get and store consortium data configurations ([MODINV-872](https://issues.folio.org/browse/MODINV-872))
 * Data Import 3rd update Action on Item Record Fails ([MODINV-842](https://issues.folio.org/browse/MODINV-842))
 * Adjust Create Instance handler to use existing Instance UUID ([MODINV-840](https://issues.folio.org/browse/MODINV-840))
 * Upgrade mod-inventory to Java 17 ([MODINV-826](https://issues.folio.org/browse/MODINV-826))

--- a/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
@@ -44,6 +44,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.DataImportEventTypes;
+import org.folio.inventory.consortium.cache.ConsortiumDataCache;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.cache.ProfileSnapshotCache;
 import org.folio.inventory.dataimport.consumers.DataImportKafkaHandler;
@@ -124,8 +125,10 @@ public class DataImportConsumerVerticle extends AbstractVerticle {
 
     ProfileSnapshotCache profileSnapshotCache = new ProfileSnapshotCache(vertx, client, Long.parseLong(profileSnapshotExpirationTime));
     MappingMetadataCache mappingMetadataCache = new MappingMetadataCache(vertx, client, Long.parseLong(mappingMetadataExpirationTime));
+    ConsortiumDataCache consortiumDataCache = new ConsortiumDataCache(vertx, client);
 
-    DataImportKafkaHandler dataImportKafkaHandler = new DataImportKafkaHandler(vertx, storage, client, profileSnapshotCache, kafkaConfig, mappingMetadataCache);
+    DataImportKafkaHandler dataImportKafkaHandler = new DataImportKafkaHandler(
+      vertx, storage, client, profileSnapshotCache, kafkaConfig, mappingMetadataCache, consortiumDataCache);
 
     List<Future> futures = EVENT_TYPES.stream()
       .map(eventType -> createKafkaConsumerWrapper(kafkaConfig, eventType, dataImportKafkaHandler))

--- a/src/main/java/org/folio/inventory/consortium/cache/ConsortiumDataCache.java
+++ b/src/main/java/org/folio/inventory/consortium/cache/ConsortiumDataCache.java
@@ -1,0 +1,92 @@
+package org.folio.inventory.consortium.cache;
+
+import static io.vertx.core.http.HttpMethod.GET;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.folio.okapi.common.XOkapiHeaders.URL;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.WebClient;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.inventory.consortium.entities.ConsortiumConfiguration;
+
+public class ConsortiumDataCache {
+
+  private static final Logger LOG = LogManager.getLogger(ConsortiumDataCache.class);
+  private static final String EXPIRATION_TIME_PARAM = "cache.consortium-data.expiration.time.seconds";
+  private static final String DEFAULT_EXPIRATION_TIME_SECONDS = "300";
+  private static final String USER_TENANTS_PATH = "/user-tenants?limit=1"; //NOSONAR
+  private static final String USER_TENANTS_FIELD = "userTenants";
+  private static final String CENTRAL_TENANT_ID_FIELD = "centralTenantId";
+  private static final String CONSORTIUM_ID_FIELD = "consortiumId";
+
+  private final HttpClient httpClient;
+  private final AsyncCache<String, Optional<ConsortiumConfiguration>> cache;
+
+  public ConsortiumDataCache(Vertx vertx, HttpClient httpClient) {
+    int expirationTime = Integer.parseInt(System.getProperty(EXPIRATION_TIME_PARAM, DEFAULT_EXPIRATION_TIME_SECONDS));
+    this.httpClient = httpClient;
+    this.cache = Caffeine.newBuilder()
+      .expireAfterWrite(expirationTime, TimeUnit.SECONDS)
+      .executor(task -> vertx.runOnContext(v -> task.run()))
+      .buildAsync();
+  }
+
+  /**
+   * Returns consortium data by specified {@code tenantId}.
+   *
+   * @param tenantId - tenant id
+   * @param headers  - okapi headers
+   * @return future of Optional with consortium data for the specified {@code tenantId},
+   * if the specified {@code tenantId} is not included to any consortium, then returns future with empty Optional
+   */
+  public Future<Optional<ConsortiumConfiguration>> getConsortiumData(String tenantId, Map<String, String> headers) {
+    try {
+      return Future.fromCompletionStage(cache.get(tenantId, (key, executor) -> loadConsortiumData(key, headers)));
+    } catch (Exception e) {
+      LOG.warn("getConsortiumData:: Error loading consortium data, tenantId: '{}'", tenantId, e);
+      return Future.failedFuture(e);
+    }
+  }
+
+  private CompletableFuture<Optional<ConsortiumConfiguration>> loadConsortiumData(String tenantId, Map<String, String> headers) {
+    String okapiUrl = headers.get(URL);
+    WebClient client = WebClient.wrap(httpClient);
+    HttpRequest<Buffer> request = client.requestAbs(GET, okapiUrl + USER_TENANTS_PATH);
+    headers.forEach(request::putHeader);
+
+    return request.send().compose(response -> {
+        if (response.statusCode() != HTTP_OK) {
+          String msg = String.format("Error loading consortium data, tenantId: '%s' response status: '%s', body: '%s'",
+            tenantId, response.statusCode(), response.bodyAsString());
+          LOG.warn("loadConsortiumData:: {}", msg);
+          return Future.failedFuture(msg);
+        }
+        JsonArray userTenants = response.bodyAsJsonObject().getJsonArray(USER_TENANTS_FIELD);
+        if (userTenants.isEmpty()) {
+          return Future.succeededFuture(Optional.<ConsortiumConfiguration>empty());
+        }
+
+        LOG.info("loadConsortiumData:: Consortium data was loaded, tenantId: '{}'", tenantId);
+        JsonObject userTenant = userTenants.getJsonObject(0);
+        return Future.succeededFuture(Optional.of(
+          new ConsortiumConfiguration(userTenant.getString(CENTRAL_TENANT_ID_FIELD), userTenant.getString(CONSORTIUM_ID_FIELD))));
+      }).toCompletionStage()
+      .toCompletableFuture();
+  }
+
+}

--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -14,6 +14,7 @@ import org.folio.inventory.client.OrdersClient;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.dao.EntityIdStorageDaoImpl;
 import org.folio.inventory.common.dao.PostgresClientFactory;
+import org.folio.inventory.consortium.cache.ConsortiumDataCache;
 import org.folio.inventory.consortium.services.ConsortiumService;
 import org.folio.inventory.dataimport.HoldingWriterFactory;
 import org.folio.inventory.dataimport.HoldingsItemMatcherFactory;
@@ -99,13 +100,14 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
   public DataImportKafkaHandler(Vertx vertx, Storage storage, HttpClient client,
                                 ProfileSnapshotCache profileSnapshotCache,
                                 KafkaConfig kafkaConfig,
-                                MappingMetadataCache mappingMetadataCache) {
+                                MappingMetadataCache mappingMetadataCache,
+                                ConsortiumDataCache consortiumDataCache) {
     this.vertx = vertx;
     this.profileSnapshotCache = profileSnapshotCache;
     this.mappingMetadataCache = mappingMetadataCache;
     this.kafkaConfig = kafkaConfig;
     orderHelperService = new OrderHelperServiceImpl(profileSnapshotCache);
-    consortiumService = new ConsortiumServiceImpl(client);
+    consortiumService = new ConsortiumServiceImpl(client, consortiumDataCache);
     registerDataImportProcessingHandlers(storage, client);
   }
 

--- a/src/test/java/org/folio/inventory/consortium/cache/ConsortiumDataCacheTest.java
+++ b/src/test/java/org/folio/inventory/consortium/cache/ConsortiumDataCacheTest.java
@@ -1,0 +1,127 @@
+package org.folio.inventory.consortium.cache;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.folio.inventory.consortium.entities.ConsortiumConfiguration;
+import org.folio.okapi.common.XOkapiHeaders;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class ConsortiumDataCacheTest {
+
+  @ClassRule
+  public static WireMockRule mockServer = new WireMockRule(WireMockConfiguration.wireMockConfig()
+    .notifier(new ConsoleNotifier(false))
+    .dynamicPort());
+
+  private static final String TENANT_ID = "diku";
+  private static final String USER_TENANTS_PATH = "/user-tenants?limit=1";
+  private static final String USER_TENANTS_FIELD = "userTenants";
+  private static final String CENTRAL_TENANT_ID_FIELD = "centralTenantId";
+  private static final String CONSORTIUM_ID_FIELD = "consortiumId";
+
+  private final Vertx vertx = Vertx.vertx();
+  private ConsortiumDataCache consortiumDataCache;
+  private Map<String, String> okapiHeaders;
+
+  @Before
+  public void setUp() {
+    consortiumDataCache = new ConsortiumDataCache(vertx, vertx.createHttpClient());
+    okapiHeaders = Map.of(
+      XOkapiHeaders.TENANT, TENANT_ID,
+      XOkapiHeaders.TOKEN, "token",
+      XOkapiHeaders.URL, mockServer.baseUrl());
+  }
+
+  @Test
+  public void shouldReturnConsortiumData(TestContext context) {
+    Async async = context.async();
+    String expectedCentralTenantId = "mobius";
+    String expectedConsortiumId = UUID.randomUUID().toString();
+
+    JsonObject userTenantsCollection = new JsonObject()
+      .put(USER_TENANTS_FIELD, new JsonArray()
+        .add(new JsonObject()
+          .put(CENTRAL_TENANT_ID_FIELD, expectedCentralTenantId)
+          .put(CONSORTIUM_ID_FIELD, expectedConsortiumId)));
+
+    WireMock.stubFor(get(USER_TENANTS_PATH)
+      .willReturn(WireMock.ok().withBody(userTenantsCollection.encodePrettily())));
+
+    Future<Optional<ConsortiumConfiguration>> future = consortiumDataCache.getConsortiumData(TENANT_ID, okapiHeaders);
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertTrue(ar.result().isPresent());
+      ConsortiumConfiguration consortiumConfig = ar.result().get();
+      context.assertEquals(expectedCentralTenantId, consortiumConfig.getCentralTenantId());
+      context.assertEquals(expectedConsortiumId, consortiumConfig.getConsortiumId());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnEmptyOptionalIfSpecifiedTenantInHeadersIsNotInConsortium(TestContext context) {
+    Async async = context.async();
+    JsonObject emptyUserTenantsCollection = new JsonObject()
+      .put(USER_TENANTS_FIELD, JsonArray.of());
+
+    WireMock.stubFor(get(USER_TENANTS_PATH)
+      .willReturn(WireMock.ok().withBody(emptyUserTenantsCollection.encodePrettily())));
+
+    Future<Optional<ConsortiumConfiguration>> future = consortiumDataCache.getConsortiumData(TENANT_ID, okapiHeaders);
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertTrue(ar.result().isEmpty());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnFailedFutureWhenGetServerErrorOnConsortiumDataLoading(TestContext context) {
+    Async async = context.async();
+    WireMock.stubFor(get(USER_TENANTS_PATH).willReturn(WireMock.serverError()));
+
+    Future<Optional<ConsortiumConfiguration>> future = consortiumDataCache.getConsortiumData(TENANT_ID, okapiHeaders)
+      .onComplete(context.asyncAssertFailure());
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.failed());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnFailedFutureWhenSpecifiedTenantIdIsNull(TestContext context) {
+    Async async = context.async();
+    WireMock.stubFor(get(USER_TENANTS_PATH).willReturn(WireMock.serverError()));
+
+    Future<Optional<ConsortiumConfiguration>> future = consortiumDataCache.getConsortiumData(null, okapiHeaders)
+      .onComplete(context.asyncAssertFailure());
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.failed());
+      async.complete();
+    });
+  }
+}

--- a/src/test/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandlerTest.java
@@ -21,6 +21,7 @@ import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
 import org.folio.JobProfile;
 import org.folio.MappingProfile;
+import org.folio.inventory.consortium.cache.ConsortiumDataCache;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.cache.ProfileSnapshotCache;
 import org.folio.inventory.storage.Storage;
@@ -152,7 +153,8 @@ public class DataImportKafkaHandlerTest {
     HttpClient client = vertx.createHttpClient();
     dataImportKafkaHandler = new DataImportKafkaHandler(vertx, mockedStorage, client,
       new ProfileSnapshotCache(vertx, client, 3600),
-      kafkaConfig, new MappingMetadataCache(vertx, client, 3600));
+      kafkaConfig, new MappingMetadataCache(vertx, client, 3600),
+      new ConsortiumDataCache(vertx, client));
 
     EventManager.clearEventHandlers();
     EventManager.registerKafkaEventPublisher(kafkaConfig, vertx, 1);

--- a/src/test/java/org/folio/inventory/dataimport/services/ConsortiumServiceTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/services/ConsortiumServiceTest.java
@@ -14,6 +14,7 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.inventory.common.Context;
+import org.folio.inventory.consortium.cache.ConsortiumDataCache;
 import org.folio.inventory.consortium.entities.ConsortiumConfiguration;
 import org.folio.inventory.consortium.entities.SharingInstance;
 import org.folio.inventory.consortium.entities.SharingStatus;
@@ -33,7 +34,9 @@ import static org.folio.inventory.support.http.ContentType.APPLICATION_JSON;
 @RunWith(VertxUnitRunner.class)
 public class ConsortiumServiceTest {
   private final Vertx vertx = Vertx.vertx();
-  private final ConsortiumServiceImpl consortiumServiceImpl = new ConsortiumServiceImpl(vertx.createHttpClient());
+  private ConsortiumDataCache consortiumDataCache = new ConsortiumDataCache(vertx, vertx.createHttpClient());
+  private final ConsortiumServiceImpl consortiumServiceImpl =
+    new ConsortiumServiceImpl(vertx.createHttpClient(), consortiumDataCache);
   private final String localTenant = "tenant";
   private final String centralTenantId = "consortiumTenant";
   private final String token = "token";


### PR DESCRIPTION
[MODINV-872](https://issues.folio.org/browse/MODINV-872)

**Description:**  added cache to get and store consortium data configurations

**Testing:** 
Tested locally the flow of Holdings creation

<img width="1303" alt="image" src="https://github.com/folio-org/mod-inventory/assets/138673581/eb80decf-f3fb-4418-8777-d17eede6b5f1">
