### PR TITLE
MODINV-941 Inventory cannot process Holdings with virtual fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 20.2.0-SNAPSHOT 2023-xx-xx
+* Inventory cannot process Holdings with virtual fields ([MODINV-941](https://issues.folio.org/browse/MODINV-941))
+
 ## 20.1.0 2023-10-13
 * Update status when user attempts to update shared auth record from member tenant ([MODDATAIMP-926](https://issues.folio.org/browse/MODDATAIMP-926))
 * Add cache to get and store consortium data configurations ([MODINV-872](https://issues.folio.org/browse/MODINV-872))
@@ -7,7 +10,6 @@
 * Upgrade folio-kafka-wrapper to 3.0.0 version ([MODINV-834](https://issues.folio.org/browse/MODINV-834))
 * Add deduplication mechanism for sharing Instance ([MODINV-866](https://issues.folio.org/browse/MODINV-866))
 * Allow to overlay source 'MARC' instances without related MARC record ([MODINV-846](https://issues.folio.org/browse/MODINV-847))
-* Inventory cannot process Holdings with virtual fields ([MODINV-941](https://issues.folio.org/browse/MODINV-941))
 
 ## 20.0.0 2023-02-20
 * Controlled Instance's field properly reflects updates made by user in MARC Authority's 1XX fields ([MODINV-773] (https://issues.folio.org/browse/MODINV-773))

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Upgrade folio-kafka-wrapper to 3.0.0 version ([MODINV-834](https://issues.folio.org/browse/MODINV-834))
 * Add deduplication mechanism for sharing Instance ([MODINV-866](https://issues.folio.org/browse/MODINV-866))
 * Allow to overlay source 'MARC' instances without related MARC record ([MODINV-846](https://issues.folio.org/browse/MODINV-847))
+* Inventory cannot process Holdings with virtual fields ([MODINV-941](https://issues.folio.org/browse/MODINV-941))
 
 ## 20.0.0 2023-02-20
 * Controlled Instance's field properly reflects updates made by user in MARC Authority's 1XX fields ([MODINV-773] (https://issues.folio.org/browse/MODINV-773))

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
@@ -19,6 +19,7 @@ class ExternalStorageModuleHoldingsRecordCollection
   private static final Logger LOGGER = LogManager.getLogger(ExternalStorageModuleHoldingsRecordCollection.class);
   private static final ObjectMapper mapper = ObjectMapperTool.getMapper();
 
+  // added to ignore unknown fields
   static {
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   }

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
@@ -19,7 +19,10 @@ class ExternalStorageModuleHoldingsRecordCollection
   private static final Logger LOGGER = LogManager.getLogger(ExternalStorageModuleHoldingsRecordCollection.class);
   private static final ObjectMapper mapper = ObjectMapperTool.getMapper();
 
-  // added to ignore unknown fields
+  /*
+    Exclude 'holdingItems' and 'bareHoldingItems' from the response mapping to HoldingsRecord
+    due to incompatibilities with changes in mod-inventory-storage.
+   */
   static {
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   }

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
@@ -1,7 +1,10 @@
 package org.folio.inventory.storage.external;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonObject;
 import java.io.IOException;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.HoldingsRecord;
@@ -9,14 +12,16 @@ import org.folio.dbschema.ObjectMapperTool;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.validation.exceptions.JsonMappingException;
 
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonObject;
-
 class ExternalStorageModuleHoldingsRecordCollection
   extends ExternalStorageModuleCollection<HoldingsRecord>
   implements HoldingsRecordCollection {
 
   private static final Logger LOGGER = LogManager.getLogger(ExternalStorageModuleHoldingsRecordCollection.class);
+  private static final ObjectMapper mapper = ObjectMapperTool.getMapper();
+
+  static {
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  }
 
   ExternalStorageModuleHoldingsRecordCollection(String baseAddress,
                                          String tenant,

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -11,18 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.folio.inventory.domain.items.ItemStatusName;
-import org.folio.inventory.support.http.client.IndividualResource;
-import org.folio.inventory.support.http.client.Response;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import api.ApiTestSuite;
 import api.support.ApiRoot;
@@ -33,8 +22,18 @@ import api.support.builders.HoldingRequestBuilder;
 import api.support.builders.ItemRequestBuilder;
 import api.support.builders.ItemsMoveRequestBuilder;
 import io.vertx.core.json.JsonObject;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import junitparams.JUnitParamsRunner;
 import lombok.SneakyThrows;
+import org.folio.inventory.domain.items.ItemStatusName;
+import org.folio.inventory.support.http.client.IndividualResource;
+import org.folio.inventory.support.http.client.Response;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 @RunWith(JUnitParamsRunner.class)
 public class ItemApiMoveExamples extends ApiTests {
@@ -168,8 +167,7 @@ public class ItemApiMoveExamples extends ApiTests {
 
     final var updatedItem = itemsClient.getById(item.getId());
 
-    assertThat(updatedItem.getJson().getString(HOLDINGS_RECORD_ID),
-      is(existingHoldingsId.toString()));
+    assertNotEquals(updatedItem.getJson().getString(HOLDINGS_RECORD_ID), existingHoldingsId.toString());
   }
 
   @Test

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -164,7 +164,7 @@ public class ItemApiMoveExamples extends ApiTests {
 
     final var moveItemsResponse = moveItems(newHoldingsId, item);
 
-    assertThat(moveItemsResponse.getStatusCode(), is(500));
+    assertThat(moveItemsResponse.getStatusCode(), is(200));
 
     final var updatedItem = itemsClient.getById(item.getId());
 

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -149,7 +149,7 @@ public class ItemApiMoveExamples extends ApiTests {
   }
 
   @Test
-  public void cannotMoveItemToHoldingsThatDoesNotMatchSchema() {
+  public void canMoveItemToHoldingsThatDoesNotMatchSchema() {
     final var instanceId = createInstance();
 
     final var existingHoldingsId = createHoldingsForInstance(instanceId);

--- a/src/test/java/api/items/ItemApiMoveExamples.java
+++ b/src/test/java/api/items/ItemApiMoveExamples.java
@@ -149,7 +149,7 @@ public class ItemApiMoveExamples extends ApiTests {
   }
 
   @Test
-  public void canMoveItemToHoldingsThatDoesNotMatchSchema() {
+  public void canMoveItemToHoldings() {
     final var instanceId = createInstance();
 
     final var existingHoldingsId = createHoldingsForInstance(instanceId);

--- a/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollectionExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollectionExamples.java
@@ -33,12 +33,14 @@ public class ExternalStorageModuleHoldingsRecordCollectionExamples extends Exter
     assertEquals(permanentLocationId, holdingsrecord.getPermanentLocationId());
   }
 
-  @Test(expected = JsonMappingException.class)
-  public void shouldNotMapFromJsonAndThrowException() {
+  @Test
+  public void shouldNotMapFromJsonAndNotThrowException() {
     JsonObject holdingsRecord = new JsonObject()
-      .put("testField", "testValue");
+      .put("holdingsItems", "testValue")
+      .put("bareHoldingsItems", "testValue");
 
-    storage.mapFromJson(holdingsRecord);
+    var result = storage.mapFromJson(holdingsRecord);
+    assertNotNull(result);
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollectionExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollectionExamples.java
@@ -3,44 +3,44 @@ package org.folio.inventory.storage.external;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import io.vertx.core.json.JsonObject;
 import java.util.UUID;
-
 import org.folio.HoldingsRecord;
-import org.folio.inventory.validation.exceptions.JsonMappingException;
 import org.junit.Test;
 
-import io.vertx.core.json.JsonObject;
-
 public class ExternalStorageModuleHoldingsRecordCollectionExamples extends ExternalStorageTests {
+
+  private static final String INSTANCE_ID = UUID.randomUUID().toString();
+  private static final String HOLDING_ID = UUID.randomUUID().toString();
+  private static final String PERMANENT_LOCATION_ID = UUID.randomUUID().toString();
+
   private final ExternalStorageModuleHoldingsRecordCollection storage =
     useHttpClient(client -> new ExternalStorageModuleHoldingsRecordCollection(
       getStorageAddress(), TENANT_ID, TENANT_TOKEN, client));
 
   @Test
   public void shouldMapFromJson() {
-    String holdingId = UUID.randomUUID().toString();
-    String instanceId = UUID.randomUUID().toString();
-    String permanentLocationId = UUID.randomUUID().toString();
     JsonObject holdingsRecord = new JsonObject()
-      .put("id", holdingId)
-      .put("instanceId", instanceId)
-      .put("permanentLocationId", permanentLocationId);
+      .put("id", HOLDING_ID)
+      .put("instanceId", INSTANCE_ID)
+      .put("permanentLocationId", PERMANENT_LOCATION_ID);
 
     HoldingsRecord holdingsrecord = storage.mapFromJson(holdingsRecord);
     assertNotNull(holdingsrecord);
-    assertEquals(holdingId, holdingsrecord.getId());
-    assertEquals(instanceId, holdingsrecord.getInstanceId());
-    assertEquals(permanentLocationId, holdingsrecord.getPermanentLocationId());
+    assertEquals(HOLDING_ID, holdingsrecord.getId());
+    assertEquals(INSTANCE_ID, holdingsrecord.getInstanceId());
+    assertEquals(PERMANENT_LOCATION_ID, holdingsrecord.getPermanentLocationId());
   }
 
   @Test
   public void shouldMapFromJsonAndIgnoreUnknownProperties() {
     JsonObject holdingsRecord = new JsonObject()
       .put("holdingsItems", "testValue")
-      .put("bareHoldingsItems", "testValue");
+      .put("bareHoldingsItems", "testValue")
+      .put("instanceId", INSTANCE_ID);
 
     var result = storage.mapFromJson(holdingsRecord);
-    assertNotNull(result);
+    assertEquals(INSTANCE_ID, result.getInstanceId());
   }
 
   @Test
@@ -53,18 +53,15 @@ public class ExternalStorageModuleHoldingsRecordCollectionExamples extends Exter
 
   @Test
   public void shouldMapToRequest() {
-    String holdingId = UUID.randomUUID().toString();
-    String instanceId = UUID.randomUUID().toString();
-    String permanentLocationId = UUID.randomUUID().toString();
     HoldingsRecord holdingsrecord = new HoldingsRecord()
-      .withId(holdingId)
-      .withInstanceId(instanceId)
-      .withPermanentLocationId(permanentLocationId);
+      .withId(HOLDING_ID)
+      .withInstanceId(INSTANCE_ID)
+      .withPermanentLocationId(PERMANENT_LOCATION_ID);
 
     JsonObject jsonObject = storage.mapToRequest(holdingsrecord);
     assertNotNull(jsonObject);
-    assertEquals(holdingId, jsonObject.getString("id"));
-    assertEquals(instanceId, jsonObject.getString("instanceId"));
-    assertEquals(permanentLocationId, jsonObject.getString("permanentLocationId"));
+    assertEquals(HOLDING_ID, jsonObject.getString("id"));
+    assertEquals(INSTANCE_ID, jsonObject.getString("instanceId"));
+    assertEquals(PERMANENT_LOCATION_ID, jsonObject.getString("permanentLocationId"));
   }
 }

--- a/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollectionExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollectionExamples.java
@@ -34,7 +34,7 @@ public class ExternalStorageModuleHoldingsRecordCollectionExamples extends Exter
   }
 
   @Test
-  public void shouldMapFromJsonAndNotThrowException() {
+  public void shouldMapFromJsonAndIgnoreUnknownProperties() {
     JsonObject holdingsRecord = new JsonObject()
       .put("holdingsItems", "testValue")
       .put("bareHoldingsItems", "testValue");


### PR DESCRIPTION
### Purpose
Inventory cannot process Holdings with virtual fields [MODINV-941](https://issues.folio.org/browse/MODINV-941)

### Approach
customize object mapper

### Learning
https://javarevisited.blogspot.com/2018/01/how-to-ignore-unknown-properties-parsing-json-java-jackson.html#axzz8NAd4SgHb