### PR TITLE
[MODINV-907] Avoid NPE during create of item after match by holding identifier

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -239,7 +239,7 @@ public class CreateItemEventHandler implements EventHandler {
   private JsonArray processMappingResult(DataImportEventPayload dataImportEventPayload, String deduplicationItemId) {
     JsonArray items = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
     JsonArray mappedItems = new JsonArray();
-    JsonArray holdingsIdentifiers = new JsonArray(dataImportEventPayload.getContext().remove(HOLDING_IDENTIFIERS));
+    JsonArray holdingsIdentifiers = getHoldingsIdentifiers(dataImportEventPayload);
     String holdingsAsString = dataImportEventPayload.getContext().get(EntityType.HOLDINGS.value());
 
     for (int i = 0; i < items.size(); i++) {
@@ -256,6 +256,13 @@ public class CreateItemEventHandler implements EventHandler {
       itemAsJson.put(ITEM_ID_FIELD, (i == 0) ? deduplicationItemId : UUID.randomUUID().toString());
     }
     return mappedItems;
+  }
+
+  private static JsonArray getHoldingsIdentifiers(DataImportEventPayload dataImportEventPayload) {
+    if (dataImportEventPayload.getContext().containsKey(HOLDING_IDENTIFIERS)) {
+      return new JsonArray(dataImportEventPayload.getContext().remove(HOLDING_IDENTIFIERS));
+    }
+    return new JsonArray();
   }
 
   @Override


### PR DESCRIPTION
### Purpose
When you want to create an item connected to an existing holdings, you match to that holdings hrid and have an action to create item. If you try to create it Item will be errored with NullException in JSON log

### Approach
Not try to remove holding identifiers from context if them does not exist there