### PR TITLE
MODINV-950 - Make configurable params for instance sharing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Apply 005 logic before saving MARC Bib in SRS [MODINV-921](https://issues.folio.org/browse/MODINV-921)
 * Remove extra fields from 'holdings/move' mechanism [MODINV-948](https://issues.folio.org/browse/MODINV-948)
 * Allow to link local instance to shared instance [MODINV-901](https://issues.folio.org/browse/MODINV-901)
+* Make configurable params for instance sharing [MODINV-950](https://issues.folio.org/browse/MODINV-950)
 
 ## 20.1.0 2023-10-13
 * Update status when user attempts to update shared auth record from member tenant ([MODDATAIMP-926](https://issues.folio.org/browse/MODDATAIMP-926))

--- a/src/main/java/org/folio/inventory/consortium/util/RestDataImportHelper.java
+++ b/src/main/java/org/folio/inventory/consortium/util/RestDataImportHelper.java
@@ -46,10 +46,21 @@ public class RestDataImportHelper {
   public static final String STATUS_COMMITTED = "COMMITTED";
   public static final String STATUS_ERROR = "ERROR";
 
+  private static final String IMPORT_STATUS_POLL_INTERVAL_SEC_PARAM =
+    "inventory.sharing.di.status.poll.interval.seconds";
+  private static final String IMPORT_STATUS_POLL_NUMBER_PARAM =
+    "inventory.sharing.di.status.poll.number";
+  private static final String DEFAULT_IMPORT_STATUS_POLL_INTERVAL_SEC = "5";
+  private static final String DEFAULT_IMPORT_STATUS_POLL_NUMBER = "5";
+
   private final Vertx vertx;
+  private final long durationInSec;
+  private final int attemptsNumber;
 
   public RestDataImportHelper(Vertx vertx) {
     this.vertx = vertx;
+    this.durationInSec = Integer.parseInt(System.getProperty(IMPORT_STATUS_POLL_INTERVAL_SEC_PARAM, DEFAULT_IMPORT_STATUS_POLL_INTERVAL_SEC));
+    this.attemptsNumber = Integer.parseInt(System.getProperty(IMPORT_STATUS_POLL_NUMBER_PARAM, DEFAULT_IMPORT_STATUS_POLL_NUMBER));
   }
 
   public static final JobProfileInfo JOB_PROFILE_INFO = new JobProfileInfo()
@@ -72,11 +83,6 @@ public class RestDataImportHelper {
       sharingInstanceMetadata.getInstanceIdentifier(), sharingInstanceMetadata.getTargetTenantId());
 
     ChangeManagerClient changeManagerClient = getChangeManagerClient(kafkaHeaders);
-
-    //TODO: move to config
-    //Constants for checkDataImportStatus method
-    final long durationInSec = 20;
-    final int attemptsNumber = 3;
 
     return initJobExecution(instanceId, changeManagerClient, kafkaHeaders)
       .compose(jobExecutionId -> setDefaultJobProfileToJobExecution(jobExecutionId, changeManagerClient))

--- a/src/main/java/org/folio/inventory/consortium/util/RestDataImportHelper.java
+++ b/src/main/java/org/folio/inventory/consortium/util/RestDataImportHelper.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.Record;
 import org.folio.inventory.consortium.entities.SharingInstance;
+import org.folio.kafka.SimpleConfigurationReader;
 import org.folio.rest.client.ChangeManagerClient;
 import org.folio.rest.jaxrs.model.InitJobExecutionsRqDto;
 import org.folio.rest.jaxrs.model.InitialRecord;
@@ -59,8 +60,10 @@ public class RestDataImportHelper {
 
   public RestDataImportHelper(Vertx vertx) {
     this.vertx = vertx;
-    this.durationInSec = Integer.parseInt(System.getProperty(IMPORT_STATUS_POLL_INTERVAL_SEC_PARAM, DEFAULT_IMPORT_STATUS_POLL_INTERVAL_SEC));
-    this.attemptsNumber = Integer.parseInt(System.getProperty(IMPORT_STATUS_POLL_NUMBER_PARAM, DEFAULT_IMPORT_STATUS_POLL_NUMBER));
+    this.durationInSec = Integer.parseInt(SimpleConfigurationReader.getValue(
+      IMPORT_STATUS_POLL_INTERVAL_SEC_PARAM, DEFAULT_IMPORT_STATUS_POLL_INTERVAL_SEC));
+    this.attemptsNumber = Integer.parseInt(SimpleConfigurationReader.getValue(
+      IMPORT_STATUS_POLL_NUMBER_PARAM, DEFAULT_IMPORT_STATUS_POLL_NUMBER));
   }
 
   public static final JobProfileInfo JOB_PROFILE_INFO = new JobProfileInfo()


### PR DESCRIPTION
## Purpose
to expose configuration parameters for overriding the interval and the number of attempts for import status check during instance sharing process

## Learning
[MODINV-950](https://issues.folio.org/browse/MODINV-950)