### PR TITLE
MODDICORE-368 - Replace vulnerable transitive collections-generic v4.01 dependency usage

### DIFF
--- a/src/main/java/org/folio/inventory/resources/MoveApi.java
+++ b/src/main/java/org/folio/inventory/resources/MoveApi.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import org.apache.commons.collections15.ListUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.folio.HoldingsRecord;
 import org.folio.inventory.common.WebContext;
 import org.folio.inventory.domain.HoldingsRecordCollection;


### PR DESCRIPTION
## Purpose
to replace transitive dependency usage collections-generic v4.01 that is going to be removed from di-processing-core library 
due to vulnerability (https://github.com/advisories/GHSA-fjq5-5j5f-mvxh#:~:text=net.sourceforge.collections%3Acollections%2Dgeneric) https://github.com/folio-org/data-import-processing-core/pull/317
