### PR TITLE
MODDICORE-366: Remove distinct by permanentLocationId for multiple Holdings during mapping if Holdings already contain at the context

### DIFF
--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -247,7 +247,6 @@ public class UpdateHoldingEventHandlerTest {
     Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
     JsonArray resultedHoldingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    Assert.assertEquals(1, resultedHoldingsList.size());
     JsonObject resultedHoldings = resultedHoldingsList.getJsonObject(0);
     Assert.assertNotNull(resultedHoldings.getString("id"));
     Assert.assertEquals(instanceId, resultedHoldings.getString("instanceId"));
@@ -392,7 +391,6 @@ public class UpdateHoldingEventHandlerTest {
     Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
     JsonArray resultedHoldingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
-    Assert.assertEquals(1, resultedHoldingsList.size());
     JsonObject resultedHoldings = resultedHoldingsList.getJsonObject(0);
     Assert.assertNotNull(resultedHoldings.getString("id"));
     Assert.assertEquals(instanceId, resultedHoldings.getString("instanceId"));


### PR DESCRIPTION
## Purpose
Remove distinct by permanentLocationId for multiple Holdings during mapping if Holdings already contain at the context
## Approach
Removed test check related to holdings with the same permanentLocationId like in [MODDICORE-366](https://github.com/folio-org/data-import-processing-core/pull/310).
