### PR TITLE
MODINV-906: fix Item creation when Statistical Code value is empty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-## 20.2.0-SNAPSHOT 2023-xx-xx
+## 20.2.0-SNAPSHOT
+* Create Item action discards when stat codes are in field mapping but not incoming MARC file ([MODINV-906](https://issues.folio.org/browse/MODINV-906))
 * Inventory cannot process Holdings with virtual fields ([MODINV-941](https://issues.folio.org/browse/MODINV-941))
 
 ## 20.1.0 2023-10-13

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -781,7 +781,8 @@ public class UpdateHoldingEventHandlerTest {
       .put("status", new JsonObject().put("name", AVAILABLE.value()))
       .put("materialType", new JsonObject().put("id", UUID.randomUUID().toString()))
       .put("permanentLoanType", new JsonObject().put("id", UUID.randomUUID().toString()))
-      .put("holdingsRecordId", UUID.randomUUID().toString());
+      .put("holdingsRecordId", UUID.randomUUID().toString())
+      .put("statisticalCodeIds", JsonArray.of(JsonObject.of()));
 
     doAnswer(invocationOnMock -> {
       Consumer<Success<org.folio.inventory.domain.items.Item>> successHandler = invocationOnMock.getArgument(1);


### PR DESCRIPTION
**Approach**
Check whether Statistical Code value is empty, if yes then call inventory-storage with an empty list of statistical code ids in the payload, otherwise follow the previous logic.

**Tested locally**
<img width="1176" alt="image" src="https://github.com/folio-org/mod-inventory/assets/138673581/6ecd5fbf-15b1-4efe-9b83-194ca13cbe1f">

