### PR TITLE
MODINV-860: Adjust Optimistic locking for multiple holdings and multiple items update

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/entities/OlHoldingsAccumulativeResults.java
+++ b/src/main/java/org/folio/inventory/dataimport/entities/OlHoldingsAccumulativeResults.java
@@ -1,0 +1,34 @@
+package org.folio.inventory.dataimport.entities;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.folio.HoldingsRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class for storing intermediate results of the Holdings(errors and successful) Handler's processing between runs if Optimistic Locking reveals.
+ * It is needed for provided intermediate results between runs via DataImportEventPayload  by key "OL_ACCUMULATIVE_RESULTS".
+ * It avoids using class-level fields.
+ */
+@Getter
+@Setter
+public class OlHoldingsAccumulativeResults {
+
+  private List<HoldingsRecord> resultedSuccessHoldings;
+  private List<PartialError> resultedErrorHoldings;
+
+  public OlHoldingsAccumulativeResults() {
+    resultedSuccessHoldings = new ArrayList<>();
+    resultedErrorHoldings = new ArrayList<>();
+  }
+
+  /**
+   * Clear all lists.
+   */
+  public void cleanup() {
+    resultedSuccessHoldings.clear();
+    resultedErrorHoldings.clear();
+  }
+}

--- a/src/main/java/org/folio/inventory/dataimport/entities/OlItemAccumulativeResults.java
+++ b/src/main/java/org/folio/inventory/dataimport/entities/OlItemAccumulativeResults.java
@@ -1,0 +1,34 @@
+package org.folio.inventory.dataimport.entities;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.folio.inventory.domain.items.Item;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Interface for storing intermediate results of the Item(errors and successful) Handler's processing between runs if Optimistic Locking reveals.
+ * It is needed for provided intermediate results between runs via DataImportEventPayload  by key "OL_ACCUMULATIVE_RESULTS".
+ * It avoids using class-level fields.
+ */
+@Getter
+@Setter
+public class OlItemAccumulativeResults{
+
+  private List<Item> resultedSuccessItems;
+  private List<PartialError> resultedErrorItems;
+
+  public OlItemAccumulativeResults() {
+    resultedSuccessItems = new ArrayList<>();
+    resultedErrorItems = new ArrayList<>();
+  }
+
+  /**
+   * Clear all lists.
+   */
+  public void cleanup() {
+    resultedSuccessItems.clear();
+    resultedErrorItems.clear();
+  }
+}

--- a/src/main/java/org/folio/inventory/dataimport/entities/OlItemAccumulativeResults.java
+++ b/src/main/java/org/folio/inventory/dataimport/entities/OlItemAccumulativeResults.java
@@ -1,8 +1,8 @@
 package org.folio.inventory.dataimport.entities;
 
+import io.vertx.core.json.JsonObject;
 import lombok.Getter;
 import lombok.Setter;
-import org.folio.inventory.domain.items.Item;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +16,7 @@ import java.util.List;
 @Setter
 public class OlItemAccumulativeResults{
 
-  private List<Item> resultedSuccessItems;
+  private List<JsonObject> resultedSuccessItems;
   private List<PartialError> resultedErrorItems;
 
   public OlItemAccumulativeResults() {

--- a/src/main/java/org/folio/inventory/dataimport/entities/PartialError.java
+++ b/src/main/java/org/folio/inventory/dataimport/entities/PartialError.java
@@ -10,6 +10,9 @@ public class PartialError {
     this.error = error;
   }
 
+  public PartialError() {
+  }
+
   public String getId() {
     return id;
   }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -382,7 +382,6 @@ public class UpdateItemEventHandler implements EventHandler {
       .withDate(dateTimeFormatter.format(ZonedDateTime.now())));
 
     itemCollection.update(item, success -> {
-        //updatePromise.complete();
         promise.complete(item);
       },
       failure -> {

--- a/src/main/java/org/folio/inventory/domain/items/Item.java
+++ b/src/main/java/org/folio/inventory/domain/items/Item.java
@@ -5,10 +5,12 @@ import java.util.List;
 import java.util.Objects;
 
 import io.vertx.core.json.JsonArray;
+import lombok.NoArgsConstructor;
 import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
 
 import io.vertx.core.json.JsonObject;
 
+@NoArgsConstructor(force = true)
 public class Item {
 
   public static final String VERSION_KEY = "_version";

--- a/src/main/java/org/folio/inventory/domain/items/Item.java
+++ b/src/main/java/org/folio/inventory/domain/items/Item.java
@@ -1,14 +1,12 @@
 package org.folio.inventory.domain.items;
 
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
-import io.vertx.core.json.JsonArray;
-import lombok.NoArgsConstructor;
-import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
-
-import io.vertx.core.json.JsonObject;
 
 public class Item {
 

--- a/src/main/java/org/folio/inventory/domain/items/Item.java
+++ b/src/main/java/org/folio/inventory/domain/items/Item.java
@@ -10,7 +10,6 @@ import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
 
 import io.vertx.core.json.JsonObject;
 
-@NoArgsConstructor(force = true)
 public class Item {
 
   public static final String VERSION_KEY = "_version";

--- a/src/main/java/org/folio/inventory/domain/items/Status.java
+++ b/src/main/java/org/folio/inventory/domain/items/Status.java
@@ -5,8 +5,6 @@
  */
 package org.folio.inventory.domain.items;
 
-import lombok.NoArgsConstructor;
-
 import java.util.Objects;
 
 /**

--- a/src/main/java/org/folio/inventory/domain/items/Status.java
+++ b/src/main/java/org/folio/inventory/domain/items/Status.java
@@ -5,11 +5,14 @@
  */
 package org.folio.inventory.domain.items;
 
+import lombok.NoArgsConstructor;
+
 import java.util.Objects;
 
 /**
  * @author ne
  */
+@NoArgsConstructor(force = true)
 public class Status {
   private final ItemStatusName name;
   private final String date;

--- a/src/main/java/org/folio/inventory/domain/items/Status.java
+++ b/src/main/java/org/folio/inventory/domain/items/Status.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 /**
  * @author ne
  */
-@NoArgsConstructor(force = true)
 public class Status {
   private final ItemStatusName name;
   private final String date;

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -12,11 +12,14 @@ import org.folio.JobProfile;
 import org.folio.MappingMetadataDto;
 import org.folio.MappingProfile;
 import org.folio.inventory.common.Context;
+import org.folio.inventory.common.api.request.PagingParameters;
 import org.folio.inventory.common.domain.Failure;
+import org.folio.inventory.common.domain.MultipleRecords;
 import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.dataimport.HoldingWriterFactory;
 import org.folio.inventory.dataimport.HoldingsMapperFactory;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
+import org.folio.inventory.dataimport.entities.PartialError;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.items.ItemCollection;
@@ -42,6 +45,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -65,11 +69,13 @@ import static org.folio.inventory.domain.items.ItemStatusName.AVAILABLE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -256,7 +262,7 @@ public class UpdateHoldingEventHandlerTest {
   }
 
   @Test
-  public void shouldUpdateHoldingOnOLRetryAndRemoveRetryCounterFromPayload() throws InterruptedException, ExecutionException, TimeoutException {
+  public void shouldUpdateHoldingOnOLRetryAndRemoveRetryCounterFromPayload() throws InterruptedException, ExecutionException, TimeoutException, UnsupportedEncodingException {
     Reader fakeReader = Mockito.mock(Reader.class);
 
     String holdingId = UUID.randomUUID().toString();
@@ -314,12 +320,367 @@ public class UpdateHoldingEventHandlerTest {
 
     CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
     DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
-    verify(holdingsRecordsCollection, times(2)).update(any(), any(), any());
-    verify(holdingsRecordsCollection).findById(holdingsRecord.getId());
+    verify(holdingsRecordsCollection, times(1)).update(any(), any(), any());
+    verify(holdingsRecordsCollection).findByCql(any(), any(), any(), any());
 
     Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
     Assert.assertNull(actualDataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER));
+  }
+
+
+  @Test
+  public void shouldUpdateMultipleHoldingsOnOLRetryAndRemoveRetryCounterFromPayloadViaSeveralRuns() throws InterruptedException, ExecutionException, TimeoutException, UnsupportedEncodingException {
+    Reader fakeReader = Mockito.mock(Reader.class);
+
+    String holdingId = UUID.randomUUID().toString();
+    String holdingId2 = UUID.randomUUID().toString();
+    String holdingId3 = UUID.randomUUID().toString();
+    String holdingId4 = UUID.randomUUID().toString();
+    String holdingId5 = UUID.randomUUID().toString();
+    String holdingId6 = UUID.randomUUID().toString();
+    String holdingId7 = UUID.randomUUID().toString();
+    String holdingId8 = UUID.randomUUID().toString();
+    String holdingId9 = UUID.randomUUID().toString();
+    String holdingId10 = UUID.randomUUID().toString();
+
+    String hrid = UUID.randomUUID().toString();
+    String hrid2 = UUID.randomUUID().toString();
+    String hrid3 = UUID.randomUUID().toString();
+    String hrid4 = UUID.randomUUID().toString();
+    String hrid5 = UUID.randomUUID().toString();
+    String hrid6 = UUID.randomUUID().toString();
+    String hrid7 = UUID.randomUUID().toString();
+    String hrid8 = UUID.randomUUID().toString();
+    String hrid9 = UUID.randomUUID().toString();
+    String hrid10 = UUID.randomUUID().toString();
+
+    String instanceId = String.valueOf(UUID.randomUUID());
+    String instanceId2 = String.valueOf(UUID.randomUUID());
+    String instanceId3 = String.valueOf(UUID.randomUUID());
+    String instanceId4 = String.valueOf(UUID.randomUUID());
+    String instanceId5 = String.valueOf(UUID.randomUUID());
+    String instanceId6 = String.valueOf(UUID.randomUUID());
+    String instanceId7 = String.valueOf(UUID.randomUUID());
+    String instanceId8 = String.valueOf(UUID.randomUUID());
+    String instanceId9 = String.valueOf(UUID.randomUUID());
+    String instanceId10 = String.valueOf(UUID.randomUUID());
+
+    String permanentLocationId = UUID.randomUUID().toString();
+    String permanentLocationId2 = UUID.randomUUID().toString();
+    String permanentLocationId3 = UUID.randomUUID().toString();
+    String permanentLocationId4 = UUID.randomUUID().toString();
+    String permanentLocationId5 = UUID.randomUUID().toString();
+    String permanentLocationId6 = UUID.randomUUID().toString();
+    String permanentLocationId7 = UUID.randomUUID().toString();
+    String permanentLocationId8 = UUID.randomUUID().toString();
+    String permanentLocationId9 = UUID.randomUUID().toString();
+    String permanentLocationId10 = UUID.randomUUID().toString();
+
+
+    HoldingsRecord actualHoldings = new HoldingsRecord()
+      .withId(holdingId)
+      .withHrid(hrid)
+      .withInstanceId(instanceId)
+      .withPermanentLocationId(permanentLocationId)
+      .withVersion(2);
+
+    HoldingsRecord actualHoldings2 = new HoldingsRecord()
+      .withId(holdingId4)
+      .withHrid(hrid4)
+      .withInstanceId(instanceId4)
+      .withPermanentLocationId(permanentLocationId4)
+      .withVersion(2);
+
+    HoldingsRecord actualHoldings3 = new HoldingsRecord()
+      .withId(holdingId5)
+      .withHrid(hrid5)
+      .withInstanceId(instanceId5)
+      .withPermanentLocationId(permanentLocationId5)
+      .withVersion(2);
+
+    HoldingsRecord actualHoldings4 = new HoldingsRecord()
+      .withId(holdingId6)
+      .withHrid(hrid6)
+      .withInstanceId(instanceId6)
+      .withPermanentLocationId(permanentLocationId6)
+      .withVersion(2);
+
+    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(permanentLocationId));
+    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    when(storage.getItemCollection(any())).thenReturn(itemCollection);
+
+    HoldingsRecord olHoldingsRecord1 = new HoldingsRecord()
+      .withId(holdingId)
+      .withInstanceId(instanceId)
+      .withHrid(hrid)
+      .withPermanentLocationId(permanentLocationId);
+    HoldingsRecord successfulHoldingsRecord2 = new HoldingsRecord()
+      .withId(holdingId2)
+      .withInstanceId(instanceId2)
+      .withHrid(hrid2)
+      .withPermanentLocationId(permanentLocationId2);
+    HoldingsRecord partialErrorHoldingsRecord3 = new HoldingsRecord()
+      .withId(holdingId3)
+      .withInstanceId(instanceId3)
+      .withHrid(hrid3)
+      .withPermanentLocationId(permanentLocationId3);
+    HoldingsRecord olHoldingsRecord4 = new HoldingsRecord()
+      .withId(holdingId4)
+      .withInstanceId(instanceId4)
+      .withHrid(hrid4)
+      .withPermanentLocationId(permanentLocationId4);
+    HoldingsRecord olHoldingsRecord5 = new HoldingsRecord()
+      .withId(holdingId5)
+      .withInstanceId(instanceId5)
+      .withHrid(hrid5)
+      .withPermanentLocationId(permanentLocationId5);
+    HoldingsRecord olHoldingsRecord6 = new HoldingsRecord()
+      .withId(holdingId6)
+      .withInstanceId(instanceId6)
+      .withHrid(hrid6)
+      .withPermanentLocationId(permanentLocationId6);
+    HoldingsRecord successfulHoldingsRecord7 = new HoldingsRecord()
+      .withId(holdingId7)
+      .withInstanceId(instanceId7)
+      .withHrid(hrid7)
+      .withPermanentLocationId(permanentLocationId7);
+    HoldingsRecord successfulHoldingsRecord8 = new HoldingsRecord()
+      .withId(holdingId8)
+      .withInstanceId(instanceId8)
+      .withHrid(hrid8)
+      .withPermanentLocationId(permanentLocationId8);
+    HoldingsRecord partialErrorHoldingsRecord9 = new HoldingsRecord()
+      .withId(holdingId9)
+      .withInstanceId(instanceId9)
+      .withHrid(hrid9)
+      .withPermanentLocationId(permanentLocationId9);
+    HoldingsRecord partialErrorHoldingsRecord10 = new HoldingsRecord()
+      .withId(holdingId10)
+      .withInstanceId(instanceId10)
+      .withHrid(hrid10)
+      .withPermanentLocationId(permanentLocationId10);
+    JsonArray holdingsList = new JsonArray();
+    holdingsList.add(new JsonObject().put("holdings", olHoldingsRecord1));
+    holdingsList.add(new JsonObject().put("holdings", successfulHoldingsRecord2));
+    holdingsList.add(new JsonObject().put("holdings", partialErrorHoldingsRecord3));
+    holdingsList.add(new JsonObject().put("holdings", olHoldingsRecord4));
+    holdingsList.add(new JsonObject().put("holdings", olHoldingsRecord5));
+    holdingsList.add(new JsonObject().put("holdings", olHoldingsRecord6));
+    holdingsList.add(new JsonObject().put("holdings", successfulHoldingsRecord7));
+    holdingsList.add(new JsonObject().put("holdings", successfulHoldingsRecord8));
+    holdingsList.add(new JsonObject().put("holdings", partialErrorHoldingsRecord9));
+    holdingsList.add(new JsonObject().put("holdings", partialErrorHoldingsRecord10));
+
+    doAnswer(invocationOnMock -> {
+      Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+      failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", holdingId), 409));
+      return null;
+    }).doAnswer(invocationOnMock -> {
+        HoldingsRecord tmpHoldingsRecord = invocationOnMock.getArgument(0);
+        Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
+        successHandler.accept(new Success<>(tmpHoldingsRecord));
+        return null;
+      }).doAnswer(invocationOnMock -> {
+        Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+        failureHandler.accept(new Failure(format("Cannot update record %s not found", partialErrorHoldingsRecord3.getId()), 404));
+        return null;
+      }).doAnswer(invocationOnMock -> {
+        Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", olHoldingsRecord4.getId()), 409));
+        return null;
+      })
+      .doAnswer(invocationOnMock -> {
+        Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", olHoldingsRecord5.getId()), 409));
+        return null;
+      })
+      .doAnswer(invocationOnMock -> {
+        Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", olHoldingsRecord6.getId()), 409));
+        return null;
+      })
+      .doAnswer(invocationOnMock -> {
+        HoldingsRecord tmpHoldingsRecord = invocationOnMock.getArgument(0);
+        Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
+        successHandler.accept(new Success<>(tmpHoldingsRecord));
+        return null;
+      })
+      .doAnswer(invocationOnMock -> {
+        HoldingsRecord tmpHoldingsRecord = invocationOnMock.getArgument(0);
+        Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
+        successHandler.accept(new Success<>(tmpHoldingsRecord));
+        return null;
+      })
+      .doAnswer(invocationOnMock -> {
+        Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+        failureHandler.accept(new Failure(format("Cannot update record %s not found", partialErrorHoldingsRecord9.getId()), 404));
+        return null;
+      })
+      .doAnswer(invocationOnMock -> {
+        Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+        failureHandler.accept(new Failure(format("Cannot update record %s not found", partialErrorHoldingsRecord10.getId()), 404));
+        return null;
+      })// 10 tries. Next invocation will be on the second run 'handle()'-method.
+      .doAnswer(invocationOnMock -> {
+        HoldingsRecord tmpHoldingsRecord = invocationOnMock.getArgument(0);
+        Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
+        successHandler.accept(new Success<>(tmpHoldingsRecord));
+        return null;
+      })
+      .doAnswer(invocationOnMock -> {
+        Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", olHoldingsRecord4.getId()), 409));
+        return null;
+      })
+      .doAnswer(invocationOnMock -> {
+        Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+        failureHandler.accept(new Failure(format("Cannot update record %s not found", holdingId5), 404));
+        return null;
+      })
+      .doAnswer(invocationOnMock -> {
+        HoldingsRecord tmpHoldingsRecord = invocationOnMock.getArgument(0);
+        Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
+        successHandler.accept(new Success<>(tmpHoldingsRecord));
+        return null;
+      }).when(holdingsRecordsCollection).update(any(), any(), any());
+
+
+    doAnswer(invocationOnMock -> {
+      MultipleRecords result = new MultipleRecords<>(List.of(actualHoldings, actualHoldings2, actualHoldings3, actualHoldings4), 4);
+      Consumer<Success<MultipleRecords>> successHandler = invocationOnMock.getArgument(2);
+      successHandler.accept(new Success<>(result));
+      return null;
+    }).when(holdingsRecordsCollection).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s OR %s OR %s)", holdingId, holdingId4, holdingId5, holdingId6))),
+      any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    MappingManager.registerReaderFactory(fakeReaderFactory);
+    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
+
+
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), Json.encode(holdingsList));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(context)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+    verify(holdingsRecordsCollection, times(14)).update(any(), any(), any());
+    verify(holdingsRecordsCollection, times(1)).findByCql(any(), any(), any(), any());
+
+    Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
+    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    Assert.assertNull(actualDataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER));
+    List<HoldingsRecord> resultedHoldingsRecords = List.of(Json.decodeValue(actualDataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord[].class));
+    Assert.assertEquals(5, resultedHoldingsRecords.size());
+    assertEquals(successfulHoldingsRecord2.getId(), String.valueOf(resultedHoldingsRecords.get(0).getId()));
+    assertEquals(successfulHoldingsRecord7.getId(), String.valueOf(resultedHoldingsRecords.get(1).getId()));
+    assertEquals(successfulHoldingsRecord8.getId(), String.valueOf(resultedHoldingsRecords.get(2).getId()));
+    assertEquals(olHoldingsRecord1.getId(), String.valueOf(resultedHoldingsRecords.get(3).getId()));
+    assertEquals(olHoldingsRecord6.getId(), String.valueOf(resultedHoldingsRecords.get(4).getId()));
+
+    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(ERRORS));
+    List<PartialError> resultedErrorList = List.of(Json.decodeValue(actualDataImportEventPayload.getContext().get(ERRORS), PartialError[].class));
+    Assert.assertEquals(5, resultedErrorList.size());
+    assertEquals(partialErrorHoldingsRecord3.getId(), String.valueOf(resultedErrorList.get(0).getId()));
+    assertEquals(partialErrorHoldingsRecord9.getId(), String.valueOf(resultedErrorList.get(1).getId()));
+    assertEquals(partialErrorHoldingsRecord10.getId(), String.valueOf(resultedErrorList.get(2).getId()));
+    assertEquals(olHoldingsRecord5.getId(), String.valueOf(resultedErrorList.get(3).getId()));
+    assertEquals(olHoldingsRecord4.getId(), String.valueOf(resultedErrorList.get(4).getId()));
+    assertEquals(resultedErrorList.get(0).getError(), format("Cannot update record %s not found", partialErrorHoldingsRecord3.getId()));
+    assertEquals(resultedErrorList.get(1).getError(), format("Cannot update record %s not found", partialErrorHoldingsRecord9.getId()));
+    assertEquals(resultedErrorList.get(2).getError(), format("Cannot update record %s not found", partialErrorHoldingsRecord10.getId()));
+    assertEquals(resultedErrorList.get(3).getError(), format("Cannot update record %s not found", olHoldingsRecord5.getId()));
+    assertEquals(resultedErrorList.get(4).getError(), format("Current retry number %s exceeded or equal given number %s for the Holding update for jobExecutionId '%s' ", 1, 1, actualDataImportEventPayload.getJobExecutionId()));
+
+
+    //Second run. We need it to verify that CURRENT_RETRY_NUMBER and all lists are cleared.
+    JsonArray holdingsListSecondRun = new JsonArray();
+    holdingsListSecondRun.add(new JsonObject().put("holdings", olHoldingsRecord1));
+    holdingsListSecondRun.add(new JsonObject().put("holdings", successfulHoldingsRecord2));
+    holdingsListSecondRun.add(new JsonObject().put("holdings", partialErrorHoldingsRecord3));
+    holdingsListSecondRun.add(new JsonObject().put("holdings", olHoldingsRecord4));
+
+    HashMap<String, String> contextSecondRun = new HashMap<>();
+    contextSecondRun.put(HOLDINGS.value(), Json.encode(holdingsListSecondRun));
+    contextSecondRun.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayloadSecondRun = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_UPDATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(contextSecondRun)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+
+    doAnswer(invocationOnMock -> {
+      Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+      failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", olHoldingsRecord1.getId()), 409));
+      return null;
+    }).doAnswer(invocationOnMock -> {
+        HoldingsRecord tmpHoldingsRecord = invocationOnMock.getArgument(0);
+        Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
+        successHandler.accept(new Success<>(tmpHoldingsRecord));
+        return null;
+      }).doAnswer(invocationOnMock -> {
+        Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+        failureHandler.accept(new Failure(format("Cannot update record %s not found", partialErrorHoldingsRecord3.getId()), 404));
+        return null;
+      }).doAnswer(invocationOnMock -> {
+        Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
+        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", olHoldingsRecord4.getId()), 409));
+        return null;
+      })
+      .doAnswer(invocationOnMock -> {
+        HoldingsRecord tmpHoldingsRecord = invocationOnMock.getArgument(0);
+        Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
+        successHandler.accept(new Success<>(tmpHoldingsRecord));
+        return null;
+      })
+      .doAnswer(invocationOnMock -> {
+        HoldingsRecord tmpHoldingsRecord = invocationOnMock.getArgument(0);
+        Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
+        successHandler.accept(new Success<>(tmpHoldingsRecord));
+        return null;
+      })
+      .when(holdingsRecordsCollection).update(any(), any(), any());
+
+    doAnswer(invocationOnMock -> {
+      MultipleRecords<HoldingsRecord> result = new MultipleRecords<>(List.of(actualHoldings, actualHoldings2), 2);
+      Consumer<Success<MultipleRecords>> successHandler = invocationOnMock.getArgument(2);
+      successHandler.accept(new Success<>(result));
+      return null;
+    }).when(holdingsRecordsCollection).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s)", holdingId, holdingId4))),
+      any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    CompletableFuture<DataImportEventPayload> futureSecondRun = updateHoldingEventHandler.handle(dataImportEventPayloadSecondRun);
+    DataImportEventPayload actualDataImportEventPayloadSecondRun = futureSecondRun.get(5, TimeUnit.MILLISECONDS);
+    verify(holdingsRecordsCollection, times(20)).update(any(), any(), any());
+    verify(holdingsRecordsCollection, times(2)).findByCql(any(), any(), any(), any());
+    Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayloadSecondRun.getEventType());
+    Assert.assertNotNull(actualDataImportEventPayloadSecondRun.getContext().get(HOLDINGS.value()));
+    Assert.assertNull(actualDataImportEventPayloadSecondRun.getContext().get(CURRENT_RETRY_NUMBER));
+    List<HoldingsRecord> resultedHoldingsRecordsSecondRun = List.of(Json.decodeValue(actualDataImportEventPayloadSecondRun.getContext().get(HOLDINGS.value()), HoldingsRecord[].class));
+    Assert.assertEquals(3, resultedHoldingsRecordsSecondRun.size());
+
+    assertEquals(successfulHoldingsRecord2.getId(), String.valueOf(resultedHoldingsRecordsSecondRun.get(0).getId()));
+    assertEquals(olHoldingsRecord1.getId(), String.valueOf(resultedHoldingsRecordsSecondRun.get(1).getId()));
+    assertEquals(olHoldingsRecord4.getId(), String.valueOf(resultedHoldingsRecordsSecondRun.get(2).getId()));
+
+    Assert.assertNotNull(actualDataImportEventPayloadSecondRun.getContext().get(ERRORS));
+    List<PartialError> resultedErrorListSecondRun = List.of(Json.decodeValue(actualDataImportEventPayloadSecondRun.getContext().get(ERRORS), PartialError[].class));
+    Assert.assertEquals(1, resultedErrorListSecondRun.size());
+    assertEquals(partialErrorHoldingsRecord3.getId(), String.valueOf(resultedErrorListSecondRun.get(0).getId()));
+    assertEquals(resultedErrorListSecondRun.get(0).getError(), format("Cannot update record %s not found", partialErrorHoldingsRecord3.getId()));
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -46,6 +46,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -265,77 +266,57 @@ public class UpdateHoldingEventHandlerTest {
   public void shouldUpdateMultipleHoldingsOnOLRetryAndRemoveRetryCounterFromPayloadViaSeveralRuns() throws InterruptedException, ExecutionException, TimeoutException, UnsupportedEncodingException {
     Reader fakeReader = Mockito.mock(Reader.class);
 
-    String holdingId = UUID.randomUUID().toString();
-    String holdingId2 = UUID.randomUUID().toString();
-    String holdingId3 = UUID.randomUUID().toString();
-    String holdingId4 = UUID.randomUUID().toString();
-    String holdingId5 = UUID.randomUUID().toString();
-    String holdingId6 = UUID.randomUUID().toString();
-    String holdingId7 = UUID.randomUUID().toString();
-    String holdingId8 = UUID.randomUUID().toString();
-    String holdingId9 = UUID.randomUUID().toString();
-    String holdingId10 = UUID.randomUUID().toString();
+    // 10 holdingsIds
+    List<String> holdingsIds = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      holdingsIds.add(UUID.randomUUID().toString());
+    }
 
-    String hrid = UUID.randomUUID().toString();
-    String hrid2 = UUID.randomUUID().toString();
-    String hrid3 = UUID.randomUUID().toString();
-    String hrid4 = UUID.randomUUID().toString();
-    String hrid5 = UUID.randomUUID().toString();
-    String hrid6 = UUID.randomUUID().toString();
-    String hrid7 = UUID.randomUUID().toString();
-    String hrid8 = UUID.randomUUID().toString();
-    String hrid9 = UUID.randomUUID().toString();
-    String hrid10 = UUID.randomUUID().toString();
+    // 10 hrids for Holdings
+    List<String> holdingsHrids = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      holdingsHrids.add(UUID.randomUUID().toString());
+    }
 
-    String instanceId = String.valueOf(UUID.randomUUID());
-    String instanceId2 = String.valueOf(UUID.randomUUID());
-    String instanceId3 = String.valueOf(UUID.randomUUID());
-    String instanceId4 = String.valueOf(UUID.randomUUID());
-    String instanceId5 = String.valueOf(UUID.randomUUID());
-    String instanceId6 = String.valueOf(UUID.randomUUID());
-    String instanceId7 = String.valueOf(UUID.randomUUID());
-    String instanceId8 = String.valueOf(UUID.randomUUID());
-    String instanceId9 = String.valueOf(UUID.randomUUID());
-    String instanceId10 = String.valueOf(UUID.randomUUID());
+    // 10 instanceIds for Holdings
+    List<String> instanceIds = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      instanceIds.add(UUID.randomUUID().toString());
+    }
 
-    String permanentLocationId = UUID.randomUUID().toString();
-    String permanentLocationId2 = UUID.randomUUID().toString();
-    String permanentLocationId3 = UUID.randomUUID().toString();
-    String permanentLocationId4 = UUID.randomUUID().toString();
-    String permanentLocationId5 = UUID.randomUUID().toString();
-    String permanentLocationId6 = UUID.randomUUID().toString();
-    String permanentLocationId7 = UUID.randomUUID().toString();
-    String permanentLocationId8 = UUID.randomUUID().toString();
-    String permanentLocationId9 = UUID.randomUUID().toString();
-    String permanentLocationId10 = UUID.randomUUID().toString();
+    // 10 permanentLocationIds for Holdings
+    List<String> permLocationIds = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      permLocationIds.add(UUID.randomUUID().toString());
+    }
 
-
+    //actual Holdings which will returned as "actual" after optimistic locking errors
     HoldingsRecord actualHoldings = new HoldingsRecord()
-      .withId(holdingId)
-      .withHrid(hrid)
-      .withInstanceId(instanceId)
+      .withId(holdingsIds.get(0))
+      .withHrid(holdingsHrids.get(0))
+      .withInstanceId(instanceIds.get(0))
       .withPermanentLocationId(permanentLocationId)
       .withVersion(2);
 
     HoldingsRecord actualHoldings2 = new HoldingsRecord()
-      .withId(holdingId4)
-      .withHrid(hrid4)
-      .withInstanceId(instanceId4)
-      .withPermanentLocationId(permanentLocationId4)
+      .withId(holdingsIds.get(3))
+      .withHrid(holdingsHrids.get(3))
+      .withInstanceId(instanceIds.get(3))
+      .withPermanentLocationId(permLocationIds.get(3))
       .withVersion(2);
 
     HoldingsRecord actualHoldings3 = new HoldingsRecord()
-      .withId(holdingId5)
-      .withHrid(hrid5)
-      .withInstanceId(instanceId5)
-      .withPermanentLocationId(permanentLocationId5)
+      .withId(holdingsIds.get(4))
+      .withHrid(holdingsHrids.get(4))
+      .withInstanceId(instanceIds.get(4))
+      .withPermanentLocationId(permLocationIds.get(4))
       .withVersion(2);
 
     HoldingsRecord actualHoldings4 = new HoldingsRecord()
-      .withId(holdingId6)
-      .withHrid(hrid6)
-      .withInstanceId(instanceId6)
-      .withPermanentLocationId(permanentLocationId6)
+      .withId(holdingsIds.get(5))
+      .withHrid(holdingsHrids.get(5))
+      .withInstanceId(instanceIds.get(5))
+      .withPermanentLocationId(permLocationIds.get(5))
       .withVersion(2);
 
     when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
@@ -343,56 +324,57 @@ public class UpdateHoldingEventHandlerTest {
     when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
     when(storage.getItemCollection(any())).thenReturn(itemCollection);
 
+    //Real Holdings which will have specific behavior: successful, optimistic locking error (ol), failure by another reason.
     HoldingsRecord olHoldingsRecord1 = new HoldingsRecord()
-      .withId(holdingId)
-      .withInstanceId(instanceId)
-      .withHrid(hrid)
-      .withPermanentLocationId(permanentLocationId);
+      .withId(holdingsIds.get(0))
+      .withInstanceId(instanceIds.get(0))
+      .withHrid(holdingsHrids.get(0))
+      .withPermanentLocationId(permLocationIds.get(0));
     HoldingsRecord successfulHoldingsRecord2 = new HoldingsRecord()
-      .withId(holdingId2)
-      .withInstanceId(instanceId2)
-      .withHrid(hrid2)
-      .withPermanentLocationId(permanentLocationId2);
+      .withId(holdingsIds.get(1))
+      .withInstanceId(instanceIds.get(1))
+      .withHrid(holdingsHrids.get(1))
+      .withPermanentLocationId(permLocationIds.get(1));
     HoldingsRecord partialErrorHoldingsRecord3 = new HoldingsRecord()
-      .withId(holdingId3)
-      .withInstanceId(instanceId3)
-      .withHrid(hrid3)
-      .withPermanentLocationId(permanentLocationId3);
+      .withId(holdingsIds.get(2))
+      .withInstanceId(instanceIds.get(2))
+      .withHrid(holdingsHrids.get(2))
+      .withPermanentLocationId(permLocationIds.get(2));
     HoldingsRecord olHoldingsRecord4 = new HoldingsRecord()
-      .withId(holdingId4)
-      .withInstanceId(instanceId4)
-      .withHrid(hrid4)
-      .withPermanentLocationId(permanentLocationId4);
+      .withId(holdingsIds.get(3))
+      .withInstanceId(instanceIds.get(3))
+      .withHrid(holdingsHrids.get(3))
+      .withPermanentLocationId(permLocationIds.get(3));
     HoldingsRecord olHoldingsRecord5 = new HoldingsRecord()
-      .withId(holdingId5)
-      .withInstanceId(instanceId5)
-      .withHrid(hrid5)
-      .withPermanentLocationId(permanentLocationId5);
+      .withId(holdingsIds.get(4))
+      .withInstanceId(instanceIds.get(4))
+      .withHrid(holdingsHrids.get(4))
+      .withPermanentLocationId(permLocationIds.get(4));
     HoldingsRecord olHoldingsRecord6 = new HoldingsRecord()
-      .withId(holdingId6)
-      .withInstanceId(instanceId6)
-      .withHrid(hrid6)
-      .withPermanentLocationId(permanentLocationId6);
+      .withId(holdingsIds.get(5))
+      .withInstanceId(instanceIds.get(5))
+      .withHrid(holdingsHrids.get(5))
+      .withPermanentLocationId(permLocationIds.get(5));
     HoldingsRecord successfulHoldingsRecord7 = new HoldingsRecord()
-      .withId(holdingId7)
-      .withInstanceId(instanceId7)
-      .withHrid(hrid7)
-      .withPermanentLocationId(permanentLocationId7);
+      .withId(holdingsIds.get(6))
+      .withInstanceId(instanceIds.get(6))
+      .withHrid(holdingsHrids.get(6))
+      .withPermanentLocationId(permLocationIds.get(6));
     HoldingsRecord successfulHoldingsRecord8 = new HoldingsRecord()
-      .withId(holdingId8)
-      .withInstanceId(instanceId8)
-      .withHrid(hrid8)
-      .withPermanentLocationId(permanentLocationId8);
+      .withId(holdingsIds.get(7))
+      .withInstanceId(instanceIds.get(7))
+      .withHrid(holdingsHrids.get(7))
+      .withPermanentLocationId(permLocationIds.get(7));
     HoldingsRecord partialErrorHoldingsRecord9 = new HoldingsRecord()
-      .withId(holdingId9)
-      .withInstanceId(instanceId9)
-      .withHrid(hrid9)
-      .withPermanentLocationId(permanentLocationId9);
+      .withId(holdingsIds.get(8))
+      .withInstanceId(instanceIds.get(8))
+      .withHrid(holdingsHrids.get(8))
+      .withPermanentLocationId(permLocationIds.get(8));
     HoldingsRecord partialErrorHoldingsRecord10 = new HoldingsRecord()
-      .withId(holdingId10)
-      .withInstanceId(instanceId10)
-      .withHrid(hrid10)
-      .withPermanentLocationId(permanentLocationId10);
+      .withId(holdingsIds.get(9))
+      .withInstanceId(instanceIds.get(9))
+      .withHrid(holdingsHrids.get(9))
+      .withPermanentLocationId(permLocationIds.get(9  ));
     JsonArray holdingsList = new JsonArray();
     holdingsList.add(new JsonObject().put("holdings", olHoldingsRecord1));
     holdingsList.add(new JsonObject().put("holdings", successfulHoldingsRecord2));
@@ -405,9 +387,10 @@ public class UpdateHoldingEventHandlerTest {
     holdingsList.add(new JsonObject().put("holdings", partialErrorHoldingsRecord9));
     holdingsList.add(new JsonObject().put("holdings", partialErrorHoldingsRecord10));
 
+    // Provide behavior for the Holdings
     doAnswer(invocationOnMock -> {
       Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-      failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", holdingId), 409));
+      failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", holdingsIds.get(0)), 409));
       return null;
     }).doAnswer(invocationOnMock -> {
         HoldingsRecord tmpHoldingsRecord = invocationOnMock.getArgument(0);
@@ -454,8 +437,8 @@ public class UpdateHoldingEventHandlerTest {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
         failureHandler.accept(new Failure(format("Cannot update record %s not found", partialErrorHoldingsRecord10.getId()), 404));
         return null;
-      })// 10 tries. Next invocation will be on the second run 'handle()'-method.
-      .doAnswer(invocationOnMock -> {
+      })// 10 Holdings processed. Next iteration will be on the second run 'handle()'-method.
+    .doAnswer(invocationOnMock -> {
         HoldingsRecord tmpHoldingsRecord = invocationOnMock.getArgument(0);
         Consumer<Success<HoldingsRecord>> successHandler = invocationOnMock.getArgument(1);
         successHandler.accept(new Success<>(tmpHoldingsRecord));
@@ -468,7 +451,7 @@ public class UpdateHoldingEventHandlerTest {
       })
       .doAnswer(invocationOnMock -> {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-        failureHandler.accept(new Failure(format("Cannot update record %s not found", holdingId5), 404));
+        failureHandler.accept(new Failure(format("Cannot update record %s not found", holdingsIds.get(4)), 404));
         return null;
       })
       .doAnswer(invocationOnMock -> {
@@ -484,7 +467,7 @@ public class UpdateHoldingEventHandlerTest {
       Consumer<Success<MultipleRecords>> successHandler = invocationOnMock.getArgument(2);
       successHandler.accept(new Success<>(result));
       return null;
-    }).when(holdingsRecordsCollection).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s OR %s OR %s)", holdingId, holdingId4, holdingId5, holdingId6))),
+    }).when(holdingsRecordsCollection).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s OR %s OR %s)", holdingsIds.get(0), holdingsIds.get(3), holdingsIds.get(4), holdingsIds.get(5)))),
       any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
 
     MappingManager.registerReaderFactory(fakeReaderFactory);
@@ -533,7 +516,6 @@ public class UpdateHoldingEventHandlerTest {
     assertEquals(resultedErrorList.get(2).getError(), format("Cannot update record %s not found", partialErrorHoldingsRecord10.getId()));
     assertEquals(resultedErrorList.get(3).getError(), format("Cannot update record %s not found", olHoldingsRecord5.getId()));
     assertEquals(resultedErrorList.get(4).getError(), format("Current retry number %s exceeded or equal given number %s for the Holding update for jobExecutionId '%s' ", 1, 1, actualDataImportEventPayload.getJobExecutionId()));
-
 
     //Second run. We need it to verify that CURRENT_RETRY_NUMBER and all lists are cleared.
     JsonArray holdingsListSecondRun = new JsonArray();
@@ -591,7 +573,7 @@ public class UpdateHoldingEventHandlerTest {
       Consumer<Success<MultipleRecords>> successHandler = invocationOnMock.getArgument(2);
       successHandler.accept(new Success<>(result));
       return null;
-    }).when(holdingsRecordsCollection).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s)", holdingId, holdingId4))),
+    }).when(holdingsRecordsCollection).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s)", holdingsIds.get(0), holdingsIds.get(3)))),
       any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
 
     CompletableFuture<DataImportEventPayload> futureSecondRun = updateHoldingEventHandler.handle(dataImportEventPayloadSecondRun);

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandlerTest.java
@@ -446,109 +446,92 @@ public class UpdateItemEventHandlerTest {
   @Test
   public void shouldUpdateMultipleItemsOnOLRetryAndRemoveRetryCounterFromPayloadViaSeveralRuns() throws InterruptedException, ExecutionException, TimeoutException, UnsupportedEncodingException {
 
-    String itemId = UUID.randomUUID().toString();
-    String itemId2 = UUID.randomUUID().toString();
-    String itemId3 = UUID.randomUUID().toString();
-    String itemId4 = UUID.randomUUID().toString();
-    String itemId5 = UUID.randomUUID().toString();
-    String itemId6 = UUID.randomUUID().toString();
-    String itemId7 = UUID.randomUUID().toString();
-    String itemId8 = UUID.randomUUID().toString();
-    String itemId9 = UUID.randomUUID().toString();
-    String itemId10 = UUID.randomUUID().toString();
+    // 10 ids for the Items
+    List<String> itemIds = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      itemIds.add(UUID.randomUUID().toString());
+    }
 
-    String holdingId = String.valueOf(UUID.randomUUID());
-    String holdingId2 = String.valueOf(UUID.randomUUID());
-    String holdingId3 = String.valueOf(UUID.randomUUID());
-    String holdingId4 = String.valueOf(UUID.randomUUID());
-    String holdingId5 = String.valueOf(UUID.randomUUID());
-    String holdingId6 = String.valueOf(UUID.randomUUID());
-    String holdingId7 = String.valueOf(UUID.randomUUID());
-    String holdingId8 = String.valueOf(UUID.randomUUID());
-    String holdingId9 = String.valueOf(UUID.randomUUID());
-    String holdingId10 = String.valueOf(UUID.randomUUID());
+    // 10 holdingsIds for Items
+    List<String> holdingsIds = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      holdingsIds.add(UUID.randomUUID().toString());
+    }
 
     String commonId = UUID.randomUUID().toString();
-    String commonId2 = UUID.randomUUID().toString();
-    String commonId3 = UUID.randomUUID().toString();
-    String commonId4 = UUID.randomUUID().toString();
-    String commonId5 = UUID.randomUUID().toString();
-    String commonId6 = UUID.randomUUID().toString();
-    String commonId7 = UUID.randomUUID().toString();
-    String commonId8 = UUID.randomUUID().toString();
-    String commonId9 = UUID.randomUUID().toString();
-    String commonId10 = UUID.randomUUID().toString();
 
     JsonObject metadata = new JsonObject();
 
-    Item actualItem = new Item(itemId, "2", holdingId, "test", new Status(AVAILABLE), commonId, commonId, metadata);
+    //actual Items which will returned as "actual" after optimistic locking errors
+    Item actualItem = new Item(itemIds.get(0), "2", holdingsIds.get(0), "test", new Status(AVAILABLE), commonId, commonId, metadata);
 
-    Item actualItem2 = new Item(itemId4, "2", holdingId4, "test", new Status(AVAILABLE), commonId, commonId, metadata);
+    Item actualItem2 = new Item(itemIds.get(3), "2", holdingsIds.get(3), "test", new Status(AVAILABLE), commonId, commonId, metadata);
 
-    Item actualItem3 = new Item(itemId5, "2", holdingId5, "test", new Status(AVAILABLE), commonId, commonId, metadata);
+    Item actualItem3 = new Item(itemIds.get(4), "2", holdingsIds.get(4), "test", new Status(AVAILABLE), commonId, commonId, metadata);
 
-    Item actualItem4 = new Item(itemId6, "2", holdingId6, "test", new Status(AVAILABLE), commonId, commonId, metadata);
+    Item actualItem4 = new Item(itemIds.get(5), "2", holdingsIds.get(5), "test", new Status(AVAILABLE), commonId, commonId, metadata);
 
+    //Real Items which will have specific behavior: successful, optimistic locking error (ol), failure by another reason.
     JsonObject olItem1 = new JsonObject()
-      .put("id", itemId)
+      .put("id", itemIds.get(0))
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
       .put("materialType", new JsonObject().put("id", commonId))
       .put("permanentLoanType", new JsonObject().put("id", commonId))
-      .put("holdingsRecordId", holdingId);
+      .put("holdingsRecordId", holdingsIds.get(0));
     JsonObject successfulItem2 = new JsonObject()
-      .put("id", itemId2)
+      .put("id", itemIds.get(1))
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
-      .put("materialType", new JsonObject().put("id", commonId2))
-      .put("permanentLoanType", new JsonObject().put("id", commonId2))
-      .put("holdingsRecordId", holdingId2);
+      .put("materialType", new JsonObject().put("id", commonId))
+      .put("permanentLoanType", new JsonObject().put("id", commonId))
+      .put("holdingsRecordId", holdingsIds.get(1));
     JsonObject partialErrorItem3 = new JsonObject()
-      .put("id", itemId3)
+      .put("id", itemIds.get(2))
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
-      .put("materialType", new JsonObject().put("id", commonId3))
-      .put("permanentLoanType", new JsonObject().put("id", commonId3))
-      .put("holdingsRecordId", holdingId3);
+      .put("materialType", new JsonObject().put("id", commonId))
+      .put("permanentLoanType", new JsonObject().put("id", commonId))
+      .put("holdingsRecordId", holdingsIds.get(2));
     JsonObject olItem4 = new JsonObject()
-      .put("id", itemId4)
+      .put("id", itemIds.get(3))
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
-      .put("materialType", new JsonObject().put("id", commonId4))
-      .put("permanentLoanType", new JsonObject().put("id", commonId4))
-      .put("holdingsRecordId", holdingId4);
+      .put("materialType", new JsonObject().put("id", commonId))
+      .put("permanentLoanType", new JsonObject().put("id", commonId))
+      .put("holdingsRecordId", holdingsIds.get(3));
     JsonObject olItem5 = new JsonObject()
-      .put("id", itemId5)
+      .put("id", itemIds.get(4))
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
-      .put("materialType", new JsonObject().put("id", commonId5))
-      .put("permanentLoanType", new JsonObject().put("id", commonId5))
-      .put("holdingsRecordId", holdingId5);
+      .put("materialType", new JsonObject().put("id", commonId))
+      .put("permanentLoanType", new JsonObject().put("id", commonId))
+      .put("holdingsRecordId", holdingsIds.get(4));
     JsonObject olItem6 = new JsonObject()
-      .put("id", itemId6)
+      .put("id", itemIds.get(5))
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
-      .put("materialType", new JsonObject().put("id", commonId6))
-      .put("permanentLoanType", new JsonObject().put("id", commonId6))
-      .put("holdingsRecordId", holdingId6);
+      .put("materialType", new JsonObject().put("id", commonId))
+      .put("permanentLoanType", new JsonObject().put("id", commonId))
+      .put("holdingsRecordId", holdingsIds.get(5));
     JsonObject successfulItem7 = new JsonObject()
-      .put("id", itemId7)
+      .put("id", itemIds.get(6))
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
-      .put("materialType", new JsonObject().put("id", commonId7))
-      .put("permanentLoanType", new JsonObject().put("id", commonId7))
-      .put("holdingsRecordId", holdingId7);
+      .put("materialType", new JsonObject().put("id", commonId))
+      .put("permanentLoanType", new JsonObject().put("id", commonId))
+      .put("holdingsRecordId", holdingsIds.get(6));
     JsonObject successfulItem8 = new JsonObject()
-      .put("id", itemId8)
+      .put("id", itemIds.get(7))
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
-      .put("materialType", new JsonObject().put("id", commonId8))
-      .put("permanentLoanType", new JsonObject().put("id", commonId8))
-      .put("holdingsRecordId", holdingId8);
+      .put("materialType", new JsonObject().put("id", commonId))
+      .put("permanentLoanType", new JsonObject().put("id", commonId))
+      .put("holdingsRecordId", holdingsIds.get(7));
     JsonObject partialErrorItem9 = new JsonObject()
-      .put("id", itemId9)
+      .put("id", itemIds.get(8))
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
-      .put("materialType", new JsonObject().put("id", commonId9))
-      .put("permanentLoanType", new JsonObject().put("id", commonId9))
-      .put("holdingsRecordId", holdingId9);
+      .put("materialType", new JsonObject().put("id", commonId))
+      .put("permanentLoanType", new JsonObject().put("id", commonId))
+      .put("holdingsRecordId", holdingsIds.get(8));
     JsonObject partialErrorItem10 = new JsonObject()
-      .put("id", itemId10)
+      .put("id", itemIds.get(9))
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
-      .put("materialType", new JsonObject().put("id", commonId10))
-      .put("permanentLoanType", new JsonObject().put("id", commonId10))
-      .put("holdingsRecordId", holdingId10);
+      .put("materialType", new JsonObject().put("id", commonId))
+      .put("permanentLoanType", new JsonObject().put("id", commonId))
+      .put("holdingsRecordId", holdingsIds.get(9));
 
     JsonArray itemList = new JsonArray();
     itemList.add(new JsonObject().put("item", olItem1));
@@ -562,9 +545,10 @@ public class UpdateItemEventHandlerTest {
     itemList.add(new JsonObject().put("item", partialErrorItem9));
     itemList.add(new JsonObject().put("item", partialErrorItem10));
 
+    // Provide behavior for the items
     doAnswer(invocationOnMock -> {
       Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-      failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemId), 409));
+      failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemIds.get(0)), 409));
       return null;
     }).doAnswer(invocationOnMock -> {
         Item itemRecord = invocationOnMock.getArgument(0);
@@ -573,21 +557,21 @@ public class UpdateItemEventHandlerTest {
         return null;
       }).doAnswer(invocationOnMock -> {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-        failureHandler.accept(new Failure(format("Cannot update record %s not found", itemId3), 404));
+        failureHandler.accept(new Failure(format("Cannot update record %s not found", itemIds.get(2)), 404));
         return null;
       }).doAnswer(invocationOnMock -> {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemId4), 409));
+        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemIds.get(3)), 409));
         return null;
       })
       .doAnswer(invocationOnMock -> {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemId5), 409));
+        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemIds.get(4)), 409));
         return null;
       })
       .doAnswer(invocationOnMock -> {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemId6), 409));
+        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemIds.get(5)), 409));
         return null;
       })
       .doAnswer(invocationOnMock -> {
@@ -604,14 +588,14 @@ public class UpdateItemEventHandlerTest {
       })
       .doAnswer(invocationOnMock -> {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-        failureHandler.accept(new Failure(format("Cannot update record %s not found", itemId9), 404));
+        failureHandler.accept(new Failure(format("Cannot update record %s not found", itemIds.get(8)), 404));
         return null;
       })
       .doAnswer(invocationOnMock -> {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-        failureHandler.accept(new Failure(format("Cannot update record %s not found", itemId10), 404));
+        failureHandler.accept(new Failure(format("Cannot update record %s not found", itemIds.get(9)), 404));
         return null;
-      })// 10 tries. Next invocation will be on the second run 'handle()'-method.
+      })// 10 Items processed. Next iteration will be on the second run 'handle()'-method.
       .doAnswer(invocationOnMock -> {
         Item itemRecord = invocationOnMock.getArgument(0);
         Consumer<Success<Item>> successHandler = invocationOnMock.getArgument(1);
@@ -620,12 +604,12 @@ public class UpdateItemEventHandlerTest {
       })
       .doAnswer(invocationOnMock -> {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemId4), 409));
+        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemIds.get(3)), 409));
         return null;
       })
       .doAnswer(invocationOnMock -> {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-        failureHandler.accept(new Failure(format("Cannot update record %s not found", itemId5), 404));
+        failureHandler.accept(new Failure(format("Cannot update record %s not found", itemIds.get(4)), 404));
         return null;
       })
       .doAnswer(invocationOnMock -> {
@@ -649,7 +633,7 @@ public class UpdateItemEventHandlerTest {
       Consumer<Success<MultipleRecords>> successHandler = invocationOnMock.getArgument(2);
       successHandler.accept(new Success<>(result));
       return null;
-    }).when(mockedItemCollection).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s OR %s OR %s)", itemId, itemId4, itemId5, itemId6))),
+    }).when(mockedItemCollection).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s OR %s OR %s)", itemIds.get(0), itemIds.get(3), itemIds.get(4), itemIds.get(5)))),
       any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
 
     MappingManager.registerReaderFactory(fakeReaderFactory);
@@ -671,7 +655,7 @@ public class UpdateItemEventHandlerTest {
     CompletableFuture<DataImportEventPayload> future = updateItemHandler.handle(dataImportEventPayload);
     DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
     verify(mockedItemCollection, times(14)).update(any(), any(), any());
-    verify(mockedItemCollection, times(1)).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s OR %s OR %s)", itemId, itemId4, itemId5, itemId6))), any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+    verify(mockedItemCollection, times(1)).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s OR %s OR %s)", itemIds.get(0), itemIds.get(3), itemIds.get(4), itemIds.get(5)))), any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
 
     Assert.assertEquals(DI_INVENTORY_ITEM_UPDATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(ITEM.value()));
@@ -679,28 +663,28 @@ public class UpdateItemEventHandlerTest {
     JsonArray resultedItems = new JsonArray(actualDataImportEventPayload.getContext().get(ITEM.value()));
 
     Assert.assertEquals(5, resultedItems.size());
-    assertEquals(itemId2, String.valueOf(resultedItems.getJsonObject(0).getString("id")));
-    assertEquals(itemId7, String.valueOf(resultedItems.getJsonObject(1).getString("id")));
-    assertEquals(itemId8, String.valueOf(resultedItems.getJsonObject(2).getString("id")));
-    assertEquals(itemId, String.valueOf(resultedItems.getJsonObject(3).getString("id")));
-    assertEquals(itemId6, String.valueOf(resultedItems.getJsonObject(4).getString("id")));
+    assertEquals(itemIds.get(1), String.valueOf(resultedItems.getJsonObject(0).getString("id")));
+    assertEquals(itemIds.get(6), String.valueOf(resultedItems.getJsonObject(1).getString("id")));
+    assertEquals(itemIds.get(7), String.valueOf(resultedItems.getJsonObject(2).getString("id")));
+    assertEquals(itemIds.get(0), String.valueOf(resultedItems.getJsonObject(3).getString("id")));
+    assertEquals(itemIds.get(5), String.valueOf(resultedItems.getJsonObject(4).getString("id")));
 
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(ERRORS));
     List<PartialError> resultedErrorList = List.of(Json.decodeValue(actualDataImportEventPayload.getContext().get(ERRORS), PartialError[].class));
     Assert.assertEquals(5, resultedErrorList.size());
-    assertEquals(itemId3, String.valueOf(resultedErrorList.get(0).getId()));
-    assertEquals(itemId9, String.valueOf(resultedErrorList.get(1).getId()));
-    assertEquals(itemId10, String.valueOf(resultedErrorList.get(2).getId()));
-    assertEquals(itemId5, String.valueOf(resultedErrorList.get(3).getId()));
-    assertEquals(itemId4, String.valueOf(resultedErrorList.get(4).getId()));
-    assertEquals(resultedErrorList.get(0).getError(), format("Cannot update record %s not found", itemId3));
-    assertEquals(resultedErrorList.get(1).getError(), format("Cannot update record %s not found", itemId9));
-    assertEquals(resultedErrorList.get(2).getError(), format("Cannot update record %s not found", itemId10));
-    assertEquals(resultedErrorList.get(3).getError(), format("Cannot update record %s not found", itemId5));
+    assertEquals(itemIds.get(2), String.valueOf(resultedErrorList.get(0).getId()));
+    assertEquals(itemIds.get(8), String.valueOf(resultedErrorList.get(1).getId()));
+    assertEquals(itemIds.get(9), String.valueOf(resultedErrorList.get(2).getId()));
+    assertEquals(itemIds.get(4), String.valueOf(resultedErrorList.get(3).getId()));
+    assertEquals(itemIds.get(3), String.valueOf(resultedErrorList.get(4).getId()));
+    assertEquals(resultedErrorList.get(0).getError(), format("Cannot update record %s not found", itemIds.get(2)));
+    assertEquals(resultedErrorList.get(1).getError(), format("Cannot update record %s not found", itemIds.get(8)));
+    assertEquals(resultedErrorList.get(2).getError(), format("Cannot update record %s not found", itemIds.get(9)));
+    assertEquals(resultedErrorList.get(3).getError(), format("Cannot update record %s not found", itemIds.get(4)));
     assertEquals(resultedErrorList.get(4).getError(), format("Current retry number %s exceeded or equal given number %s for the Item update for jobExecutionId '%s' ", 1, 1, actualDataImportEventPayload.getJobExecutionId()));
 
 
-    //Second run. We need it to verify that CURRENT_RETRY_NUMBER and all lists are cleared.
+    //Second run. We need it to verify that CURRENT_RETRY_NUMBER and all accumulative results are cleared.
     JsonArray itemsListSecondRun = new JsonArray();
     itemsListSecondRun.add(new JsonObject().put("item", olItem1));
     itemsListSecondRun.add(new JsonObject().put("item", successfulItem2));
@@ -721,7 +705,7 @@ public class UpdateItemEventHandlerTest {
 
     doAnswer(invocationOnMock -> {
       Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-      failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemId), 409));
+      failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemIds.get(0)), 409));
       return null;
     }).doAnswer(invocationOnMock -> {
         Item tmpHoldingsRecord = invocationOnMock.getArgument(0);
@@ -730,11 +714,11 @@ public class UpdateItemEventHandlerTest {
         return null;
       }).doAnswer(invocationOnMock -> {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-        failureHandler.accept(new Failure(format("Cannot update record %s not found", itemId3), 404));
+        failureHandler.accept(new Failure(format("Cannot update record %s not found", itemIds.get(2)), 404));
         return null;
       }).doAnswer(invocationOnMock -> {
         Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemId4), 409));
+        failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemIds.get(3)), 409));
         return null;
       })
       .doAnswer(invocationOnMock -> {
@@ -756,13 +740,13 @@ public class UpdateItemEventHandlerTest {
       Consumer<Success<MultipleRecords>> successHandler = invocationOnMock.getArgument(2);
       successHandler.accept(new Success<>(result));
       return null;
-    }).when(mockedItemCollection).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s)", itemId, itemId4))),
+    }).when(mockedItemCollection).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s)", itemIds.get(0), itemIds.get(3)))),
       any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
 
     CompletableFuture<DataImportEventPayload> futureSecondRun = updateItemHandler.handle(dataImportEventPayloadSecondRun);
     DataImportEventPayload actualDataImportEventPayloadSecondRun = futureSecondRun.get(10000, TimeUnit.MILLISECONDS);
     verify(mockedItemCollection, times(20)).update(any(), any(), any());
-    verify(mockedItemCollection, times(1)).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s)", itemId, itemId4))), any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+    verify(mockedItemCollection, times(1)).findByCql(Mockito.argThat(cql -> cql.equals(String.format("id==(%s OR %s)", itemIds.get(0), itemIds.get(3)))), any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
     Assert.assertEquals(DI_INVENTORY_ITEM_UPDATED.value(), actualDataImportEventPayloadSecondRun.getEventType());
     Assert.assertNotNull(actualDataImportEventPayloadSecondRun.getContext().get(ITEM.value()));
     Assert.assertNull(actualDataImportEventPayloadSecondRun.getContext().get(UpdateHoldingEventHandler.CURRENT_RETRY_NUMBER));

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandlerTest.java
@@ -697,7 +697,7 @@ public class UpdateItemEventHandlerTest {
     assertEquals(resultedErrorList.get(1).getError(), format("Cannot update record %s not found", itemId9));
     assertEquals(resultedErrorList.get(2).getError(), format("Cannot update record %s not found", itemId10));
     assertEquals(resultedErrorList.get(3).getError(), format("Cannot update record %s not found", itemId5));
-    assertEquals(resultedErrorList.get(4).getError(), format("Current retry number %s exceeded or equal given number %s for the Holding update for jobExecutionId '%s' ", 1, 1, actualDataImportEventPayload.getJobExecutionId()));
+    assertEquals(resultedErrorList.get(4).getError(), format("Current retry number %s exceeded or equal given number %s for the Item update for jobExecutionId '%s' ", 1, 1, actualDataImportEventPayload.getJobExecutionId()));
 
 
     //Second run. We need it to verify that CURRENT_RETRY_NUMBER and all lists are cleared.
@@ -867,7 +867,7 @@ public class UpdateItemEventHandlerTest {
     List<PartialError> resultedErrorList = List.of(Json.decodeValue(actualDataImportEventPayload.getContext().get(ERRORS), PartialError[].class));
     Assert.assertEquals(1, resultedErrorList.size());
     assertEquals(itemId, String.valueOf(resultedErrorList.get(0).getId()));
-    assertEquals(format("Current retry number 1 exceeded or equal given number 1 for the Holding update for jobExecutionId '%s' ", actualDataImportEventPayload.getJobExecutionId()), resultedErrorList.get(0).getError());
+    assertEquals(format("Current retry number 1 exceeded or equal given number 1 for the Item update for jobExecutionId '%s' ", actualDataImportEventPayload.getJobExecutionId()), resultedErrorList.get(0).getError());
   }
 
 


### PR DESCRIPTION
## Purpose
1.Adjust the OL process to handle multiple expired holdings/items.
2. Compose the main handle and retry the result to set partial errors and created holdings/items into context.
3. Fix an issue for the Holdings/Items where the 3rd action for the entity can't processed after OL revealed.


## Approach
1. Improved the code inside handlers for the updating multiple Holdings+Items.
2. Brand new mechanism for retreiving actual entities via batch, not by one by one.
3. New tests added. Useless tests removed.

## Learning
JIRA: https://issues.folio.org/browse/MODINV-860


This PR should be merged with the: https://github.com/folio-org/data-import-processing-core/pull/314.