### PR TITLE
FAT-9975: Additional permissions for soft delete added.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -433,7 +433,11 @@
           "methods": ["DELETE"],
           "pathPattern": "/inventory/instances/{id}/mark-deleted",
           "permissionsRequired": [],
-          "modulePermissions": []
+          "modulePermissions": [
+            "inventory-storage.instances.item.get",
+            "inventory-storage.instances.item.put",
+            "source-storage.records.update"
+          ]
         }
       ]
     },


### PR DESCRIPTION
It is needed to fix an issue in scope of integration tests problem: 
`status code was: 403, expected: 204, response time in milliseconds: 291, url: https://folio-testing-karate-okapi.ci.folio.org/inventory/instances/f0fe6f14-c37d-4c4c-b7cf-ac56d01b535f/mark-deleted, response: 
Access for user 'test-user' (00000000-1111-5555-9999-999999999992) requires permission: inventory-storage.instances.item.get
classpath:folijet/mod-inventory/features/inventoryFeatureTest.feature:258`