### PR TITLE
MODINV-782 SPIKE: Remove duplicated action DI_INVENTORY_INSTANCE_CREATED from Kafka event

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Upgrade vertx to 4.5.4 [MODDICORE-398](https://folio-org.atlassian.net/browse/MODDICORE-398)
 * Add 999 validation for instance creation [MODDATAIMP-1001](https://folio-org.atlassian.net/browse/MODDATAIMP-1001)
 * Adjust Match event handlers to take into account multiple search results from previous match [MODINV-936](https://issues.folio.org/browse/MODINV-936)
+* SPIKE: Remove duplicated action DI_INVENTORY_INSTANCE_CREATED from Kafka event [MODINV-782](https://folio-org.atlassian.net/browse/MODINV-782)
 
 ## 20.1.0 2023-10-13
 * Update status when user attempts to update shared auth record from member tenant ([MODDATAIMP-926](https://issues.folio.org/browse/MODDATAIMP-926))

--- a/src/main/java/org/folio/inventory/dataimport/services/OrderHelperServiceImpl.java
+++ b/src/main/java/org/folio/inventory/dataimport/services/OrderHelperServiceImpl.java
@@ -64,7 +64,10 @@ public class OrderHelperServiceImpl implements OrderHelperService {
       .collect(Collectors.toList());
 
     if (!actionProfiles.isEmpty() && checkIfOrderActionProfileExists(actionProfiles) && checkIfCurrentProfileIsTheLastOne(eventPayload, actionProfiles)) {
-      eventPayload.getEventsChain().add(targetEventType.value());
+      if (!eventPayload.getEventsChain().contains(targetEventType.value())) {
+        eventPayload.getEventsChain().add(targetEventType.value());
+      }
+
       eventPayload.getContext().put(POST_PROCESSING_INDICATOR, Boolean.TRUE.toString());
       eventPayload.setEventType(DI_ORDER_CREATED_READY_FOR_POST_PROCESSING.value());
     }


### PR DESCRIPTION
### Purpose
SPIKE: Remove duplicated action DI_INVENTORY_INSTANCE_CREATED from Kafka event [MODINV-782](https://folio-org.atlassian.net/browse/MODINV-782)

### Approach
add if condition in OrderHelperServiceImpl