### PR TITLE
MODDATAIMP-957: set matched ID before record creation in SRS 

### DIFF
--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
@@ -316,6 +316,7 @@ public class CreateInstanceEventHandlerTest {
     String actualDate = AdditionalFieldsUtil.getValueFromControlledField(recordCaptor.getValue(), TAG_005);
     assertNotNull(actualDate);
     assertEquals(expectedDate.substring(0, 10), actualDate.substring(0, 10));
+    assertEquals(recordId, recordCaptor.getValue().getMatchedId());
   }
 
   @Test(expected = ExecutionException.class)


### PR DESCRIPTION
**Purpose:** be able to create a record in SRS

**Approach:** set matched ID with record ID value to be validated successfully during REST call.

**Tested locally:**
<img width="1116" alt="image" src="https://github.com/folio-org/mod-inventory/assets/138673581/6e4ac5ab-ba9d-4f90-9059-d6f29b1037d6">
