### PR TITLE
[MODINV-953] Adjust non-match by POL/VRN logic to not throw an exception

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/AbstractPreloader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/AbstractPreloader.java
@@ -52,11 +52,14 @@ public abstract class AbstractPreloader {
 
         return doPreloading(dataImportEventPayload, preloadingField.get(), preloadValues)
                 .thenApply(values -> {
+                    if (values.isEmpty()) {
+                      return null;
+                    }
                     matchExpression.setFields(Collections.singletonList(
                             new Field().withLabel("field").withValue(getLoaderTargetFieldName())));
                     matchDetail.setExistingMatchExpression(matchExpression);
 
-                    return LoadQueryBuilder.build(ListValue.of(values), matchDetail);
+                    return LoadQueryBuilder.build(ListValue.of(values.get()), matchDetail);
                 });
     }
 
@@ -86,7 +89,7 @@ public abstract class AbstractPreloader {
 
     protected abstract String getMatchEntityName();
     protected abstract String getLoaderTargetFieldName();
-    protected abstract CompletableFuture<List<String>> doPreloading(DataImportEventPayload eventPayload,
+    protected abstract CompletableFuture<Optional<List<String>>> doPreloading(DataImportEventPayload eventPayload,
                                                                     PreloadingFields preloadingField,
                                                                     List<String> loadingParameters);
 }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/HoldingsPreloader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/HoldingsPreloader.java
@@ -2,6 +2,7 @@ package org.folio.inventory.dataimport.handlers.matching.preloaders;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -34,9 +35,9 @@ public class HoldingsPreloader extends AbstractPreloader {
     }
 
     @Override
-    protected CompletableFuture<List<String>> doPreloading(DataImportEventPayload eventPayload,
-                                                           PreloadingFields preloadingField,
-                                                           List<String> loadingParameters) {
+    protected CompletableFuture<Optional<List<String>>> doPreloading(DataImportEventPayload eventPayload,
+                                                                    PreloadingFields preloadingField,
+                                                                    List<String> loadingParameters) {
         return ordersPreloaderHelper.preload(eventPayload, preloadingField, loadingParameters, this::extractHoldingsIdsForHoldings);
     }
 

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/InstancePreloader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/InstancePreloader.java
@@ -2,6 +2,7 @@ package org.folio.inventory.dataimport.handlers.matching.preloaders;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -33,9 +34,9 @@ public class InstancePreloader extends AbstractPreloader {
     }
 
     @Override
-    protected CompletableFuture<List<String>> doPreloading(DataImportEventPayload eventPayload,
-                                                           PreloadingFields preloadingField,
-                                                           List<String> loadingParameters) {
+    protected CompletableFuture<Optional<List<String>>> doPreloading(DataImportEventPayload eventPayload,
+                                                                    PreloadingFields preloadingField,
+                                                                    List<String> loadingParameters) {
         return ordersPreloaderHelper.preload(eventPayload, preloadingField, loadingParameters, this::extractInstanceIdsForInstances);
     }
 

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/ItemPreloader.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/preloaders/ItemPreloader.java
@@ -2,6 +2,7 @@ package org.folio.inventory.dataimport.handlers.matching.preloaders;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -34,9 +35,9 @@ public class ItemPreloader extends AbstractPreloader {
     }
 
     @Override
-    protected CompletableFuture<List<String>> doPreloading(DataImportEventPayload eventPayload,
-                                                           PreloadingFields preloadingField,
-                                                           List<String> loadingParameters) {
+    protected CompletableFuture<Optional<List<String>>> doPreloading(DataImportEventPayload eventPayload,
+                                                                    PreloadingFields preloadingField,
+                                                                    List<String> loadingParameters) {
         return ordersPreloaderHelper.preload(eventPayload, preloadingField, loadingParameters, this::extractHoldingsIdsForItems);
     }
 

--- a/src/test/java/org/folio/inventory/eventhandlers/preloaders/HoldingsPreloaderTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/preloaders/HoldingsPreloaderTest.java
@@ -12,6 +12,7 @@ import static org.folio.rest.jaxrs.model.MatchExpression.DataValueType.VALUE_FRO
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -80,7 +81,7 @@ public class HoldingsPreloaderTest {
         List<String> holdingsIdsMock = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
         when(ordersPreloaderHelper.preload(eq(eventPayload), eq(PreloadingFields.POL), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(holdingsIdsMock));
+                .thenReturn(CompletableFuture.completedFuture(Optional.of(holdingsIdsMock)));
 
         LoadQuery initialLoadQuery = LoadQueryBuilder.build(ListValue.of(POLS), matchDetail);
         LoadQuery loadQuery = preloader.preload(initialLoadQuery, eventPayload)

--- a/src/test/java/org/folio/inventory/eventhandlers/preloaders/HoldingsPreloaderTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/preloaders/HoldingsPreloaderTest.java
@@ -95,6 +95,31 @@ public class HoldingsPreloaderTest {
 
     @Test
     @SneakyThrows
+    public void shouldReturnNullLoadQueryWhenLoadedNoPol() {
+        MatchExpression incomingMatchExpression = new MatchExpression()
+          .withDataValueType(VALUE_FROM_RECORD)
+          .withFields(List.of(
+            new Field().withLabel("field").withValue("935"),
+            new Field().withLabel("indicator1").withValue(""),
+            new Field().withLabel("indicator2").withValue(""),
+            new Field().withLabel("recordSubfield").withValue("a")
+          ));
+        DataImportEventPayload eventPayload = createEventPayload();
+        MatchDetail matchDetail =((MatchProfile) eventPayload.getCurrentNode().getContent()).getMatchDetails().get(0);
+        matchDetail.setIncomingMatchExpression(incomingMatchExpression);
+
+        when(ordersPreloaderHelper.preload(eq(eventPayload), eq(PreloadingFields.POL), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        LoadQuery initialLoadQuery = LoadQueryBuilder.build(ListValue.of(POLS), matchDetail);
+        LoadQuery loadQuery = preloader.preload(initialLoadQuery, eventPayload)
+          .get(20, TimeUnit.SECONDS);
+
+        Assertions.assertThat(loadQuery).isNull();
+    }
+
+    @Test
+    @SneakyThrows
     public void shouldReturnNullForNullLoadQuery() {
         LoadQuery loadQuery = preloader.preload(null, createEventPayload())
                 .get(20, TimeUnit.SECONDS);

--- a/src/test/java/org/folio/inventory/eventhandlers/preloaders/InstancePreloaderTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/preloaders/InstancePreloaderTest.java
@@ -12,6 +12,7 @@ import static org.folio.rest.jaxrs.model.MatchExpression.DataValueType.VALUE_FRO
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -80,7 +81,7 @@ public class InstancePreloaderTest {
         List<String> instanceIdsMock = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
         when(ordersPreloaderHelper.preload(eq(eventPayload), eq(PreloadingFields.POL), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(instanceIdsMock));
+                .thenReturn(CompletableFuture.completedFuture(Optional.of(instanceIdsMock)));
 
         LoadQuery initialLoadQuery = LoadQueryBuilder.build(ListValue.of(POLS), matchDetail);
         LoadQuery loadQuery = preloader.preload(initialLoadQuery, eventPayload)

--- a/src/test/java/org/folio/inventory/eventhandlers/preloaders/InstancePreloaderTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/preloaders/InstancePreloaderTest.java
@@ -94,6 +94,31 @@ public class InstancePreloaderTest {
 
     @Test
     @SneakyThrows
+    public void shouldReturnNullLoadQueryWhenLoadedNoPol() {
+        MatchExpression incomingMatchExpression = new MatchExpression()
+          .withDataValueType(VALUE_FROM_RECORD)
+          .withFields(List.of(
+            new Field().withLabel("field").withValue("935"),
+            new Field().withLabel("indicator1").withValue(""),
+            new Field().withLabel("indicator2").withValue(""),
+            new Field().withLabel("recordSubfield").withValue("a")
+          ));
+        DataImportEventPayload eventPayload = createEventPayload();
+        MatchDetail matchDetail =((MatchProfile) eventPayload.getCurrentNode().getContent()).getMatchDetails().get(0);
+        matchDetail.setIncomingMatchExpression(incomingMatchExpression);
+
+        when(ordersPreloaderHelper.preload(eq(eventPayload), eq(PreloadingFields.POL), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        LoadQuery initialLoadQuery = LoadQueryBuilder.build(ListValue.of(POLS), matchDetail);
+        LoadQuery loadQuery = preloader.preload(initialLoadQuery, eventPayload)
+          .get(20, TimeUnit.SECONDS);
+
+        Assertions.assertThat(loadQuery).isNull();
+    }
+
+    @Test
+    @SneakyThrows
     public void shouldReturnNullForNullLoadQuery() {
         LoadQuery loadQuery = preloader.preload(null, createEventPayload())
                 .get(20, TimeUnit.SECONDS);

--- a/src/test/java/org/folio/inventory/eventhandlers/preloaders/ItemPreloaderTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/preloaders/ItemPreloaderTest.java
@@ -12,6 +12,7 @@ import static org.folio.rest.jaxrs.model.MatchExpression.DataValueType.VALUE_FRO
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -80,7 +81,7 @@ public class ItemPreloaderTest {
         List<String> holdingsIdsMock = List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
         when(ordersPreloaderHelper.preload(eq(eventPayload), eq(PreloadingFields.POL), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(holdingsIdsMock));
+                .thenReturn(CompletableFuture.completedFuture(Optional.of(holdingsIdsMock)));
 
         LoadQuery initialLoadQuery = LoadQueryBuilder.build(ListValue.of(POLS), matchDetail);
         LoadQuery loadQuery = preloader.preload(initialLoadQuery, eventPayload)

--- a/src/test/java/org/folio/inventory/eventhandlers/preloaders/ItemPreloaderTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/preloaders/ItemPreloaderTest.java
@@ -95,6 +95,31 @@ public class ItemPreloaderTest {
 
     @Test
     @SneakyThrows
+    public void shouldReturnNullLoadQueryWhenLoadedNoPol() {
+        MatchExpression incomingMatchExpression = new MatchExpression()
+          .withDataValueType(VALUE_FROM_RECORD)
+          .withFields(List.of(
+            new Field().withLabel("field").withValue("935"),
+            new Field().withLabel("indicator1").withValue(""),
+            new Field().withLabel("indicator2").withValue(""),
+            new Field().withLabel("recordSubfield").withValue("a")
+          ));
+        DataImportEventPayload eventPayload = createEventPayload();
+        MatchDetail matchDetail =((MatchProfile) eventPayload.getCurrentNode().getContent()).getMatchDetails().get(0);
+        matchDetail.setIncomingMatchExpression(incomingMatchExpression);
+
+        when(ordersPreloaderHelper.preload(eq(eventPayload), eq(PreloadingFields.POL), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        LoadQuery initialLoadQuery = LoadQueryBuilder.build(ListValue.of(POLS), matchDetail);
+        LoadQuery loadQuery = preloader.preload(initialLoadQuery, eventPayload)
+          .get(20, TimeUnit.SECONDS);
+
+        Assertions.assertThat(loadQuery).isNull();
+    }
+
+    @Test
+    @SneakyThrows
     public void shouldReturnNullForNullLoadQuery() {
         LoadQuery loadQuery = preloader.preload(null, createEventPayload())
                 .get(20, TimeUnit.SECONDS);

--- a/src/test/java/org/folio/inventory/eventhandlers/preloaders/OrdersPreloaderHelperTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/preloaders/OrdersPreloaderHelperTest.java
@@ -60,13 +60,14 @@ public class OrdersPreloaderHelperTest {
         when(ordersClient.getPoLineCollection(eq(orderLinesCql), any()))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(poLineCollectionMock)));
 
-        List<String> instanceIds = ordersPreloaderHelper.preload(createEventPayload(),
+        Optional<List<String>> instanceIds = ordersPreloaderHelper.preload(createEventPayload(),
                         PreloadingFields.POL,
                         poLineNumbersMock,
                         getPreloadResultConverter())
                 .get(20, TimeUnit.SECONDS);
 
-        Assertions.assertThat(instanceIds).isEqualTo(instanceIdsMock);
+        Assertions.assertThat(instanceIds.isPresent()).isTrue();
+        Assertions.assertThat(instanceIds.get()).isEqualTo(instanceIdsMock);
     }
 
     @Test
@@ -86,13 +87,14 @@ public class OrdersPreloaderHelperTest {
         when(ordersClient.getPoLineCollection(eq(orderLinesCql), any()))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(poLineCollectionMock)));
 
-        List<String> instanceIds = ordersPreloaderHelper.preload(createEventPayload(),
+        Optional<List<String>> instanceIds = ordersPreloaderHelper.preload(createEventPayload(),
                         PreloadingFields.VRN,
                         vendorReferenceNumbersMock,
                         getPreloadResultConverter())
                 .get(20, TimeUnit.SECONDS);
 
-        Assertions.assertThat(instanceIds).isEqualTo(instanceIdsMock);
+      Assertions.assertThat(instanceIds.isPresent()).isTrue();
+      Assertions.assertThat(instanceIds.get()).isEqualTo(instanceIdsMock);
     }
 
     @Test
@@ -108,17 +110,17 @@ public class OrdersPreloaderHelperTest {
 
     @Test
     @SneakyThrows
-    public void shouldFailOnEmptyResponseFromOrdersClient() {
+    public void shouldReturnEmptyOptionalOnEmptyResponseFromOrdersClient() {
         when(ordersClient.getPoLineCollection(any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
-        Assertions.assertThatThrownBy(() -> ordersPreloaderHelper.preload(createEventPayload(),
-                                PreloadingFields.POL,
-                                Collections.singletonList(UUID.randomUUID().toString()),
-                                getPreloadResultConverter())
-                        .get(20, TimeUnit.SECONDS))
-                .getCause()
-                .hasMessage(NOT_FOUND_POL_MESSAGE);
+        Optional<List<String>> instanceIds = ordersPreloaderHelper.preload(createEventPayload(),
+            PreloadingFields.POL,
+            Collections.singletonList(UUID.randomUUID().toString()),
+            getPreloadResultConverter())
+          .get(20, TimeUnit.SECONDS);
+
+        Assertions.assertThat(instanceIds.isEmpty()).isTrue();
     }
 
     private Function<JsonArray, List<String>> getPreloadResultConverter() {

--- a/src/test/java/org/folio/inventory/eventhandlers/preloaders/OrdersPreloaderHelperTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/preloaders/OrdersPreloaderHelperTest.java
@@ -66,8 +66,8 @@ public class OrdersPreloaderHelperTest {
                         getPreloadResultConverter())
                 .get(20, TimeUnit.SECONDS);
 
-        Assertions.assertThat(instanceIds.isPresent()).isTrue();
-        Assertions.assertThat(instanceIds.get()).isEqualTo(instanceIdsMock);
+        Assertions.assertThat(instanceIds).isPresent();
+        Assertions.assertThat(instanceIds).contains(instanceIdsMock);
     }
 
     @Test
@@ -93,8 +93,8 @@ public class OrdersPreloaderHelperTest {
                         getPreloadResultConverter())
                 .get(20, TimeUnit.SECONDS);
 
-      Assertions.assertThat(instanceIds.isPresent()).isTrue();
-      Assertions.assertThat(instanceIds.get()).isEqualTo(instanceIdsMock);
+      Assertions.assertThat(instanceIds).isPresent();
+      Assertions.assertThat(instanceIds).contains(instanceIdsMock);
     }
 
     @Test
@@ -120,7 +120,7 @@ public class OrdersPreloaderHelperTest {
             getPreloadResultConverter())
           .get(20, TimeUnit.SECONDS);
 
-        Assertions.assertThat(instanceIds.isEmpty()).isTrue();
+        Assertions.assertThat(instanceIds).isNotPresent();
     }
 
     private Function<JsonArray, List<String>> getPreloadResultConverter() {


### PR DESCRIPTION
### Purpose
Not throw an exception when not matched by POL/VRN

### Approach
When not found POL, return null loadQuery and not make request on inventory-storage