### PR TITLE
MODINV-886 - Problem with Inventory Single Record Imports for UPDATES in member tenant, for shared instances

### DIFF
--- a/src/main/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImpl.java
+++ b/src/main/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImpl.java
@@ -75,7 +75,7 @@ public class MarcInstanceSharingHandlerImpl implements InstanceSharingHandler {
         return restDataImportHelper.importMarcRecord(marcRecord, sharingInstanceMetadata, kafkaHeaders)
           .compose(result -> {
             if ("COMMITTED".equals(result)) {
-              // Delete source record by instance ID if the result is "COMMITTED"
+              // Delete source record by record ID if the result is "COMMITTED"
               return deleteSourceRecordByRecordId(marcRecord.getId(), instanceId, sourceTenant, sourceStorageClient)
                 .compose(deletedInstanceId ->
                   instanceOperations.getInstanceById(instanceId, target))

--- a/src/main/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImpl.java
+++ b/src/main/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImpl.java
@@ -204,6 +204,7 @@ public class MarcInstanceSharingHandlerImpl implements InstanceSharingHandler {
             recordId, instanceId, tenantId, responseResult.cause());
           promise.fail(responseResult.cause());
         } else {
+          LOGGER.info("TEST: resp status: {}, body: {}", responseResult.result().statusCode(), responseResult.result().bodyAsString());
           LOGGER.info("deleteSourceRecordByInstanceId:: Source record with recordId={} for instance with InstanceId={} from tenant {} has been deleted.",
             recordId, instanceId, tenantId);
           promise.complete(instanceId);

--- a/src/main/java/org/folio/inventory/consortium/util/RestDataImportHelper.java
+++ b/src/main/java/org/folio/inventory/consortium/util/RestDataImportHelper.java
@@ -210,13 +210,13 @@ public class RestDataImportHelper {
     }
 
     LOGGER.info("checkDataImportStatus:: Checking import status by jobExecutionId={}. InstanceId={}.",
-      sharingInstanceMetadata.getInstanceIdentifier(), jobExecutionId);
+      jobExecutionId, sharingInstanceMetadata.getInstanceIdentifier());
 
     getJobExecutionStatusByJobExecutionId(jobExecutionId, changeManagerClient).onComplete(jobExecution -> {
       if (jobExecution.succeeded()) {
         String jobExecutionStatus = jobExecution.result();
         LOGGER.info("checkDataImportStatus:: Check import status for DI with jobExecutionId={}, InstanceId={}, JobExecutionStatus={}",
-          sharingInstanceMetadata.getInstanceIdentifier(), jobExecutionId, jobExecutionStatus);
+          jobExecutionId, sharingInstanceMetadata.getInstanceIdentifier(), jobExecutionStatus);
         if (jobExecutionStatus.equals(STATUS_COMMITTED) || jobExecutionStatus.equals(STATUS_ERROR)) {
           promise.complete(jobExecutionStatus);
         } else {

--- a/src/test/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImplTest.java
+++ b/src/test/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImplTest.java
@@ -47,6 +47,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import static org.folio.HttpStatus.HTTP_INTERNAL_SERVER_ERROR;
+import static org.folio.HttpStatus.HTTP_NO_CONTENT;
 import static org.folio.inventory.consortium.util.RestDataImportHelperTest.buildHttpResponseWithBuffer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -141,7 +143,7 @@ public class MarcInstanceSharingHandlerImplTest {
     when(restDataImportHelper.importMarcRecord(any(), any(), any()))
       .thenReturn(Future.succeededFuture("COMMITTED"));
 
-    doReturn(Future.succeededFuture(instanceId)).when(marcHandler).deleteSourceRecordByInstanceId(any(), any(), any(), any());
+    doReturn(Future.succeededFuture(instanceId)).when(marcHandler).deleteSourceRecordByRecordId(any(), any(), any(), any());
     when(instance.getJsonForStorage()).thenReturn((JsonObject) Json.decodeValue(recordJson));
     when(instance.getHrid()).thenReturn(targetInstanceHrid);
     when(instanceOperationsHelper.updateInstance(any(), any())).thenReturn(Future.succeededFuture());
@@ -201,7 +203,7 @@ public class MarcInstanceSharingHandlerImplTest {
     when(entitiesLinksService.getInstanceAuthorityLinks(any(), any()))
       .thenReturn(Future.succeededFuture(links));
 
-    doReturn(Future.succeededFuture(instanceId)).when(marcHandler).deleteSourceRecordByInstanceId(any(), any(), any(), any());
+    doReturn(Future.succeededFuture(instanceId)).when(marcHandler).deleteSourceRecordByRecordId(any(), any(), any(), any());
     when(instance.getJsonForStorage()).thenReturn((JsonObject) Json.decodeValue(recordJsonWithLinkedAuthorities));
     when(instance.getHrid()).thenReturn(targetInstanceHrid);
     when(instanceOperationsHelper.updateInstance(any(), any())).thenReturn(Future.succeededFuture());
@@ -325,7 +327,7 @@ public class MarcInstanceSharingHandlerImplTest {
     when(entitiesLinksService.getInstanceAuthorityLinks(any(), any()))
       .thenReturn(Future.succeededFuture(links));
 
-    doReturn(Future.succeededFuture(instanceId)).when(marcHandler).deleteSourceRecordByInstanceId(any(), any(), any(), any());
+    doReturn(Future.succeededFuture(instanceId)).when(marcHandler).deleteSourceRecordByRecordId(any(), any(), any(), any());
     when(instance.getJsonForStorage()).thenReturn((JsonObject) Json.decodeValue(recordJsonWithLinkedAuthorities));
     when(instance.getHrid()).thenReturn(targetInstanceHrid);
     when(instanceOperationsHelper.updateInstance(any(), any())).thenReturn(Future.succeededFuture());
@@ -419,11 +421,14 @@ public class MarcInstanceSharingHandlerImplTest {
     String instanceId = "fea6477b-d8f5-4d22-9e86-6218407c780b";
     String tenant = "sourceTenant";
 
+    HttpResponse<Buffer> mockedResponse = mock(HttpResponse.class);
+
+    when(mockedResponse.statusCode()).thenReturn(HTTP_NO_CONTENT.toInt());
     when(sourceStorageClient.deleteSourceStorageRecordsById(any()))
-      .thenReturn(Future.succeededFuture());
+      .thenReturn(Future.succeededFuture(mockedResponse));
 
     MarcInstanceSharingHandlerImpl handler = new MarcInstanceSharingHandlerImpl(instanceOperationsHelper, null, vertx, httpClient);
-    handler.deleteSourceRecordByInstanceId(recordId, instanceId, tenant, sourceStorageClient)
+    handler.deleteSourceRecordByRecordId(recordId, instanceId, tenant, sourceStorageClient)
       .onComplete(result -> assertEquals(instanceId, result.result()));
 
     verify(sourceStorageClient, times(1)).deleteSourceStorageRecordsById(recordId);
@@ -440,7 +445,26 @@ public class MarcInstanceSharingHandlerImplTest {
       .thenReturn(Future.failedFuture(new NotFoundException("Not found")));
 
     MarcInstanceSharingHandlerImpl handler = new MarcInstanceSharingHandlerImpl(instanceOperationsHelper, null, vertx, httpClient);
-    handler.deleteSourceRecordByInstanceId(recordId, instanceId, tenant, sourceStorageClient)
+    handler.deleteSourceRecordByRecordId(recordId, instanceId, tenant, sourceStorageClient)
+      .onComplete(result -> assertTrue(result.failed()));
+
+    verify(sourceStorageClient, times(1)).deleteSourceStorageRecordsById(recordId);
+  }
+
+  @Test
+  public void deleteSourceRecordByInstanceIdFailedTestWhenResponseStatusIsNotNoContent() {
+
+    String instanceId = "991f37c8-cd22-4db7-9543-a4ec68735e95";
+    String recordId = "fea6477b-d8f5-4d22-9e86-6218407c780b";
+    String tenant = "sourceTenant";
+
+    HttpResponse<Buffer> mockedResponse = mock(HttpResponse.class);
+    when(mockedResponse.statusCode()).thenReturn(HTTP_INTERNAL_SERVER_ERROR.toInt());
+    when(sourceStorageClient.deleteSourceStorageRecordsById(any()))
+      .thenReturn(Future.succeededFuture(mockedResponse));
+
+    MarcInstanceSharingHandlerImpl handler = new MarcInstanceSharingHandlerImpl(instanceOperationsHelper, null, vertx, httpClient);
+    handler.deleteSourceRecordByRecordId(recordId, instanceId, tenant, sourceStorageClient)
       .onComplete(result -> assertTrue(result.failed()));
 
     verify(sourceStorageClient, times(1)).deleteSourceStorageRecordsById(recordId);

--- a/src/test/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImplTest.java
+++ b/src/test/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImplTest.java
@@ -453,7 +453,6 @@ public class MarcInstanceSharingHandlerImplTest {
 
   @Test
   public void deleteSourceRecordByInstanceIdFailedTestWhenResponseStatusIsNotNoContent() {
-
     String instanceId = "991f37c8-cd22-4db7-9543-a4ec68735e95";
     String recordId = "fea6477b-d8f5-4d22-9e86-6218407c780b";
     String tenant = "sourceTenant";


### PR DESCRIPTION
## Purpose
Lack of permission causes an error on record deletion on local tenant. As a result local marc record that should be deleted/marked as deleted is considered during records matching that in turn causes multiple matching error (and error during single record imports for record updates).
The module gets an error response on record deletion but the module logs say that marc record has been deleted.

## Approach
* add response status verification from request for record deletion in order to complete result and to write log message accordingly
* add and update test

## Learning
[MODINV-886](https://issues.folio.org/browse/MODINV-886)

Requires: https://github.com/folio-org/mod-consortia/pull/129