### PR TITLE
MODINV-984: Remove extra fields from 'holdings/move' mechanism

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Set instance record as deleted ([MODINV-883](https://issues.folio.org/browse/MODINV-883))
 * Remove step of initial saving of incoming records to SRS [MODSOURMAN-1022](https://issues.folio.org/browse/MODSOURMAN-1022)
 * Apply 005 logic before saving MARC Bib in SRS [MODINV-921](https://issues.folio.org/browse/MODINV-921)
+* Remove extra fields from 'holdings/move' mechanism [MODINV-948](https://issues.folio.org/browse/MODINV-948)
+
 
 ## 20.1.0 2023-10-13
 * Update status when user attempts to update shared auth record from member tenant ([MODDATAIMP-926](https://issues.folio.org/browse/MODDATAIMP-926))

--- a/src/main/java/org/folio/inventory/resources/MoveApi.java
+++ b/src/main/java/org/folio/inventory/resources/MoveApi.java
@@ -48,6 +48,8 @@ public class MoveApi extends AbstractInventoryResource {
   public static final String ITEMS_PROPERTY = "items";
   public static final String HOLDINGS_RECORDS_PROPERTY = "holdingsRecords";
   public static final String HOLDINGS_STORAGE = "/holdings-storage/holdings";
+  private static final String HOLDING_ITEMS_PROPERTY = "holdingItems";
+  private static final String BARE_HOLDING_ITEMS_PROPERTY = "bareHoldingItems";
 
   public MoveApi(final Storage storage, final HttpClient client) {
     super(storage, client);
@@ -175,9 +177,15 @@ public class MoveApi extends AbstractInventoryResource {
 
   private List<HoldingsRecord> updateInstanceIdForHoldings(String toInstanceId, List<JsonObject> jsons) {
     return jsons.stream()
+      .peek(this::removeExtraRedundantFields)
       .map(json -> json.mapTo(HoldingsRecord.class))
       .map(holding -> holding.withInstanceId(toInstanceId))
       .collect(toList());
+  }
+
+  private void removeExtraRedundantFields(JsonObject json) {
+    json.remove(HOLDING_ITEMS_PROPERTY);
+    json.remove(BARE_HOLDING_ITEMS_PROPERTY);
   }
 
   private void updateHoldings(RoutingContext routingContext, WebContext context, List<String> idsToUpdate,


### PR DESCRIPTION
Added a mechanism to remove extra redundant fields from Holdings Json while using POST holdings/move.
Tests added.
NEWS updated.