### PR TITLE
MODINV-965: Remove jsonld-java dependency fixing commons-io 2.5 CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,12 +169,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.jsonld-java</groupId>
-      <artifactId>jsonld-java</artifactId>
-      <version>0.9.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>3.0.0</version>

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -49,9 +49,6 @@ import org.folio.util.PercentCodec;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Test;
-
-import com.github.jsonldjava.core.JsonLdError;
-
 import api.support.ApiRoot;
 import api.support.ApiTests;
 import api.support.InstanceApiClient;
@@ -76,8 +73,7 @@ public class InstancesApiExamples extends ApiTests {
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
-    ExecutionException,
-    JsonLdError {
+    ExecutionException {
 
     String testNote = "this is a note";
     JsonArray adminNote = new JsonArray();
@@ -171,8 +167,7 @@ public class InstancesApiExamples extends ApiTests {
     throws InterruptedException,
     MalformedURLException,
     TimeoutException,
-    ExecutionException,
-    JsonLdError {
+    ExecutionException {
 
     String instanceId = UUID.randomUUID().toString();
     final String hrid = "in777";


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINV-965

mod-inventory master branch ships with commons-io 2.5 when looking into the generated tar file. This is caused by the jsonld-java dependency that downgrades commons-io from 2.11.0 to the vulnerable version 2.5.

commons-io 2.5 has a FilenameUtils.normalize path traversal vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2021-29425

jsonld-java is not needed because the declared jsonld-java exceptions cannot be thrown.

After the change the generated mod-inventory jar file no longer contains commons-io 2.5 but commons-io 2.11.0.