### PR TITLE
MODINV-911 fix item entity serialization error

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/ItemLoader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/loaders/ItemLoader.java
@@ -60,8 +60,13 @@ public class ItemLoader extends AbstractLoader<Item> {
       if (isNotEmpty(eventPayload.getContext().get(AbstractLoader.MULTI_MATCH_IDS))) {
         cqlSubMatch = getConditionByMultiMatchResult(eventPayload);
       } else if (isNotEmpty(eventPayload.getContext().get(EntityType.ITEM.value()))) {
-        JsonObject itemAsJson = new JsonObject(eventPayload.getContext().get(EntityType.ITEM.value()));
-        cqlSubMatch = format(" AND id == \"%s\"", itemAsJson.getString("id"));
+        JsonArray itemsAsJson = new JsonArray(eventPayload.getContext().get(EntityType.ITEM.value()));
+        if (!itemsAsJson.isEmpty()) {
+          String itemIds = itemsAsJson.stream().map(JsonObject.class::cast)
+            .map(jsonObj -> jsonObj.getString("id"))
+            .collect(Collectors.joining(" OR "));
+          cqlSubMatch = format(" AND id == (%s)", itemIds);
+        }
       } else if (isNotEmpty(eventPayload.getContext().get(EntityType.HOLDINGS.value()))) {
         JsonArray holdingsAsJson = new JsonArray(eventPayload.getContext().get(EntityType.HOLDINGS.value()));
         if (!holdingsAsJson.isEmpty()) {

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchItemEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchItemEventHandlerUnitTest.java
@@ -318,12 +318,12 @@ public class MatchItemEventHandlerUnitTest {
       callback.accept(result);
       return null;
     }).when(itemCollection)
-      .findByCql(eq(format("hrid == \"%s\" AND id == \"%s\"", ITEM_HRID, ITEM_ID)),
+      .findByCql(eq(format("hrid == \"%s\" AND id == (%s)", ITEM_HRID, ITEM_ID)),
         any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
 
     EventHandler eventHandler = new MatchItemEventHandler(mappingMetadataCache, null);
     HashMap<String, String> context = new HashMap<>();
-    context.put(EntityType.ITEM.value(), JsonObject.mapFrom(createItem()).encode());
+    context.put(EntityType.ITEM.value(), JsonArray.of(JsonObject.mapFrom(createItem())).encode());
     context.put(MAPPING_PARAMS, LOCATIONS_PARAMS);
     context.put(RELATIONS, MATCHING_RELATIONS);
     DataImportEventPayload eventPayload = createEventPayload().withContext(context);


### PR DESCRIPTION
## Purpose
[MODSOURMAN-1035](https://issues.folio.org/browse/MODSOURMAN-1035)

Data import with MARC bit -> Item update fails due to serialization error: `Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type java.util.LinkedHashMap<java.lang.Object,java.lang.Object> from Array value (token JsonToken.START_ARRAY)`

## Approach
Fix this by expecting JsonArray for ITEM entity