### PR TITLE
[MODINV-913] Fix data lost during sharing instance from member tenant to the central

### DIFF
--- a/src/main/java/org/folio/inventory/consortium/handlers/FolioInstanceSharingHandlerImpl.java
+++ b/src/main/java/org/folio/inventory/consortium/handlers/FolioInstanceSharingHandlerImpl.java
@@ -35,13 +35,13 @@ public class FolioInstanceSharingHandlerImpl implements InstanceSharingHandler {
       instanceId, sourceTenantId, targetTenantId);
 
     // Remove HRID_KEY from the instance JSON
-    JsonObject jsonInstance = instance.getJsonForStorage();
+    JsonObject jsonInstance = new JsonObject(instance.getJsonForStorage().encode());
     jsonInstance.remove(HRID_KEY);
 
     // Add instance to the targetInstanceCollection
     return instanceOperations.addInstance(Instance.fromJson(jsonInstance), target)
       .compose(targetInstance -> {
-        JsonObject jsonInstanceToPublish = instance.getJsonForStorage();
+        JsonObject jsonInstanceToPublish = new JsonObject(instance.getJsonForStorage().encode());
         jsonInstanceToPublish.put(SOURCE, CONSORTIUM_FOLIO.getValue());
         jsonInstanceToPublish.put(HRID_KEY, targetInstance.getHrid());
 

--- a/src/main/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImpl.java
+++ b/src/main/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImpl.java
@@ -81,7 +81,7 @@ public class MarcInstanceSharingHandlerImpl implements InstanceSharingHandler {
                   instanceOperations.getInstanceById(instanceId, target))
                 .compose(targetInstance -> {
                   // Update JSON instance to include SOURCE=CONSORTIUM-MARC
-                  JsonObject jsonInstanceToPublish = instance.getJsonForStorage();
+                  JsonObject jsonInstanceToPublish = new JsonObject(instance.getJsonForStorage().encode());
                   jsonInstanceToPublish.put(SOURCE, CONSORTIUM_MARC.getValue());
                   jsonInstanceToPublish.put(HRID_KEY, targetInstance.getHrid());
                   // Update instance in sourceInstanceCollection


### PR DESCRIPTION
### Purpose 
Fix data lost during sharing instances from member tenant to the central

### Approach 
Rewrap JSON object from **instance.getJsonForStorage()** method to contain all elements in JSON arrays as JSON objects