### PR TITLE
[MODINV-890] Create entity links for sharing authorities on central tenant during Instance sharing process

### DIFF
--- a/src/main/java/org/folio/inventory/consortium/util/RestDataImportHelper.java
+++ b/src/main/java/org/folio/inventory/consortium/util/RestDataImportHelper.java
@@ -53,8 +53,8 @@ public class RestDataImportHelper {
   }
 
   public static final JobProfileInfo JOB_PROFILE_INFO = new JobProfileInfo()
-    .withId("e34d7b92-9b83-11eb-a8b3-0242ac130003") //default stub id
-    .withName("Default - Create instance and SRS MARC Bib")
+    .withId("90fd4389-e5a9-4cc5-88cf-1568c0ff7e8b") //default stub id
+    .withName("ECS - Create instance and SRS MARC Bib")
     .withDataType(JobProfileInfo.DataType.MARC);
 
   /**
@@ -82,7 +82,7 @@ public class RestDataImportHelper {
       .compose(jobExecutionId -> setDefaultJobProfileToJobExecution(jobExecutionId, changeManagerClient))
       .compose(jobExecutionId -> {
         RawRecordsDto dataChunk = buildDataChunk(false, singletonList(new InitialRecord().withRecord(
-          JsonObject.mapFrom(marcRecord.getParsedRecord().getContent()).toString())));
+          getParsedRecordContentAsString(marcRecord))));
         return postChunk(jobExecutionId, true, dataChunk, changeManagerClient)
           .compose(response -> {
             //Sending empty chunk to finish import
@@ -91,6 +91,13 @@ public class RestDataImportHelper {
           });
       })
       .compose(jobExecutionId -> checkDataImportStatus(jobExecutionId, sharingInstanceMetadata, durationInSec, attemptsNumber, changeManagerClient));
+  }
+
+  private static String getParsedRecordContentAsString(Record marcRecord) {
+    if (marcRecord.getParsedRecord().getContent() instanceof String parsedRecordContent) {
+      return parsedRecordContent;
+    }
+    return JsonObject.mapFrom(marcRecord.getParsedRecord().getContent()).toString();
   }
 
   protected Future<String> initJobExecution(String instanceId, ChangeManagerClient changeManagerClient, Map<String, String> kafkaHeaders) {

--- a/src/main/java/org/folio/inventory/services/EntitiesLinksService.java
+++ b/src/main/java/org/folio/inventory/services/EntitiesLinksService.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface EntitiesLinksService {
   Future<List<Link>> getInstanceAuthorityLinks(Context context, String instanceId);
-  Future<List<Link>> putInstanceAuthorityLinks(Context context, String instanceId, List<Link> entityLinks);
+  Future<Void> putInstanceAuthorityLinks(Context context, String instanceId, List<Link> entityLinks);
   Future<List<LinkingRuleDto>> getLinkingRules(Context context);
 }

--- a/src/main/java/org/folio/inventory/services/EntitiesLinksServiceImpl.java
+++ b/src/main/java/org/folio/inventory/services/EntitiesLinksServiceImpl.java
@@ -15,12 +15,12 @@ import org.folio.Link;
 import org.folio.LinkingRuleDto;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.consortium.exceptions.ConsortiumException;
-import org.folio.inventory.support.http.client.Response;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.String.format;
 import static org.folio.inventory.consortium.util.ConsortiumUtil.DEFAULT_EXPIRATION_TIME_SECONDS;
 import static org.folio.inventory.consortium.util.ConsortiumUtil.EXPIRATION_TIME_PARAM;
 import static org.folio.inventory.consortium.util.ConsortiumUtil.createOkapiHttpClient;
@@ -29,7 +29,11 @@ public class EntitiesLinksServiceImpl implements EntitiesLinksService {
   private static final Logger LOGGER = LogManager.getLogger(EntitiesLinksServiceImpl.class);
   private static final String AUTHORITY_LINK_PATH = "/links/instances/%s";
   private static final String LINKING_RULES_PATH = "/linking-rules/instance-authority";
+  private static final String SUCCESS_MESSAGE = "Successfully %s entities links for instance with id: %s";
+  private static final String ERROR_MESSAGE = "Error during %s entities links for instance with id: %s, status code: %s, response message: %s";
   public static final String LINKS = "links";
+  public static final String GET = "get";
+  public static final String UPDATE = "update";
   private final HttpClient httpClient;
   private final AsyncCache<String, List<LinkingRuleDto>> linkingRulesCache;
 
@@ -46,38 +50,38 @@ public class EntitiesLinksServiceImpl implements EntitiesLinksService {
   public Future<List<Link>> getInstanceAuthorityLinks(Context context, String instanceId) {
     CompletableFuture<List<Link>> completableFuture = createOkapiHttpClient(context, httpClient)
       .thenCompose(client ->
-        client.get(context.getOkapiLocation() + String.format(AUTHORITY_LINK_PATH, instanceId))
+        client.get(context.getOkapiLocation() + format(AUTHORITY_LINK_PATH, instanceId))
           .thenCompose(httpResponse -> {
-            String successMessage = String.format("getInstanceAuthorityLinks:: Successfully retrieved entities links for instance with id: %s", instanceId);
-            String errorMessage = String.format("Error during retrieving entity links for instance with id: %s", instanceId);
-            return handleInstanceAuthorityLinksResponse(httpResponse, successMessage, errorMessage);
+            if (httpResponse.getStatusCode() == HttpStatus.SC_OK) {
+              List<Link> response = List.of(Json.decodeValue(Json.encode(httpResponse.getJson().getJsonArray(LINKS)), Link[].class));
+              LOGGER.debug(format(SUCCESS_MESSAGE, GET, instanceId));
+              return CompletableFuture.completedFuture(response);
+            } else {
+              String errorMessage = format(ERROR_MESSAGE, GET, instanceId, httpResponse.getStatusCode(), httpResponse.getBody());
+              LOGGER.warn(errorMessage, httpResponse.getBody());
+              return CompletableFuture.failedFuture(new ConsortiumException(errorMessage));
+            }
           }));
     return Future.fromCompletionStage(completableFuture);
   }
 
   @Override
-  public Future<List<Link>> putInstanceAuthorityLinks(Context context, String instanceId, List<Link> entityLinks) {
+  public Future<Void> putInstanceAuthorityLinks(Context context, String instanceId, List<Link> entityLinks) {
     JsonObject body = new JsonObject().put(LINKS, new JsonArray(entityLinks));
-    CompletableFuture<List<Link>> completableFuture = createOkapiHttpClient(context, httpClient)
+    CompletableFuture<Void> completableFuture = createOkapiHttpClient(context, httpClient)
       .thenCompose(client ->
-        client.put(context.getOkapiLocation() + String.format(AUTHORITY_LINK_PATH, instanceId), body)
+        client.put(context.getOkapiLocation() + format(AUTHORITY_LINK_PATH, instanceId), body)
           .thenCompose(httpResponse -> {
-            String successMessage = String.format("getInstanceAuthorityLinks:: Successfully updated entities links for instance with id: %s", instanceId);
-            String errorMessage = String.format("Error during updating entity links for instance with id: %s", instanceId);
-            return handleInstanceAuthorityLinksResponse(httpResponse, successMessage, errorMessage);
+            if (httpResponse.getStatusCode() == HttpStatus.SC_NO_CONTENT) {
+              LOGGER.debug(format(SUCCESS_MESSAGE, UPDATE, instanceId));
+              return CompletableFuture.completedFuture(null);
+            } else {
+              String errorMessage = format(ERROR_MESSAGE, UPDATE, instanceId, httpResponse.getStatusCode(), httpResponse.getBody());
+              LOGGER.warn(errorMessage, httpResponse.getBody());
+              return CompletableFuture.failedFuture(new ConsortiumException(errorMessage));
+            }
           }));
     return Future.fromCompletionStage(completableFuture);
-  }
-
-  private static CompletableFuture<List<Link>> handleInstanceAuthorityLinksResponse(Response httpResponse, String successMessage, String errorMessage) {
-    if (httpResponse.getStatusCode() == HttpStatus.SC_OK) {
-      List<Link> response = List.of(Json.decodeValue(Json.encode(httpResponse.getJson().getJsonArray(LINKS)), Link[].class));
-      LOGGER.debug(successMessage);
-      return CompletableFuture.completedFuture(response);
-    } else {
-      LOGGER.warn(errorMessage);
-      return CompletableFuture.failedFuture(new ConsortiumException(errorMessage));
-    }
   }
 
   @Override
@@ -97,8 +101,9 @@ public class EntitiesLinksServiceImpl implements EntitiesLinksService {
         LOGGER.debug("loadLinkingRules:: Successfully loaded linking rules for tenant with id: {}", context.getTenantId());
         return CompletableFuture.completedFuture(linkingRules);
       } else {
-        String message = String.format("Error during loading linking rules for tenant with id: %s", context.getTenantId());
-        LOGGER.warn(String.format("loadLinkingRules:: %s", message));
+        String message = format("Error during loading linking rules for tenant with id: %s, status code: %s, response message: %s",
+          context.getTenantId(), httpResponse.getStatusCode(), httpResponse.getBody());
+        LOGGER.warn(format("loadLinkingRules:: %s", message));
         return CompletableFuture.failedFuture(new ConsortiumException(message));
       }
     }));

--- a/src/test/java/org/folio/inventory/dataimport/services/EntitiesLinksServiceTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/services/EntitiesLinksServiceTest.java
@@ -62,7 +62,7 @@ public class EntitiesLinksServiceTest {
 
     WireMock.stubFor(WireMock.put(new UrlPathPattern(new RegexPattern("/links/instances/" + instanceId), true))
         .withRequestBody(WireMock.equalToJson(INSTANCE_AUTHORITY_LINKS))
-      .willReturn(WireMock.ok().withBody(Json.encode(instanceAuthorityLinksResponse))));
+      .willReturn(WireMock.noContent()));
   }
 
   @Test
@@ -94,8 +94,6 @@ public class EntitiesLinksServiceTest {
     List<Link> instanceAuthorityLinks = List.of(Json.decodeValue(new JsonObject(INSTANCE_AUTHORITY_LINKS_BODY).getJsonArray("links").encode(), Link[].class));
     entitiesLinksService.putInstanceAuthorityLinks(context, instanceId, instanceAuthorityLinks).onComplete(ar -> {
       testContext.assertTrue(ar.succeeded());
-      testContext.assertTrue(!ar.result().isEmpty());
-      testContext.assertEquals(ar.result().get(0).getAuthorityId(), authorityId);
       async.complete();
     });
   }


### PR DESCRIPTION
## Purpose
In a consortium environment, fields in local MARC bib records may be linked to local MARC authority records. However, Instances with source = MARC may also be promoted to be shared to the rest of the consortium. When the Instance with source = MARC is shared, we need to unlink the controlled fields in the MARC bibliographic record from the local MARC authority records.
## Approach

- Create entity links for sharing authorities on central tenant during Instance sharing process
- Use new default profile "ECS - Create Instance" with **"remove9Subfields" : false** for instance sharing