### PR TITLE
MODDATAIMP-926: Restrict updating shadow MARC authority records for member tenants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 20.1.0-SNAPSHOT 2023-XX-XX
+* Update status when user attempts to update shared auth record from member tenant ([MODDATAIMP-926](https://issues.folio.org/browse/MODDATAIMP-926))
 * Add cache to get and store consortium data configurations ([MODINV-872](https://issues.folio.org/browse/MODINV-872))
 * Data Import 3rd update Action on Item Record Fails ([MODINV-842](https://issues.folio.org/browse/MODINV-842))
 * Adjust Create Instance handler to use existing Instance UUID ([MODINV-840](https://issues.folio.org/browse/MODINV-840))

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateAuthorityEventHandler.java
@@ -33,6 +33,7 @@ public class UpdateAuthorityEventHandler extends AbstractAuthorityEventHandler {
   private static final String CURRENT_EVENT_TYPE_PROPERTY = "CURRENT_EVENT_TYPE";
   private static final String CURRENT_AUTHORITY_PROPERTY = "CURRENT_AUTHORITY";
   private static final String CURRENT_NODE_PROPERTY = "CURRENT_NODE";
+  private static final String SOURCE_CONSORTIUM_PREFIX = "CONSORTIUM-";
   private static final String ERROR_UPDATING_AUTHORITY_MSG_TEMPLATE = "Failed updating Authority. Cause: %s, status: '%s'";
   private static final String AUTHORITY_NOT_FOUND_MSG = "Authority record was not found by id: %s";
   private final KafkaEventPublisher eventPublisher;
@@ -104,6 +105,10 @@ public class UpdateAuthorityEventHandler extends AbstractAuthorityEventHandler {
     collection.findById(mappedRecord.getId()).thenAccept(actualRecord -> {
       if (actualRecord == null) {
         promise.fail(new EventProcessingException(format(AUTHORITY_NOT_FOUND_MSG, mappedRecord.getId())));
+        return;
+      }
+      if (actualRecord.getSource() != null && actualRecord.getSource().value().startsWith(SOURCE_CONSORTIUM_PREFIX)) {
+        promise.fail(new DataImportException("Shared MARC authority record cannot be updated from this tenant"));
         return;
       }
 


### PR DESCRIPTION
[MODDATAIMP-926](https://issues.folio.org/browse/MODDATAIMP-926)

**Depends on PR:** https://github.com/folio-org/data-import-processing-core/pull/309

**Purpose:** restrict updating shadow MARC authority records for member tenants