### PR TITLE
MODDATAIMP Data import profile - incoming record contains 999

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * Move Marc-Bib matching event handler to inventory [MODINV-935](https://issues.folio.org/browse/MODINV-935)
 * The duplicate record is created after updating action [MODINV-969](https://issues.folio.org/browse/MODINV-969)
 * Upgrade vertx to 4.5.4 [MODDICORE-398](https://folio-org.atlassian.net/browse/MODDICORE-398)
+* Add 999 validation for instance creation [MODDATAIMP-1001](https://folio-org.atlassian.net/browse/MODDATAIMP-1001)
 
 ## 20.1.0 2023-10-13
 * Update status when user attempts to update shared auth record from member tenant ([MODDATAIMP-926](https://issues.folio.org/browse/MODDATAIMP-926))

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
@@ -96,7 +96,6 @@ public class CreateInstanceEventHandler extends AbstractInstanceEventHandler {
 
       if (AdditionalFieldsUtil.getValue(targetRecord, TAG_999, SUBFIELD_I).isPresent()) {
         LOGGER.error(INSTANCE_CREATION_999_ERROR_MESSAGE);
-        future.completeExceptionally(new EventProcessingException(INSTANCE_CREATION_999_ERROR_MESSAGE));
         return CompletableFuture.failedFuture(new EventProcessingException(INSTANCE_CREATION_999_ERROR_MESSAGE));
       }
 

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
@@ -94,7 +94,7 @@ public class CreateInstanceEventHandler extends AbstractInstanceEventHandler {
       Context context = EventHandlingUtil.constructContext(dataImportEventPayload.getTenant(), dataImportEventPayload.getToken(), dataImportEventPayload.getOkapiUrl());
       Record targetRecord = Json.decodeValue(payloadContext.get(EntityType.MARC_BIBLIOGRAPHIC.value()), Record.class);
 
-      if (AdditionalFieldsUtil.getValue(targetRecord, TAG_999, SUBFIELD_I).isPresent()) {
+      if (!Boolean.parseBoolean(payloadContext.get("acceptInstanceId")) && AdditionalFieldsUtil.getValue(targetRecord, TAG_999, SUBFIELD_I).isPresent()) {
         LOGGER.error(INSTANCE_CREATION_999_ERROR_MESSAGE);
         return CompletableFuture.failedFuture(new EventProcessingException(INSTANCE_CREATION_999_ERROR_MESSAGE));
       }

--- a/src/main/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtil.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtil.java
@@ -292,16 +292,11 @@ public final class AdditionalFieldsUtil {
   }
 
   public static Optional<String> getValue(Record srcRecord, String tag, char subfield) {
-    try {
       return Optional.ofNullable(computeMarcRecord(srcRecord))
         .stream()
         .flatMap(marcRecord -> marcRecord.getVariableFields(tag).stream())
         .flatMap(field -> getFieldValue(field, subfield).stream())
         .findFirst();
-    } catch (Exception e) {
-      LOGGER.warn("getValue:: Failed to read a field {} from record {}", tag, srcRecord.getId(), e);
-    }
-    return Optional.empty();
   }
 
   private static Optional<String> getFieldValue(VariableField field, char subfield) {

--- a/src/main/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtil.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtil.java
@@ -62,6 +62,7 @@ public final class AdditionalFieldsUtil {
   private static final char TAG_035_IND = ' ';
   private static final String ANY_STRING = "*";
   private static final char INDICATOR = 'f';
+  public static final char SUBFIELD_I = 'i';
   private static final String HR_ID_FIELD = "hrid";
   private static final CacheLoader<String, org.marc4j.marc.Record> parsedRecordContentCacheLoader;
   private static final LoadingCache<String, org.marc4j.marc.Record> parsedRecordContentCache;
@@ -288,6 +289,29 @@ public final class AdditionalFieldsUtil {
       return null;
     }
     return null;
+  }
+
+  public static Optional<String> getValue(Record srcRecord, String tag, char subfield) {
+    try {
+      return Optional.ofNullable(computeMarcRecord(srcRecord))
+        .stream()
+        .flatMap(marcRecord -> marcRecord.getVariableFields(tag).stream())
+        .flatMap(field -> getFieldValue(field, subfield).stream())
+        .findFirst();
+    } catch (Exception e) {
+      LOGGER.warn("getValue:: Failed to read a field {} from record {}", tag, srcRecord.getId(), e);
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> getFieldValue(VariableField field, char subfield) {
+    if (field instanceof DataField dataField) {
+      return dataField.getSubfields(subfield).stream().findFirst().map(Subfield::getData);
+    } else if (field instanceof ControlField controlField) {
+      return Optional.ofNullable(controlField.getData());
+    } else {
+      return Optional.empty();
+    }
   }
 
   private static MarcReader buildMarcReader(Record srcRecord) {

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
@@ -105,9 +105,10 @@ import static org.mockito.Mockito.when;
 
 public class CreateInstanceEventHandlerTest {
 
-  private static final String PARSED_CONTENT = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"003\":\"in001\"},{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"titleValue\"}]}},{\"336\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"b\":\"b6698d38-149f-11ec-82a8-0242ac130003\"}]}},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}} , {\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } }]}";
+  private static final String PARSED_CONTENT = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"003\":\"in001\"},{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"titleValue\"}]}},{\"336\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"b\":\"b6698d38-149f-11ec-82a8-0242ac130003\"}]}},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}}]}";
   private static final String PARSED_CONTENT_999ffi = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"titleValue\"}]}},{\"336\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"b\":\"b6698d38-149f-11ec-82a8-0242ac130003\"}]}},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}}]}";
-  private static final String PARSED_CONTENT_WITH_005 = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"005\":\"20141107001016.0\"},{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"titleValue\"}]}},{\"336\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"b\":\"b6698d38-149f-11ec-82a8-0242ac130003\"}]}},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}} , {\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } }]}";
+  private static final String PARSED_CONTENT_WITH_005 = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"005\":\"20141107001016.0\"},{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"titleValue\"}]}},{\"336\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"b\":\"b6698d38-149f-11ec-82a8-0242ac130003\"}]}},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}}]}";
+  private static final String PARSED_CONTENT_WITH_999fi = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } }]}";
   private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/bib-rules.json";
   private static final String MAPPING_METADATA_URL = "/mapping-metadata";
   private static final String TENANT_ID = "diku";
@@ -573,6 +574,33 @@ public class CreateInstanceEventHandlerTest {
 
     CompletableFuture<DataImportEventPayload> future = createInstanceEventHandler.handle(dataImportEventPayload);
     future.get(5, TimeUnit.MILLISECONDS);
+  }
+
+  @Test(expected = Exception.class)
+  public void shouldNotProcessEventIfRecordContains999field() throws InterruptedException, ExecutionException, TimeoutException {
+    var recordId = UUID.randomUUID().toString();
+
+
+    HttpResponse<Buffer> resp = buildHttpResponseWithBuffer(BufferImpl.buffer("{}"));
+    when(sourceStorageClient.postSourceStorageRecords(any())).thenReturn(Future.succeededFuture(resp));
+
+    var context = new HashMap<String, String>();
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_999fi));
+    record.setId(recordId);
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_INSTANCE_CREATED.value())
+      .withContext(context)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0))
+      .withTenant(TENANT_ID)
+      .withOkapiUrl(mockServer.baseUrl())
+      .withToken(TOKEN)
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withOkapiUrl(mockServer.baseUrl());
+
+    CompletableFuture<DataImportEventPayload> future = createInstanceEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload actualDataImportEventPayload = future.get(20, TimeUnit.SECONDS);
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
@@ -108,7 +108,7 @@ public class CreateInstanceEventHandlerTest {
   private static final String PARSED_CONTENT = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"003\":\"in001\"},{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"titleValue\"}]}},{\"336\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"b\":\"b6698d38-149f-11ec-82a8-0242ac130003\"}]}},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}}]}";
   private static final String PARSED_CONTENT_999ffi = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"titleValue\"}]}},{\"336\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"b\":\"b6698d38-149f-11ec-82a8-0242ac130003\"}]}},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}}]}";
   private static final String PARSED_CONTENT_WITH_005 = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"005\":\"20141107001016.0\"},{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"titleValue\"}]}},{\"336\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"b\":\"b6698d38-149f-11ec-82a8-0242ac130003\"}]}},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}}]}";
-  private static final String PARSED_CONTENT_WITH_999fi = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } }]}";
+  private static final String PARSED_CONTENT_WITH_999fi = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"003\":\"in001\"},{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"titleValue\"}]}},{\"336\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"b\":\"b6698d38-149f-11ec-82a8-0242ac130003\"}]}},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}} , {\"999\": {\"ind1\":\"f\", \"ind2\":\"f\", \"subfields\":[ { \"i\": \"957985c6-97e3-4038-b0e7-343ecd0b8120\"} ] } }]}";
   private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/bib-rules.json";
   private static final String MAPPING_METADATA_URL = "/mapping-metadata";
   private static final String TENANT_ID = "diku";
@@ -207,7 +207,16 @@ public class CreateInstanceEventHandlerTest {
   }
 
   @Test
-  public void shouldProcessEvent() throws InterruptedException, ExecutionException, TimeoutException {
+  public void shouldProcessEventWithout999() throws InterruptedException, ExecutionException, TimeoutException {
+    shouldProcessEvent(PARSED_CONTENT, Boolean.FALSE.toString());
+  }
+
+  @Test
+  public void shouldProcessEventWith999AndAcceptedInstanceId() throws InterruptedException, ExecutionException, TimeoutException {
+    shouldProcessEvent(PARSED_CONTENT_WITH_999fi, Boolean.TRUE.toString());
+  }
+
+  public void shouldProcessEvent(String content, String acceptInstanceId) throws InterruptedException, ExecutionException, TimeoutException {
     Reader fakeReader = Mockito.mock(Reader.class);
 
     String instanceTypeId = "fe19bae4-da28-472b-be90-d442e2428ead";
@@ -228,10 +237,11 @@ public class CreateInstanceEventHandlerTest {
     MappingManager.registerWriterFactory(new InstanceWriterFactory());
 
     HashMap<String, String> context = new HashMap<>();
-    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT));
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(content));
     record.setId(recordId);
 
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+    context.put("acceptInstanceId", acceptInstanceId);
 
     Buffer buffer = BufferImpl.buffer("{\"parsedRecord\":{" +
       "\"id\":\"990fad8b-64ec-4de4-978c-9f8bbed4c6d3\"," +
@@ -580,16 +590,15 @@ public class CreateInstanceEventHandlerTest {
   public void shouldNotProcessEventIfRecordContains999field() throws InterruptedException, ExecutionException, TimeoutException {
     var recordId = UUID.randomUUID().toString();
 
-
     HttpResponse<Buffer> resp = buildHttpResponseWithBuffer(BufferImpl.buffer("{}"));
     when(sourceStorageClient.postSourceStorageRecords(any())).thenReturn(Future.succeededFuture(resp));
 
     var context = new HashMap<String, String>();
-    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_999fi));
+    var record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_999fi));
     record.setId(recordId);
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
-    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+    var dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INVENTORY_INSTANCE_CREATED.value())
       .withContext(context)
       .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0))
@@ -599,8 +608,8 @@ public class CreateInstanceEventHandlerTest {
       .withJobExecutionId(UUID.randomUUID().toString())
       .withOkapiUrl(mockServer.baseUrl());
 
-    CompletableFuture<DataImportEventPayload> future = createInstanceEventHandler.handle(dataImportEventPayload);
-    DataImportEventPayload actualDataImportEventPayload = future.get(20, TimeUnit.SECONDS);
+    var future = createInstanceEventHandler.handle(dataImportEventPayload);
+    future.get(20, TimeUnit.SECONDS);
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtilTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtilTest.java
@@ -412,6 +412,7 @@ public class AdditionalFieldsUtilTest {
 
   @Test
   public void shouldReturnFields() {
+    // given
     var id = UUID.randomUUID().toString();
     var hrId = "in001";
     var parsedContent = """
@@ -428,16 +429,14 @@ public class AdditionalFieldsUtilTest {
           ]
       }
       """.formatted(hrId, id);
-    Record record = new Record().withId(UUID.randomUUID().toString())
-      .withParsedRecord(new ParsedRecord().withContent(parsedContent))
-      .withGeneration(0)
-      .withState(Record.State.ACTUAL)
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId("001").withInstanceHrid("in001"));
+    var record = new Record().withParsedRecord(new ParsedRecord().withContent(parsedContent));
 
+    // when
     var parsedHrId = AdditionalFieldsUtil.getValue(record, TAG_001, ' ');
     var parsedId = AdditionalFieldsUtil.getValue(record, TAG_999, 'i');
     var missingField = AdditionalFieldsUtil.getValue(record, TAG_005, ' ');
 
+    // then
     assertTrue(parsedHrId.isPresent());
     assertTrue(parsedId.isPresent());
     assertTrue(missingField.isEmpty());

--- a/src/test/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtilTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtilTest.java
@@ -436,9 +436,12 @@ public class AdditionalFieldsUtilTest {
 
     var parsedHrId = AdditionalFieldsUtil.getValue(record, TAG_001, ' ');
     var parsedId = AdditionalFieldsUtil.getValue(record, TAG_999, 'i');
+    var missingField = AdditionalFieldsUtil.getValue(record, TAG_005, ' ');
 
     assertTrue(parsedHrId.isPresent());
     assertTrue(parsedId.isPresent());
+    assertTrue(missingField.isEmpty());
+
     assertEquals(hrId, parsedHrId.get());
     assertEquals(id, parsedId.get());
   }

--- a/src/test/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtilTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtilTest.java
@@ -27,18 +27,9 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
-import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.addDataFieldToMarcRecord;
-import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.addControlledFieldToMarcRecord;
-import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.addFieldToMarcRecord;
-import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.dateTime005Formatter;
-import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.isFieldExist;
-import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.getCacheStats;
-import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.getValueFromControlledField;
-import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.TAG_005;
-import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.removeField;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.*;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 @RunWith(BlockJUnit4ClassRunner.class)
 public class AdditionalFieldsUtilTest {
@@ -417,6 +408,39 @@ public class AdditionalFieldsUtilTest {
     String actualDate = AdditionalFieldsUtil.getValueFromControlledField(record, TAG_005);
     assertNotNull(actualDate);
     assertEquals(expectedDate.substring(0, 10), actualDate.substring(0, 10));
+  }
+
+  @Test
+  public void shouldReturnFields() {
+    var id = UUID.randomUUID().toString();
+    var hrId = "in001";
+    var parsedContent = """
+      {
+          "fields": [
+              {"001": "%s"},
+              {"999": {
+                  "ind1": "f",
+                  "ind2": "f",
+                  "subfields": [
+                      {"i": "%s"}
+                  ]
+              }}
+          ]
+      }
+      """.formatted(hrId, id);
+    Record record = new Record().withId(UUID.randomUUID().toString())
+      .withParsedRecord(new ParsedRecord().withContent(parsedContent))
+      .withGeneration(0)
+      .withState(Record.State.ACTUAL)
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId("001").withInstanceHrid("in001"));
+
+    var parsedHrId = AdditionalFieldsUtil.getValue(record, TAG_001, ' ');
+    var parsedId = AdditionalFieldsUtil.getValue(record, TAG_999, 'i');
+
+    assertTrue(parsedHrId.isPresent());
+    assertTrue(parsedId.isPresent());
+    assertEquals(hrId, parsedHrId.get());
+    assertEquals(id, parsedId.get());
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Fix a validation error when trying to import a .mrc-file with a record that has 999ff fields with this Job Profile: 
1) Modify Action Profile to remove 999 field
2) Create Instance Action Profile .

## Approach
Add 999fi validation to CreateinstanceEventHandler

## Learning
[MODDATAIMP-1001](https://folio-org.atlassian.net/browse/MODDATAIMP-1001)