### PR TITLE
[MODINV-987] Allow to retrieve ITEM universally during HOLDINGS update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Add 999 validation for instance creation [MODDATAIMP-1001](https://folio-org.atlassian.net/browse/MODDATAIMP-1001)
 * Adjust Match event handlers to take into account multiple search results from previous match [MODINV-936](https://issues.folio.org/browse/MODINV-936)
 * SPIKE: Remove duplicated action DI_INVENTORY_INSTANCE_CREATED from Kafka event [MODINV-782](https://folio-org.atlassian.net/browse/MODINV-782)
+* Allow to retrieve ITEM universally during HOLDINGS update [MODINV-987](https://folio-org.atlassian.net/browse/MODINV-987)
 
 ## 20.1.0 2023-10-13
 * Update status when user attempts to update shared auth record from member tenant ([MODDATAIMP-926](https://issues.folio.org/browse/MODDATAIMP-926))

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -401,7 +401,7 @@ public class CreateItemEventHandler implements EventHandler {
     return promise.future();
   }
 
-  private JsonObject getItemFromJson(JsonObject itemAsJson) {
+  public static JsonObject getItemFromJson(JsonObject itemAsJson) {
     if (itemAsJson.getJsonObject(ITEM_PATH_FIELD) != null) {
       return itemAsJson.getJsonObject(ITEM_PATH_FIELD);
     }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
@@ -141,9 +141,14 @@ public class UpdateHoldingEventHandler implements EventHandler {
             updatedHoldingsRecordFutures.add(updatePromise.future());
             holdingsRecordCollection.update(holding,
               success -> {
-                LOGGER.info(format("handle:: Successfully updated holdings with id: %s", holding.getId()));
-                updatedHoldingsRecord.add(holding);
-                constructDataImportEventPayload(updatePromise, dataImportEventPayload, list, context, errors);
+                try {
+                  LOGGER.info(format("handle:: Successfully updated holdings with id: %s", holding.getId()));
+                  updatedHoldingsRecord.add(holding);
+                  constructDataImportEventPayload(updatePromise, dataImportEventPayload, list, context, errors);
+                } catch (Exception e) {
+                  LOGGER.warn("handle:: Error updating inventory Holdings by jobExecutionId: '{}'", jobExecutionId, e);
+                  future.completeExceptionally(e);
+                }
               },
               failure -> {
                 if (failure.getStatusCode() == HttpStatus.SC_CONFLICT) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
@@ -45,6 +45,7 @@ import static org.folio.ActionProfile.Action.UPDATE;
 import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
 import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_UPDATED;
+import static org.folio.inventory.dataimport.handlers.actions.CreateItemEventHandler.getItemFromJson;
 import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.constructContext;
 import static org.folio.inventory.dataimport.util.LoggerUtil.INCOMING_RECORD_ID;
 import static org.folio.inventory.dataimport.util.LoggerUtil.logParametersEventHandler;
@@ -57,7 +58,6 @@ public class UpdateHoldingEventHandler implements EventHandler {
 
   private static final Logger LOGGER = LogManager.getLogger(UpdateHoldingEventHandler.class);
 
-  private static final String UPDATE_HOLDING_ERROR_MESSAGE = "Can`t update  holding by jobExecutionId: '%s' and recordId: '%s' and chunkId: '%s'";
   private static final String CONTEXT_EMPTY_ERROR_MESSAGE = "Can`t update Holding entity: context or Holding-entity are empty or doesn`t exist!";
   private static final String EMPTY_REQUIRED_FIELDS_ERROR_MESSAGE = "Can`t update Holding entity: one of required fields(hrid, permanentLocationId, instanceId) are empty!";
   private static final String MAPPING_METADATA_NOT_FOUND_MESSAGE = "MappingMetadata snapshot was not found by jobExecutionId '%s'. Record: '%s', chunkId: '%s' ";
@@ -310,29 +310,36 @@ public class UpdateHoldingEventHandler implements EventHandler {
     }
   }
 
-  private void updateDataImportEventPayloadItem(Promise<Void> future, DataImportEventPayload dataImportEventPayload, ItemCollection itemCollection, List<PartialError> errors) {
+  private void updateDataImportEventPayloadItem(Promise<Void> promise, DataImportEventPayload dataImportEventPayload, ItemCollection itemCollection, List<PartialError> errors) {
     JsonArray oldItemsAsJson = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
     JsonArray resultedItemsList = new JsonArray();
+    List<Future> updateItemsFutures = new ArrayList<>();
 
     for (int i = 0; i < oldItemsAsJson.size(); i++) {
-      JsonObject singleItemAsJson = oldItemsAsJson.getJsonObject(i);
-      String itemId = singleItemAsJson.getJsonObject("item").getString(ITEM_ID_HEADER);
+      Promise<Void> updateItemPromise = Promise.promise();
+      updateItemsFutures.add(updateItemPromise.future());
+
+      JsonObject singleItemAsJson = getItemFromJson(oldItemsAsJson.getJsonObject(i));
+      String itemId = singleItemAsJson.getString(ITEM_ID_HEADER);
       itemCollection.findById(itemId, findResult -> {
         if (Objects.nonNull(findResult)) {
           JsonObject itemAsJson = new JsonObject(ItemUtil.mapToMappingResultRepresentation(findResult.getResult()));
           resultedItemsList.add(itemAsJson);
-          dataImportEventPayload.getContext().put(ITEM.value(), Json.encode(itemAsJson));
         }
-        future.complete();
+        updateItemPromise.complete();
       }, failure -> {
         errors.add(new PartialError(itemId != null ? itemId : BLANK, failure.getReason()));
         EventProcessingException processingException =
           new EventProcessingException(format(CANNOT_GET_ACTUAL_ITEM_MESSAGE, itemId, failure.getReason(), failure.getStatusCode()));
         LOGGER.warn("updateDataImportEventPayloadItem:: " + processingException);
-        future.complete();
+        updateItemPromise.complete();
       });
     }
-    dataImportEventPayload.getContext().put(ITEM.value(), resultedItemsList.encode());
+    CompositeFuture.all(updateItemsFutures)
+      .onComplete(ar -> {
+        dataImportEventPayload.getContext().put(ITEM.value(), resultedItemsList.encode());
+        promise.complete();
+      });
   }
 
   private Future<List<HoldingsRecord>> getActualHoldingsList(List<HoldingsRecord> holdingsRecords, HoldingsRecordCollection holdingsRecordCollection) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -57,6 +57,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.ActionProfile.Action.UPDATE;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_ITEM_UPDATED;
+import static org.folio.inventory.dataimport.handlers.actions.CreateItemEventHandler.getItemFromJson;
 import static org.folio.inventory.dataimport.util.LoggerUtil.INCOMING_RECORD_ID;
 import static org.folio.inventory.dataimport.util.LoggerUtil.logParametersEventHandler;
 import static org.folio.inventory.domain.items.Item.STATUS_KEY;
@@ -283,8 +284,7 @@ public class UpdateItemEventHandler implements EventHandler {
 
     JsonArray itemsJsonArray = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
     for (int i = 0; i < itemsJsonArray.size(); i++) {
-      JsonObject itemAsJson = itemsJsonArray.getJsonObject(i);
-      itemAsJson = itemAsJson.getJsonObject(ITEM_PATH_FIELD) != null ? itemAsJson.getJsonObject(ITEM_PATH_FIELD) : itemAsJson;
+      JsonObject itemAsJson = getItemFromJson(itemsJsonArray.getJsonObject(i));
       itemOldStatuses.put(itemAsJson.getString(ID_PATH_FIELD), itemAsJson.getJsonObject(STATUS_KEY).getString("name"));
     }
     dataImportEventPayload.getContext().put(ITEM.value(), itemsJsonArray.encode());
@@ -325,8 +325,7 @@ public class UpdateItemEventHandler implements EventHandler {
 
     JsonArray itemsJsonArray = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
     for (int i = 0; i < itemsJsonArray.size(); i++) {
-      JsonObject itemAsJson = itemsJsonArray.getJsonObject(i);
-      itemAsJson = itemAsJson.getJsonObject(ITEM_PATH_FIELD) != null ? itemAsJson.getJsonObject(ITEM_PATH_FIELD) : itemAsJson;
+      JsonObject itemAsJson = getItemFromJson(itemsJsonArray.getJsonObject(i));
       itemsJsonArray.set(i, new JsonObject().put(ITEM_PATH_FIELD, getItemAsJsonWithProperFields(itemAsJson)));
     }
     dataImportEventPayload.getContext().put(ITEM.value(), itemsJsonArray.encode());

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -834,8 +834,12 @@ public class UpdateHoldingEventHandlerTest {
 
     Assert.assertEquals(DI_INVENTORY_HOLDING_UPDATED.value(), actualDataImportEventPayload.getEventType());
     Assert.assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    Assert.assertNotNull(actualDataImportEventPayload.getContext().get(ITEM.value()));
     JsonArray resultedHoldingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
     JsonObject resultedHoldings = resultedHoldingsList.getJsonObject(0);
+    JsonArray resultedItemsList = new JsonArray(actualDataImportEventPayload.getContext().get(ITEM.value()));
+    JsonObject resultedItem = resultedItemsList.getJsonObject(0);
+    Assert.assertEquals(existingItemJson.getString("id"), resultedItem.getString("id"));
     Assert.assertNotNull(resultedHoldings.getString("id"));
     Assert.assertEquals(instanceId, resultedHoldings.getString("instanceId"));
     Assert.assertEquals(permanentLocationId, resultedHoldings.getString("permanentLocationId"));
@@ -1104,7 +1108,7 @@ public class UpdateHoldingEventHandlerTest {
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
     context.put(HOLDINGS.value(), Json.encode(holdingsList));
-    context.put(ITEM.value(), Json.encode(Lists.newArrayList(new JsonObject().put("item", existingItemJson))));
+    context.put(ITEM.value(), Json.encode(JsonArray.of(existingItemJson)));
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()


### PR DESCRIPTION
### Purpose 
Job stucks if user matches item and then updates holding
![image](https://github.com/folio-org/mod-inventory/assets/111740564/2f8d7244-f495-4c59-a7c0-92f19c7a3adf)

### Approach 
Allow to retrieve ITEM universally during HOLDINGS update