### PR TITLE
MODINV-957 Create Kafka topics instead of relying on auto create in mod-inventory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Allow to link local instance to shared instance [MODINV-901](https://issues.folio.org/browse/MODINV-901)
 * OOM issue in mod-inventory ([MODINV-944](https://issues.folio.org/browse/MODINV-944))
 * Make configurable params for instance sharing [MODINV-950](https://issues.folio.org/browse/MODINV-950)
+* Create Kafka topics instead of relying on auto create in mod-inventory [MODINV-957](https://issues.folio.org/browse/MODINV-957)
 
 ## 20.1.0 2023-10-13
 * Update status when user attempts to update shared auth record from member tenant ([MODDATAIMP-926](https://issues.folio.org/browse/MODDATAIMP-926))

--- a/README.MD
+++ b/README.MD
@@ -108,7 +108,6 @@ After setup, it is good to check logs in all related modules for errors.
     * "_inventory.kafka.MarcBibUpdateConsumer.loadLimit_": 5
     * "_inventory.kafka.MarcBibUpdateConsumer.maxDistributionNumber_": 100
 * Variables for setting number of partitions of topics:
-  * DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING
   * DI_INVENTORY_INSTANCE_CREATED
   * DI_INVENTORY_HOLDING_CREATED
   * DI_INVENTORY_ITEM_CREATED
@@ -119,6 +118,8 @@ After setup, it is good to check logs in all related modules for errors.
   * DI_INVENTORY_HOLDING_UPDATED
   * DI_INVENTORY_ITEM_UPDATED
   * DI_INVENTORY_INSTANCE_NOT_MATCHED
+  * DI_INVENTORY_HOLDING_NOT_MATCHED
+  * DI_INVENTORY_ITEM_NOT_MATCHED
   * DI_INVENTORY_AUTHORITY_UPDATED
 Default value for all partitions is 1
 

--- a/README.MD
+++ b/README.MD
@@ -107,6 +107,20 @@ After setup, it is good to check logs in all related modules for errors.
     * "_inventory.kafka.MarcBibUpdateConsumerVerticle.instancesNumber_": 3
     * "_inventory.kafka.MarcBibUpdateConsumer.loadLimit_": 5
     * "_inventory.kafka.MarcBibUpdateConsumer.maxDistributionNumber_": 100
+* Variables for setting number of partitions of topics:
+  * DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING
+  * DI_INVENTORY_INSTANCE_CREATED
+  * DI_INVENTORY_HOLDING_CREATED
+  * DI_INVENTORY_ITEM_CREATED
+  * DI_INVENTORY_INSTANCE_MATCHED
+  * DI_INVENTORY_HOLDING_MATCHED
+  * DI_INVENTORY_ITEM_MATCHED
+  * DI_INVENTORY_INSTANCE_UPDATED
+  * DI_INVENTORY_HOLDING_UPDATED
+  * DI_INVENTORY_ITEM_UPDATED
+  * DI_INVENTORY_INSTANCE_NOT_MATCHED
+  * DI_INVENTORY_AUTHORITY_UPDATED
+Default value for all partitions is 1
 
 # Making Requests
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -433,7 +433,11 @@
           "methods": ["DELETE"],
           "pathPattern": "/inventory/instances/{id}/mark-deleted",
           "permissionsRequired": [],
-          "modulePermissions": []
+          "modulePermissions": [
+            "inventory-storage.instances.item.get",
+            "inventory-storage.instances.item.put",
+            "source-storage.records.update"
+          ]
         }
       ]
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -392,7 +392,8 @@
             "inventory-storage.instance-relationships.collection.get",
             "inventory-storage.instance-relationships.item.post",
             "inventory-storage.instance-relationships.item.put",
-            "inventory-storage.instance-relationships.item.delete"
+            "inventory-storage.instance-relationships.item.delete",
+            "user-tenants.collection.get"
           ]
         },
         {
@@ -412,7 +413,8 @@
             "inventory-storage.instance-relationships.collection.get",
             "inventory-storage.instance-relationships.item.post",
             "inventory-storage.instance-relationships.item.put",
-            "inventory-storage.instance-relationships.item.delete"
+            "inventory-storage.instance-relationships.item.delete",
+            "user-tenants.collection.get"
           ]
         },
         {
@@ -456,7 +458,8 @@
             "inventory-storage.instance-relationships.collection.get",
             "inventory-storage.instance-relationships.item.post",
             "inventory-storage.instance-relationships.item.put",
-            "inventory-storage.instance-relationships.item.delete"
+            "inventory-storage.instance-relationships.item.delete",
+            "user-tenants.collection.get"
           ]
         }
       ]

--- a/src/main/java/org/folio/inventory/services/InventoryKafkaTopic.java
+++ b/src/main/java/org/folio/inventory/services/InventoryKafkaTopic.java
@@ -1,5 +1,8 @@
 package org.folio.inventory.services;
 
+import static org.folio.kafka.KafkaTopicNameHelper.formatTopicName;
+import static org.folio.kafka.services.KafkaEnvironmentProperties.environment;
+
 import org.folio.kafka.services.KafkaTopic;
 
 public class InventoryKafkaTopic implements KafkaTopic {
@@ -25,5 +28,10 @@ public class InventoryKafkaTopic implements KafkaTopic {
   @Override
   public int numPartitions() {
     return numPartitions;
+  }
+
+  @Override
+  public String fullTopicName(String tenant) {
+    return formatTopicName(environment(), tenant, topicName());
   }
 }

--- a/src/main/java/org/folio/inventory/services/InventoryKafkaTopic.java
+++ b/src/main/java/org/folio/inventory/services/InventoryKafkaTopic.java
@@ -1,0 +1,29 @@
+package org.folio.inventory.services;
+
+import org.folio.kafka.services.KafkaTopic;
+
+public class InventoryKafkaTopic implements KafkaTopic {
+
+  private final String topic;
+  private final int numPartitions;
+
+  public InventoryKafkaTopic(String topic, int numPartitions) {
+    this.topic = topic;
+    this.numPartitions = numPartitions;
+  }
+
+  @Override
+  public String moduleName() {
+    return "inventory";
+  }
+
+  @Override
+  public String topicName() {
+    return topic;
+  }
+
+  @Override
+  public int numPartitions() {
+    return numPartitions;
+  }
+}

--- a/src/main/java/org/folio/inventory/services/InventoryKafkaTopicService.java
+++ b/src/main/java/org/folio/inventory/services/InventoryKafkaTopicService.java
@@ -1,0 +1,78 @@
+package org.folio.inventory.services;
+
+import org.folio.kafka.services.KafkaTopic;
+
+public class InventoryKafkaTopicService {
+
+  public KafkaTopic[] createTopicObjects() {
+    var instanceCreatedReadyForPostProcessing = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING",
+      instanceCreatedReadyForPostProcessingNumPartitions());
+    var instanceCreated = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED", instanceCreatedNumPartitions());
+    var holdingCreated = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_CREATED", holdingCreatedNumPartitions());
+    var itemCreated = new InventoryKafkaTopic("DI_INVENTORY_ITEM_CREATED", itemCreatedNumPartitions());
+
+    var instanceMatched = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_MATCHED", instanceMatchedNumPartitions());
+    var holdingMatched = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_MATCHED", holdingMatchedNumPartitions());
+    var itemMatched = new InventoryKafkaTopic("DI_INVENTORY_ITEM_MATCHED", itemMatchedNumPartitions());
+
+    var instanceUpdated = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_UPDATED", instanceUpdatedNumPartitions());
+    var holdingUpdated = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_UPDATED", holdingUpdatedNumPartitions());
+    var itemUpdated = new InventoryKafkaTopic("DI_INVENTORY_ITEM_UPDATED", itemUpdatedNumPartitions());
+
+    var instanceNotMatched = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_NOT_MATCHED", instanceNotMatchedNumPartitions());
+
+    var authorityUpdated = new InventoryKafkaTopic("DI_INVENTORY_AUTHORITY_UPDATED", authorityUpdatedNumPartitions());
+
+    return new InventoryKafkaTopic[] {instanceCreatedReadyForPostProcessing, instanceCreated, holdingCreated,
+                                      itemCreated, instanceMatched, holdingMatched, itemMatched,
+                                      instanceUpdated, holdingUpdated, itemUpdated, instanceNotMatched, authorityUpdated};
+  }
+
+  private Integer instanceCreatedNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.instanceCreated.partitions", "1"));
+  }
+
+  private Integer holdingCreatedNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.holdingCreated.partitions", "1"));
+  }
+
+  private Integer instanceCreatedReadyForPostProcessingNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.instanceCreatedReadyForPostProcessing.partitions", "1"));
+  }
+
+  private Integer itemCreatedNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.itemCreated.partitions", "1"));
+  }
+
+  private Integer instanceMatchedNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.instanceMatched.partitions", "1"));
+  }
+
+  private Integer holdingMatchedNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.holdingMatched.partitions", "1"));
+  }
+
+  private Integer itemMatchedNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.itemMatched.partitions", "1"));
+  }
+
+  private Integer instanceUpdatedNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.instanceUpdated.partitions", "1"));
+  }
+
+  private Integer holdingUpdatedNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.holdingUpdated.partitions", "1"));
+  }
+
+  private Integer itemUpdatedNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.itemUpdated.partitions", "1"));
+  }
+
+  private Integer instanceNotMatchedNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.instanceNotMatched.partitions", "1"));
+  }
+
+  private Integer authorityUpdatedNumPartitions() {
+    return Integer.valueOf(System.getProperty("inventory.kafka.authorityUpdated.partitions", "1"));
+  }
+}

--- a/src/main/java/org/folio/inventory/services/InventoryKafkaTopicService.java
+++ b/src/main/java/org/folio/inventory/services/InventoryKafkaTopicService.java
@@ -7,8 +7,6 @@ import org.folio.kafka.services.KafkaTopic;
 public class InventoryKafkaTopicService {
 
   public KafkaTopic[] createTopicObjects() {
-    var instanceCreatedReadyForPostProcessing = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING",
-      instanceCreatedReadyForPostProcessingPartitions());
     var instanceCreated = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED", instanceCreatedPartitions());
     var holdingCreated = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_CREATED", holdingCreatedPartitions());
     var itemCreated = new InventoryKafkaTopic("DI_INVENTORY_ITEM_CREATED", itemCreatedPartitions());
@@ -22,10 +20,11 @@ public class InventoryKafkaTopicService {
     var itemUpdated = new InventoryKafkaTopic("DI_INVENTORY_ITEM_UPDATED", itemUpdatedPartitions());
 
     var instanceNotMatched = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_NOT_MATCHED", instanceNotMatchedPartitions());
-
+    var holdingNotMatched = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_NOT_MATCHED", holdingNotMatchedPartitions());
+    var itemNotMatched = new InventoryKafkaTopic("DI_INVENTORY_ITEM_NOT_MATCHED", itemNotMatchedPartitions());
     var authorityUpdated = new InventoryKafkaTopic("DI_INVENTORY_AUTHORITY_UPDATED", authorityUpdatedPartitions());
 
-    return new InventoryKafkaTopic[] {instanceCreatedReadyForPostProcessing, instanceCreated, holdingCreated,
+    return new InventoryKafkaTopic[] {instanceCreated, holdingCreated,
                                       itemCreated, instanceMatched, holdingMatched, itemMatched,
                                       instanceUpdated, holdingUpdated, itemUpdated, instanceNotMatched, authorityUpdated};
   }
@@ -36,10 +35,6 @@ public class InventoryKafkaTopicService {
 
   private Integer holdingCreatedPartitions() {
     return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_HOLDING_CREATED_PARTITIONS"), "1"));
-  }
-
-  private Integer instanceCreatedReadyForPostProcessingPartitions() {
-    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING_PARTITIONS"), "1"));
   }
 
   private Integer itemCreatedPartitions() {
@@ -72,6 +67,14 @@ public class InventoryKafkaTopicService {
 
   private Integer instanceNotMatchedPartitions() {
     return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_INSTANCE_NOT_MATCHED_PARTITIONS"), "1"));
+  }
+
+  private Integer itemNotMatchedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_HOLDING_NOT_MATCHED_PARTITIONS"), "1"));
+  }
+
+  private Integer holdingNotMatchedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_ITEM_NOT_MATCHED_PARTITIONS"), "1"));
   }
 
   private Integer authorityUpdatedPartitions() {

--- a/src/main/java/org/folio/inventory/services/InventoryKafkaTopicService.java
+++ b/src/main/java/org/folio/inventory/services/InventoryKafkaTopicService.java
@@ -1,78 +1,80 @@
 package org.folio.inventory.services;
 
+import static org.apache.commons.lang3.StringUtils.firstNonBlank;
+
 import org.folio.kafka.services.KafkaTopic;
 
 public class InventoryKafkaTopicService {
 
   public KafkaTopic[] createTopicObjects() {
     var instanceCreatedReadyForPostProcessing = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING",
-      instanceCreatedReadyForPostProcessingNumPartitions());
-    var instanceCreated = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED", instanceCreatedNumPartitions());
-    var holdingCreated = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_CREATED", holdingCreatedNumPartitions());
-    var itemCreated = new InventoryKafkaTopic("DI_INVENTORY_ITEM_CREATED", itemCreatedNumPartitions());
+      instanceCreatedReadyForPostProcessingPartitions());
+    var instanceCreated = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED", instanceCreatedPartitions());
+    var holdingCreated = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_CREATED", holdingCreatedPartitions());
+    var itemCreated = new InventoryKafkaTopic("DI_INVENTORY_ITEM_CREATED", itemCreatedPartitions());
 
-    var instanceMatched = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_MATCHED", instanceMatchedNumPartitions());
-    var holdingMatched = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_MATCHED", holdingMatchedNumPartitions());
-    var itemMatched = new InventoryKafkaTopic("DI_INVENTORY_ITEM_MATCHED", itemMatchedNumPartitions());
+    var instanceMatched = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_MATCHED", instanceMatchedPartitions());
+    var holdingMatched = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_MATCHED", holdingMatchedPartitions());
+    var itemMatched = new InventoryKafkaTopic("DI_INVENTORY_ITEM_MATCHED", itemMatchedPartitions());
 
-    var instanceUpdated = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_UPDATED", instanceUpdatedNumPartitions());
-    var holdingUpdated = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_UPDATED", holdingUpdatedNumPartitions());
-    var itemUpdated = new InventoryKafkaTopic("DI_INVENTORY_ITEM_UPDATED", itemUpdatedNumPartitions());
+    var instanceUpdated = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_UPDATED", instanceUpdatedPartitions());
+    var holdingUpdated = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_UPDATED", holdingUpdatedPartitions());
+    var itemUpdated = new InventoryKafkaTopic("DI_INVENTORY_ITEM_UPDATED", itemUpdatedPartitions());
 
-    var instanceNotMatched = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_NOT_MATCHED", instanceNotMatchedNumPartitions());
+    var instanceNotMatched = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_NOT_MATCHED", instanceNotMatchedPartitions());
 
-    var authorityUpdated = new InventoryKafkaTopic("DI_INVENTORY_AUTHORITY_UPDATED", authorityUpdatedNumPartitions());
+    var authorityUpdated = new InventoryKafkaTopic("DI_INVENTORY_AUTHORITY_UPDATED", authorityUpdatedPartitions());
 
     return new InventoryKafkaTopic[] {instanceCreatedReadyForPostProcessing, instanceCreated, holdingCreated,
                                       itemCreated, instanceMatched, holdingMatched, itemMatched,
                                       instanceUpdated, holdingUpdated, itemUpdated, instanceNotMatched, authorityUpdated};
   }
 
-  private Integer instanceCreatedNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.instanceCreated.partitions", "1"));
+  private Integer instanceCreatedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_INSTANCE_CREATED_PARTITIONS"), "1"));
   }
 
-  private Integer holdingCreatedNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.holdingCreated.partitions", "1"));
+  private Integer holdingCreatedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_HOLDING_CREATED_PARTITIONS"), "1"));
   }
 
-  private Integer instanceCreatedReadyForPostProcessingNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.instanceCreatedReadyForPostProcessing.partitions", "1"));
+  private Integer instanceCreatedReadyForPostProcessingPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING_PARTITIONS"), "1"));
   }
 
-  private Integer itemCreatedNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.itemCreated.partitions", "1"));
+  private Integer itemCreatedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_ITEM_CREATED_PARTITIONS"), "1"));
   }
 
-  private Integer instanceMatchedNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.instanceMatched.partitions", "1"));
+  private Integer instanceMatchedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_INSTANCE_MATCHED_PARTITIONS"), "1"));
   }
 
-  private Integer holdingMatchedNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.holdingMatched.partitions", "1"));
+  private Integer holdingMatchedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_HOLDING_MATCHED_PARTITIONS"), "1"));
   }
 
-  private Integer itemMatchedNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.itemMatched.partitions", "1"));
+  private Integer itemMatchedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_ITEM_MATCHED_PARTITIONS"), "1"));
   }
 
-  private Integer instanceUpdatedNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.instanceUpdated.partitions", "1"));
+  private Integer instanceUpdatedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_INSTANCE_UPDATED_PARTITIONS"), "1"));
   }
 
-  private Integer holdingUpdatedNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.holdingUpdated.partitions", "1"));
+  private Integer holdingUpdatedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_HOLDING_UPDATED_PARTITIONS"), "1"));
   }
 
-  private Integer itemUpdatedNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.itemUpdated.partitions", "1"));
+  private Integer itemUpdatedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_ITEM_UPDATED_PARTITIONS"), "1"));
   }
 
-  private Integer instanceNotMatchedNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.instanceNotMatched.partitions", "1"));
+  private Integer instanceNotMatchedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_INSTANCE_NOT_MATCHED_PARTITIONS"), "1"));
   }
 
-  private Integer authorityUpdatedNumPartitions() {
-    return Integer.valueOf(System.getProperty("inventory.kafka.authorityUpdated.partitions", "1"));
+  private Integer authorityUpdatedPartitions() {
+    return Integer.valueOf(firstNonBlank(System.getenv("DI_INVENTORY_AUTHORITY_UPDATED_PARTITIONS"), "1"));
   }
 }

--- a/src/main/java/org/folio/inventory/services/InventoryKafkaTopicService.java
+++ b/src/main/java/org/folio/inventory/services/InventoryKafkaTopicService.java
@@ -26,7 +26,8 @@ public class InventoryKafkaTopicService {
 
     return new InventoryKafkaTopic[] {instanceCreated, holdingCreated,
                                       itemCreated, instanceMatched, holdingMatched, itemMatched,
-                                      instanceUpdated, holdingUpdated, itemUpdated, instanceNotMatched, authorityUpdated};
+                                      instanceUpdated, holdingUpdated, itemUpdated, instanceNotMatched,
+                                      holdingNotMatched, itemNotMatched, authorityUpdated};
   }
 
   private Integer instanceCreatedPartitions() {

--- a/src/main/java/org/folio/inventory/services/InventoryKafkaTopicService.java
+++ b/src/main/java/org/folio/inventory/services/InventoryKafkaTopicService.java
@@ -7,27 +7,20 @@ import org.folio.kafka.services.KafkaTopic;
 public class InventoryKafkaTopicService {
 
   public KafkaTopic[] createTopicObjects() {
-    var instanceCreated = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED", instanceCreatedPartitions());
-    var holdingCreated = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_CREATED", holdingCreatedPartitions());
-    var itemCreated = new InventoryKafkaTopic("DI_INVENTORY_ITEM_CREATED", itemCreatedPartitions());
-
-    var instanceMatched = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_MATCHED", instanceMatchedPartitions());
-    var holdingMatched = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_MATCHED", holdingMatchedPartitions());
-    var itemMatched = new InventoryKafkaTopic("DI_INVENTORY_ITEM_MATCHED", itemMatchedPartitions());
-
-    var instanceUpdated = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_UPDATED", instanceUpdatedPartitions());
-    var holdingUpdated = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_UPDATED", holdingUpdatedPartitions());
-    var itemUpdated = new InventoryKafkaTopic("DI_INVENTORY_ITEM_UPDATED", itemUpdatedPartitions());
-
-    var instanceNotMatched = new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_NOT_MATCHED", instanceNotMatchedPartitions());
-    var holdingNotMatched = new InventoryKafkaTopic("DI_INVENTORY_HOLDING_NOT_MATCHED", holdingNotMatchedPartitions());
-    var itemNotMatched = new InventoryKafkaTopic("DI_INVENTORY_ITEM_NOT_MATCHED", itemNotMatchedPartitions());
-    var authorityUpdated = new InventoryKafkaTopic("DI_INVENTORY_AUTHORITY_UPDATED", authorityUpdatedPartitions());
-
-    return new InventoryKafkaTopic[] {instanceCreated, holdingCreated,
-                                      itemCreated, instanceMatched, holdingMatched, itemMatched,
-                                      instanceUpdated, holdingUpdated, itemUpdated, instanceNotMatched,
-                                      holdingNotMatched, itemNotMatched, authorityUpdated};
+    return new InventoryKafkaTopic[] {
+      new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED", instanceCreatedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_HOLDING_CREATED", holdingCreatedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_ITEM_CREATED", itemCreatedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_MATCHED", instanceMatchedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_HOLDING_MATCHED", holdingMatchedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_ITEM_MATCHED", itemMatchedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_UPDATED", instanceUpdatedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_HOLDING_UPDATED", holdingUpdatedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_NOT_MATCHED", instanceNotMatchedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_HOLDING_NOT_MATCHED", holdingNotMatchedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_ITEM_UPDATED", itemUpdatedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_ITEM_NOT_MATCHED", itemNotMatchedPartitions()),
+      new InventoryKafkaTopic("DI_INVENTORY_AUTHORITY_UPDATED", authorityUpdatedPartitions())};
   }
 
   private Integer instanceCreatedPartitions() {

--- a/src/test/java/org/folio/inventory/service/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/inventory/service/KafkaAdminClientServiceTest.java
@@ -1,0 +1,165 @@
+package org.folio.inventory.service;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.kafka.admin.KafkaAdminClient;
+import io.vertx.kafka.admin.NewTopic;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.folio.inventory.services.InventoryKafkaTopic;
+import org.folio.inventory.services.InventoryKafkaTopicService;
+import org.folio.kafka.services.KafkaAdminClientService;
+import org.folio.kafka.services.KafkaTopic;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+@RunWith(VertxUnitRunner.class)
+public class KafkaAdminClientServiceTest {
+
+  private final String STUB_TENANT = "foo-tenant";
+  private KafkaAdminClient mockClient;
+  private Vertx vertx;
+  @Mock
+  private InventoryKafkaTopicService inventoryKafkaTopicService;
+
+  @Before
+  public void setUp() {
+    vertx = mock(Vertx.class);
+    mockClient = mock(KafkaAdminClient.class);
+    inventoryKafkaTopicService = mock(InventoryKafkaTopicService.class);
+    KafkaTopic[] topicObjects = {
+      new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_HOLDING_CREATED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_ITEM_CREATED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_MATCHED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_HOLDING_MATCHED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_ITEM_MATCHED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_UPDATED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_HOLDING_UPDATED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_ITEM_UPDATED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_NOT_MATCHED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_AUTHORITY_UPDATED", 1)
+    };
+
+
+    when(inventoryKafkaTopicService.createTopicObjects()).thenReturn(topicObjects);
+  }
+
+  @Test
+  public void shouldCreateTopicIfAlreadyExist(TestContext testContext) {
+    when(mockClient.createTopics(anyList()))
+      .thenReturn(failedFuture(new TopicExistsException("x")))
+      .thenReturn(failedFuture(new TopicExistsException("y")))
+      .thenReturn(failedFuture(new TopicExistsException("z")))
+      .thenReturn(succeededFuture());
+    when(mockClient.listTopics()).thenReturn(succeededFuture(Set.of("old")));
+    when(mockClient.close()).thenReturn(succeededFuture());
+
+    createKafkaTopicsAsync(mockClient)
+      .onComplete(testContext.asyncAssertSuccess(notUsed -> {
+        verify(mockClient, times(4)).listTopics();
+        verify(mockClient, times(4)).createTopics(anyList());
+        verify(mockClient, times(1)).close();
+      }));
+  }
+
+  @Test
+  public void shouldFailIfExistExceptionIsPermanent(TestContext testContext) {
+    when(mockClient.createTopics(anyList())).thenReturn(failedFuture(new TopicExistsException("x")));
+    when(mockClient.listTopics()).thenReturn(succeededFuture(Set.of("old")));
+    when(mockClient.close()).thenReturn(succeededFuture());
+
+    createKafkaTopicsAsync(mockClient)
+      .onComplete(testContext.asyncAssertFailure(e -> {
+        assertThat(e, instanceOf(TopicExistsException.class));
+        verify(mockClient, times(1)).close();
+      }));
+  }
+
+  @Test
+  public void shouldNotCreateTopicOnOther(TestContext testContext) {
+    when(mockClient.createTopics(anyList())).thenReturn(failedFuture(new RuntimeException("err msg")));
+    when(mockClient.listTopics()).thenReturn(succeededFuture(Set.of("old")));
+    when(mockClient.close()).thenReturn(succeededFuture());
+
+    createKafkaTopicsAsync(mockClient)
+      .onComplete(testContext.asyncAssertFailure(cause -> {
+          testContext.assertEquals("err msg", cause.getMessage());
+          verify(mockClient, times(1)).close();
+        }
+      ));
+  }
+
+  @Test
+  public void shouldCreateTopicIfNotExist(TestContext testContext) {
+    when(mockClient.createTopics(anyList())).thenReturn(succeededFuture());
+    when(mockClient.listTopics()).thenReturn(succeededFuture(Set.of("old")));
+    when(mockClient.close()).thenReturn(succeededFuture());
+
+    createKafkaTopicsAsync(mockClient)
+      .onComplete(testContext.asyncAssertSuccess(notUsed -> {
+
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<List<NewTopic>> createTopicsCaptor = forClass(List.class);
+
+        verify(mockClient, times(1)).createTopics(createTopicsCaptor.capture());
+        verify(mockClient, times(1)).close();
+
+        // Only these items are expected, so implicitly checks size of list
+        assertThat(getTopicNames(createTopicsCaptor), containsInAnyOrder(allExpectedTopics.toArray()));
+      }));
+  }
+
+  private List<String> getTopicNames(ArgumentCaptor<List<NewTopic>> createTopicsCaptor) {
+    return createTopicsCaptor.getAllValues().get(0).stream()
+      .map(NewTopic::getName)
+      .collect(Collectors.toList());
+  }
+
+  private Future<Void> createKafkaTopicsAsync(KafkaAdminClient client) {
+    try (var mocked = mockStatic(KafkaAdminClient.class)) {
+      mocked.when(() -> KafkaAdminClient.create(eq(vertx), anyMap())).thenReturn(client);
+
+      return new KafkaAdminClientService(vertx)
+        .createKafkaTopics(inventoryKafkaTopicService.createTopicObjects(), STUB_TENANT);
+    }
+  }
+
+  private final Set<String> allExpectedTopics = Set.of(
+    "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING",
+      "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_CREATED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_HOLDING_CREATED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_ITEM_CREATED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_MATCHED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_HOLDING_MATCHED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_ITEM_MATCHED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_UPDATED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_HOLDING_UPDATED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_ITEM_UPDATED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_NOT_MATCHED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_AUTHORITY_UPDATED"
+  );
+}

--- a/src/test/java/org/folio/inventory/service/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/inventory/service/KafkaAdminClientServiceTest.java
@@ -150,18 +150,18 @@ public class KafkaAdminClientServiceTest {
   }
 
   private final Set<String> allExpectedTopics = Set.of(
-      "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_CREATED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_HOLDING_CREATED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_ITEM_CREATED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_MATCHED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_HOLDING_MATCHED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_ITEM_MATCHED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_UPDATED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_HOLDING_UPDATED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_ITEM_UPDATED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_NOT_MATCHED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_HOLDING_NOT_MATCHED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_ITEM_NOT_MATCHED",
-      "folio.foo-tenant.inventory.DI_INVENTORY_AUTHORITY_UPDATED"
+      "folio.foo-tenant.DI_INVENTORY_INSTANCE_CREATED",
+      "folio.foo-tenant.DI_INVENTORY_HOLDING_CREATED",
+      "folio.foo-tenant.DI_INVENTORY_ITEM_CREATED",
+      "folio.foo-tenant.DI_INVENTORY_INSTANCE_MATCHED",
+      "folio.foo-tenant.DI_INVENTORY_HOLDING_MATCHED",
+      "folio.foo-tenant.DI_INVENTORY_ITEM_MATCHED",
+      "folio.foo-tenant.DI_INVENTORY_INSTANCE_UPDATED",
+      "folio.foo-tenant.DI_INVENTORY_HOLDING_UPDATED",
+      "folio.foo-tenant.DI_INVENTORY_ITEM_UPDATED",
+      "folio.foo-tenant.DI_INVENTORY_INSTANCE_NOT_MATCHED",
+      "folio.foo-tenant.DI_INVENTORY_HOLDING_NOT_MATCHED",
+      "folio.foo-tenant.DI_INVENTORY_ITEM_NOT_MATCHED",
+      "folio.foo-tenant.DI_INVENTORY_AUTHORITY_UPDATED"
   );
 }

--- a/src/test/java/org/folio/inventory/service/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/inventory/service/KafkaAdminClientServiceTest.java
@@ -50,7 +50,6 @@ public class KafkaAdminClientServiceTest {
     mockClient = mock(KafkaAdminClient.class);
     inventoryKafkaTopicService = mock(InventoryKafkaTopicService.class);
     KafkaTopic[] topicObjects = {
-      new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING", 1),
         new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_CREATED", 1),
         new InventoryKafkaTopic("DI_INVENTORY_HOLDING_CREATED", 1),
         new InventoryKafkaTopic("DI_INVENTORY_ITEM_CREATED", 1),
@@ -61,6 +60,8 @@ public class KafkaAdminClientServiceTest {
         new InventoryKafkaTopic("DI_INVENTORY_HOLDING_UPDATED", 1),
         new InventoryKafkaTopic("DI_INVENTORY_ITEM_UPDATED", 1),
         new InventoryKafkaTopic("DI_INVENTORY_INSTANCE_NOT_MATCHED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_HOLDING_NOT_MATCHED", 1),
+        new InventoryKafkaTopic("DI_INVENTORY_ITEM_NOT_MATCHED", 1),
         new InventoryKafkaTopic("DI_INVENTORY_AUTHORITY_UPDATED", 1)
     };
 
@@ -149,7 +150,6 @@ public class KafkaAdminClientServiceTest {
   }
 
   private final Set<String> allExpectedTopics = Set.of(
-    "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING",
       "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_CREATED",
       "folio.foo-tenant.inventory.DI_INVENTORY_HOLDING_CREATED",
       "folio.foo-tenant.inventory.DI_INVENTORY_ITEM_CREATED",
@@ -160,6 +160,8 @@ public class KafkaAdminClientServiceTest {
       "folio.foo-tenant.inventory.DI_INVENTORY_HOLDING_UPDATED",
       "folio.foo-tenant.inventory.DI_INVENTORY_ITEM_UPDATED",
       "folio.foo-tenant.inventory.DI_INVENTORY_INSTANCE_NOT_MATCHED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_HOLDING_NOT_MATCHED",
+      "folio.foo-tenant.inventory.DI_INVENTORY_ITEM_NOT_MATCHED",
       "folio.foo-tenant.inventory.DI_INVENTORY_AUTHORITY_UPDATED"
   );
 }


### PR DESCRIPTION
### Purpose
Create Kafka topics instead of relying on auto create in mod-inventory [MODINV-957](https://issues.folio.org/browse/MODINV-957)

### Approach
* create topics
* cover with tests
* update readme and news