### PR TITLE
[MODINV-901] Add missed module permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -392,7 +392,8 @@
             "inventory-storage.instance-relationships.collection.get",
             "inventory-storage.instance-relationships.item.post",
             "inventory-storage.instance-relationships.item.put",
-            "inventory-storage.instance-relationships.item.delete"
+            "inventory-storage.instance-relationships.item.delete",
+            "user-tenants.collection.get"
           ]
         },
         {
@@ -412,7 +413,8 @@
             "inventory-storage.instance-relationships.collection.get",
             "inventory-storage.instance-relationships.item.post",
             "inventory-storage.instance-relationships.item.put",
-            "inventory-storage.instance-relationships.item.delete"
+            "inventory-storage.instance-relationships.item.delete",
+            "user-tenants.collection.get"
           ]
         },
         {
@@ -456,7 +458,8 @@
             "inventory-storage.instance-relationships.collection.get",
             "inventory-storage.instance-relationships.item.post",
             "inventory-storage.instance-relationships.item.put",
-            "inventory-storage.instance-relationships.item.delete"
+            "inventory-storage.instance-relationships.item.delete",
+            "user-tenants.collection.get"
           ]
         }
       ]


### PR DESCRIPTION
https://issues.folio.org/browse/MODINV-901
Added missed module permission after this PR merged: https://github.com/folio-org/mod-inventory/pull/666/files

This issue causes Karate failures of Thunderjet team with error:
`{
  "errors" : [ {
    "message" : "io.vertx.core.impl.NoStackTraceThrowable: Error loading consortium data, tenantId: 'testtenant3598671572787159866' response status: '403', body: 'Access for user 'test-user' (00000000-1111-5555-9999-999999999992) requires permission: user-tenants.collection.get'",
    "code" : "genericError",
    "parameters" : [ ]
  } ],
  "total_records" : 1
}`