### PR TITLE
MODINV-997: keep 00X field's position when Creating/Deriving MARC records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
 * Add subscription on DI_SRS_MARC_BIB_RECORD_UPDATED event about marc-bib update [MODSOURMAN-1106](https://folio-org.atlassian.net/browse/MODSOURMAN-1106)
 * Consortial: Local HRID gets added as 035 when instance is shared [MODINV-918](https://folio-org.atlassian.net/browse/MODINV-918)
 * Consortial: non-MARC data not saved when local source = MARC instance is promoted [MODINV-960](https://folio-org.atlassian.net/browse/MODINV-960)
+* Keep order of MARC fields while Creating/Deriving/Editing MARC records [MODSOURMAN-1137](https://folio-org.atlassian.net/browse/MODSOURMAN-1137)
 
 ## 20.1.0 2023-10-13
 * Update status when user attempts to update shared auth record from member tenant ([MODDATAIMP-926](https://issues.folio.org/browse/MODDATAIMP-926))

--- a/src/main/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtil.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtil.java
@@ -717,7 +717,7 @@ public final class AdditionalFieldsUtil {
       var fieldsNode = sourceJson.get(FIELDS);
 
       for (JsonNode fieldNode : fieldsNode) {
-        var tag = fieldNode.fieldNames().next();
+        var tag = getTagFromNode(fieldNode);
         if (tag.equals(TAG_001)) {
           sourceFields.add(0, tag);
           has001 = true;

--- a/src/test/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtilTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtilTest.java
@@ -3,6 +3,7 @@ package org.folio.inventory.dataimport.util;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.inventory.TestUtil;
@@ -17,7 +18,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
+import org.marc4j.MarcException;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -35,6 +38,9 @@ import static org.junit.Assert.*;
 public class AdditionalFieldsUtilTest {
 
   private static final String PARSED_MARC_RECORD_PATH = "src/test/resources/marc/parsedMarcRecord.json";
+  private static final String PARSED_RECORD = "src/test/resources/marc/parsedRecord.json";
+  private static final String REORDERED_PARSED_RECORD = "src/test/resources/marc/reorderedParsedRecord.json";
+  private static final String REORDERING_RESULT_RECORD = "src/test/resources/marc/reorderingResultRecord.json";
 
   @Test
   public void shouldAddInstanceIdSubfield() throws IOException {
@@ -632,5 +638,25 @@ public class AdditionalFieldsUtilTest {
     AdditionalFieldsUtil.remove035FieldWhenRecordContainsHrId(record);
     // then
     Assert.assertEquals(expectedParsedContent, parsedRecord.getContent());
+  }
+
+  @Test
+  public void shouldReorderMarcRecordFields() throws IOException, MarcException {
+    var reorderedRecordContent = readFileFromPath(PARSED_RECORD);
+    var sourceRecordContent = readFileFromPath(REORDERED_PARSED_RECORD);
+    var reorderingResultRecord = readFileFromPath(REORDERING_RESULT_RECORD);
+
+    var resultContent = AdditionalFieldsUtil.reorderMarcRecordFields(sourceRecordContent, reorderedRecordContent);
+
+    assertNotNull(resultContent);
+    assertEquals(formatContent(resultContent), formatContent(reorderingResultRecord));
+  }
+
+  private static String readFileFromPath(String path) throws IOException {
+    return new String(FileUtils.readFileToByteArray(new File(path)));
+  }
+
+  private String formatContent(String content) {
+    return content.replaceAll("\\s", "");
   }
 }

--- a/src/test/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtilTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtilTest.java
@@ -30,7 +30,17 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
-import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.*;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.TAG_001;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.TAG_005;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.TAG_999;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.addControlledFieldToMarcRecord;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.addDataFieldToMarcRecord;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.addFieldToMarcRecord;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.dateTime005Formatter;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.getCacheStats;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.getValueFromControlledField;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.isFieldExist;
+import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.removeField;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.*;
 
@@ -53,8 +63,8 @@ public class AdditionalFieldsUtilTest {
     String leader = new JsonObject(parsedRecordContent).getString("leader");
     Record record = new Record().withId(recordId).withParsedRecord(parsedRecord);
     // when
-    boolean addedSourceRecordId = AdditionalFieldsUtil.addFieldToMarcRecord(record, AdditionalFieldsUtil.TAG_999, 's', recordId);
-    boolean addedInstanceId = AdditionalFieldsUtil.addFieldToMarcRecord(record, AdditionalFieldsUtil.TAG_999, 'i', instanceId);
+    boolean addedSourceRecordId = addFieldToMarcRecord(record, TAG_999, 's', recordId);
+    boolean addedInstanceId = addFieldToMarcRecord(record, TAG_999, 'i', instanceId);
     // then
     Assert.assertTrue(addedSourceRecordId);
     Assert.assertTrue(addedInstanceId);
@@ -66,8 +76,8 @@ public class AdditionalFieldsUtilTest {
     int totalFieldsCount = 0;
     for (int i = fields.size(); i-- > 0; ) {
       JsonObject targetField = fields.getJsonObject(i);
-      if (targetField.containsKey(AdditionalFieldsUtil.TAG_999)) {
-        JsonArray subfields = targetField.getJsonObject(AdditionalFieldsUtil.TAG_999).getJsonArray("subfields");
+      if (targetField.containsKey(TAG_999)) {
+        JsonArray subfields = targetField.getJsonObject(TAG_999).getJsonArray("subfields");
         for (int j = subfields.size(); j-- > 0; ) {
           JsonObject targetSubfield = subfields.getJsonObject(j);
           if (targetSubfield.containsKey("i")) {
@@ -91,7 +101,7 @@ public class AdditionalFieldsUtilTest {
     Record record = new Record();
     String instanceId = UUID.randomUUID().toString();
     // when
-    boolean added = AdditionalFieldsUtil.addFieldToMarcRecord(record, AdditionalFieldsUtil.TAG_999, 'i', instanceId);
+    boolean added = addFieldToMarcRecord(record, TAG_999, 'i', instanceId);
     // then
     Assert.assertFalse(added);
     Assert.assertNull(record.getParsedRecord());
@@ -105,7 +115,7 @@ public class AdditionalFieldsUtilTest {
     record.setParsedRecord(new ParsedRecord().withContent(content));
     String instanceId = UUID.randomUUID().toString();
     // when
-    boolean added = AdditionalFieldsUtil.addFieldToMarcRecord(record, AdditionalFieldsUtil.TAG_999, 'i', instanceId);
+    boolean added = addFieldToMarcRecord(record, TAG_999, 'i', instanceId);
     // then
     Assert.assertFalse(added);
     Assert.assertNotNull(record.getParsedRecord());
@@ -121,7 +131,7 @@ public class AdditionalFieldsUtilTest {
     record.setParsedRecord(new ParsedRecord().withContent(content));
     String instanceId = UUID.randomUUID().toString();
     // when
-    boolean added = AdditionalFieldsUtil.addFieldToMarcRecord(record, AdditionalFieldsUtil.TAG_999, 'i', instanceId);
+    boolean added = addFieldToMarcRecord(record, TAG_999, 'i', instanceId);
     // then
     Assert.assertFalse(added);
     Assert.assertNotNull(record.getParsedRecord());
@@ -137,7 +147,7 @@ public class AdditionalFieldsUtilTest {
     record.setParsedRecord(new ParsedRecord().withContent(content));
     String instanceId = UUID.randomUUID().toString();
     // when
-    boolean added = AdditionalFieldsUtil.addFieldToMarcRecord(record, AdditionalFieldsUtil.TAG_999, 'i', instanceId);
+    boolean added = addFieldToMarcRecord(record, TAG_999, 'i', instanceId);
     // then
     Assert.assertFalse(added);
     Assert.assertNotNull(record.getParsedRecord());
@@ -151,7 +161,7 @@ public class AdditionalFieldsUtilTest {
     record.setParsedRecord(new ParsedRecord().withContent(null));
     String instanceId = UUID.randomUUID().toString();
     // when
-    boolean added = AdditionalFieldsUtil.addFieldToMarcRecord(record, AdditionalFieldsUtil.TAG_999, 'i', instanceId);
+    boolean added = addFieldToMarcRecord(record, TAG_999, 'i', instanceId);
     // then
     Assert.assertFalse(added);
     Assert.assertNotNull(record.getParsedRecord());
@@ -166,7 +176,7 @@ public class AdditionalFieldsUtilTest {
     String leader = new JsonObject(parsedRecordContent).getString("leader");
     parsedRecord.setContent(parsedRecordContent);
     Record record = new Record().withId(recordId).withParsedRecord(parsedRecord);
-    boolean deleted = AdditionalFieldsUtil.removeField(record, "001");
+    boolean deleted = removeField(record, "001");
     Assert.assertTrue(deleted);
     JsonObject content = new JsonObject(parsedRecord.getContent().toString());
     JsonArray fields = content.getJsonArray("fields");
@@ -184,7 +194,7 @@ public class AdditionalFieldsUtilTest {
     String parsedRecordContent = TestUtil.readFileFromPath(PARSED_MARC_RECORD_PATH);
     ParsedRecord parsedRecord = new ParsedRecord().withContent(parsedRecordContent);
     Record record = new Record().withId(recordId).withParsedRecord(parsedRecord);
-    boolean added = AdditionalFieldsUtil.addControlledFieldToMarcRecord(record, "002", "", null);
+    boolean added = addControlledFieldToMarcRecord(record, "002", "", null);
     Assert.assertFalse(added);
   }
 
@@ -195,7 +205,7 @@ public class AdditionalFieldsUtilTest {
     ParsedRecord parsedRecord = new ParsedRecord().withContent(parsedRecordContent);
     String leader = new JsonObject(parsedRecordContent).getString("leader");
     Record record = new Record().withId(recordId).withParsedRecord(parsedRecord);
-    boolean added = AdditionalFieldsUtil.addControlledFieldToMarcRecord(
+    boolean added = addControlledFieldToMarcRecord(
       record, "002", "test", AdditionalFieldsUtil::addControlledFieldToMarcRecord);
     Assert.assertTrue(added);
     JsonObject content = new JsonObject(parsedRecord.getContent().toString());
@@ -215,7 +225,7 @@ public class AdditionalFieldsUtilTest {
     ParsedRecord parsedRecord = new ParsedRecord().withContent(parsedRecordContent);
     String leader = new JsonObject(parsedRecordContent).getString("leader");
     Record record = new Record().withId(recordId).withParsedRecord(parsedRecord);
-    boolean added = AdditionalFieldsUtil.addControlledFieldToMarcRecord(
+    boolean added = addControlledFieldToMarcRecord(
       record, "003", "test", AdditionalFieldsUtil::replaceOrAddControlledFieldInMarcRecord);
     Assert.assertTrue(added);
     JsonObject content = new JsonObject(parsedRecord.getContent().toString());
@@ -254,7 +264,7 @@ public class AdditionalFieldsUtilTest {
     String leader = new JsonObject(parsedRecordContent).getString("leader");
     Record record = new Record().withId(UUID.randomUUID().toString()).withParsedRecord(parsedRecord);
     // when
-    boolean added = AdditionalFieldsUtil.addDataFieldToMarcRecord(record, "035", ' ', ' ', 'a', instanceHrId);
+    boolean added = addDataFieldToMarcRecord(record, "035", ' ', ' ', 'a', instanceHrId);
     // then
     Assert.assertTrue(added);
     JsonObject content = new JsonObject(parsedRecord.getContent().toString());
@@ -284,7 +294,7 @@ public class AdditionalFieldsUtilTest {
     ParsedRecord parsedRecord = new ParsedRecord().withContent(parsedContent);
     Record record = new Record().withId(UUID.randomUUID().toString()).withParsedRecord(parsedRecord);
     // when
-    boolean added = AdditionalFieldsUtil.addDataFieldToMarcRecord(record, "999", 'f', 'f', 'i', instanceId);
+    boolean added = addDataFieldToMarcRecord(record, "999", 'f', 'f', 'i', instanceId);
     // then
     Assert.assertTrue(added);
     Assert.assertEquals(expectedParsedContent, parsedRecord.getContent());
@@ -393,7 +403,7 @@ public class AdditionalFieldsUtilTest {
     AdditionalFieldsUtil.updateLatestTransactionDate(record,
       new MappingParameters().withMarcFieldProtectionSettings(List.of(new MarcFieldProtectionSetting().withField("*").withData("*"))));
 
-    String actualDate = AdditionalFieldsUtil.getValueFromControlledField(record, TAG_005);
+    String actualDate = getValueFromControlledField(record, TAG_005);
     assertNotNull(actualDate);
     assertEquals("20141107001016.0", actualDate);
   }
@@ -411,7 +421,7 @@ public class AdditionalFieldsUtilTest {
 
     AdditionalFieldsUtil.updateLatestTransactionDate(record, new MappingParameters());
 
-    String actualDate = AdditionalFieldsUtil.getValueFromControlledField(record, TAG_005);
+    String actualDate = getValueFromControlledField(record, TAG_005);
     assertNotNull(actualDate);
     assertEquals(expectedDate.substring(0, 10), actualDate.substring(0, 10));
   }
@@ -545,7 +555,7 @@ public class AdditionalFieldsUtilTest {
     Assert.assertEquals(2, cacheStats.missCount());
     Assert.assertEquals(2, cacheStats.loadCount());
     // add field to marc record
-    Assert.assertTrue(addFieldToMarcRecord(record, AdditionalFieldsUtil.TAG_999, 'i', instanceId));
+    Assert.assertTrue(addFieldToMarcRecord(record, TAG_999, 'i', instanceId));
     cacheStats = getCacheStats().minus(initialCacheStats);
     Assert.assertEquals(9, cacheStats.requestCount());
     Assert.assertEquals(7, cacheStats.hitCount());

--- a/src/test/resources/marc/parsedRecord.json
+++ b/src/test/resources/marc/parsedRecord.json
@@ -1,0 +1,335 @@
+{
+  "leader":"01314nam  22003851a 4500",
+  "fields":[
+    {
+      "001":"ybp7406411"
+    },
+    {
+      "005":"20120404100627.6"
+    },
+    {
+      "003":"NhCcYBP"
+    },
+    {
+      "006":"m||||||||d|||||||"
+    },
+    {
+      "007":"cr||n|||||||||"
+    },
+    {
+      "008":"120329s2011    sz a    ob    001 0 eng d"
+    },
+    {
+      "020":{
+        "subfields":[
+          {
+            "a":"2940447241 (electronic bk.)"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "020":{
+        "subfields":[
+          {
+            "a":"9782940447244 (electronic bk.)"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "040":{
+        "subfields":[
+          {
+            "a":"NhCcYBP"
+          },
+          {
+            "c":"NhCcYBP"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "050":{
+        "subfields":[
+          {
+            "a":"Z246"
+          },
+          {
+            "b":".A43 2011"
+          }
+        ],
+        "ind1":" ",
+        "ind2":"4"
+      }
+    },
+    {
+      "082":{
+        "subfields":[
+          {
+            "a":"686.22"
+          },
+          {
+            "2":"22"
+          }
+        ],
+        "ind1":"0",
+        "ind2":"4"
+      }
+    },
+    {
+      "100":{
+        "subfields":[
+          {
+            "a":"Ambrose, Gavin."
+          }
+        ],
+        "ind1":"1",
+        "ind2":" "
+      }
+    },
+    {
+      "245":{
+        "subfields":[
+          {
+            "a":"The fundamentals of typography"
+          },
+          {
+            "h":"[electronic resource] /"
+          },
+          {
+            "c":"Gavin Ambrose, Paul Harris."
+          }
+        ],
+        "ind1":"1",
+        "ind2":"4"
+      }
+    },
+    {
+      "250":{
+        "subfields":[
+          {
+            "a":"2nd ed."
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "260":{
+        "subfields":[
+          {
+            "a":"Lausanne ;"
+          },
+          {
+            "a":"Worthing :"
+          },
+          {
+            "b":"AVA Academia,"
+          },
+          {
+            "c":"2011."
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "300":{
+        "subfields":[
+          {
+            "a":"1 online resource."
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "490":{
+        "subfields":[
+          {
+            "a":"AVA Academia series"
+          }
+        ],
+        "ind1":"1",
+        "ind2":" "
+      }
+    },
+    {
+      "500":{
+        "subfields":[
+          {
+            "a":"Previous ed.: 2006."
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "504":{
+        "subfields":[
+          {
+            "a":"Includes bibliographical references (p. [200]) and index."
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "505":{
+        "subfields":[
+          {
+            "a":"Type and language -- A few basics -- Letterforms -- Words and paragraphs -- Using type."
+          }
+        ],
+        "ind1":"0",
+        "ind2":" "
+      }
+    },
+    {
+      "650":{
+        "subfields":[
+          {
+            "a":"Graphic design (Typography)"
+          }
+        ],
+        "ind1":" ",
+        "ind2":"0"
+      }
+    },
+    {
+      "650":{
+        "subfields":[
+          {
+            "a":"Printing."
+          }
+        ],
+        "ind1":" ",
+        "ind2":"0"
+      }
+    },
+    {
+      "700":{
+        "subfields":[
+          {
+            "a":"Harris, Paul,"
+          },
+          {
+            "d":"1971-"
+          }
+        ],
+        "ind1":"1",
+        "ind2":" "
+      }
+    },
+    {
+      "710":{
+        "subfields":[
+          {
+            "a":"EBSCOhost"
+          }
+        ],
+        "ind1":"2",
+        "ind2":" "
+      }
+    },
+    {
+      "776":{
+        "subfields":[
+          {
+            "c":"Original"
+          },
+          {
+            "z":"9782940411764"
+          },
+          {
+            "z":"294041176X"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "830":{
+        "subfields":[
+          {
+            "a":"AVA academia."
+          }
+        ],
+        "ind1":" ",
+        "ind2":"0"
+      }
+    },
+    {
+      "856":{
+        "subfields":[
+          {
+            "u":"http://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=430135"
+          }
+        ],
+        "ind1":"4",
+        "ind2":"0"
+      }
+    },
+    {
+      "935":{
+        "subfields":[
+          {
+            "a":".o13465259"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "980":{
+        "subfields":[
+          {
+            "a":"130307"
+          },
+          {
+            "b":"7107"
+          },
+          {
+            "e":"7107"
+          },
+          {
+            "f":"243965"
+          },
+          {
+            "g":"1"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "981":{
+        "subfields":[
+          {
+            "b":"OM"
+          },
+          {
+            "c":"nlnet"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    }
+  ]
+}

--- a/src/test/resources/marc/reorderedParsedRecord.json
+++ b/src/test/resources/marc/reorderedParsedRecord.json
@@ -1,0 +1,335 @@
+{
+  "leader":"01314nam  22003851a 4500",
+  "fields":[
+    {
+      "040":{
+        "subfields":[
+          {
+            "a":"NhCcYBP"
+          },
+          {
+            "c":"NhCcYBP"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "001":"ybp7406411"
+    },
+    {
+      "003":"NhCcYBP"
+    },
+    {
+      "006":"m||||||||d|||||||"
+    },
+    {
+      "007":"cr||n|||||||||"
+    },
+    {
+      "008":"120329s2011    sz a    ob    001 0 eng d"
+    },
+    {
+      "020":{
+        "subfields":[
+          {
+            "a":"2940447241 (electronic bk.)"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "020":{
+        "subfields":[
+          {
+            "a":"9782940447244 (electronic bk.)"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "050":{
+        "subfields":[
+          {
+            "a":"Z246"
+          },
+          {
+            "b":".A43 2011"
+          }
+        ],
+        "ind1":" ",
+        "ind2":"4"
+      }
+    },
+    {
+      "082":{
+        "subfields":[
+          {
+            "a":"686.22"
+          },
+          {
+            "2":"22"
+          }
+        ],
+        "ind1":"0",
+        "ind2":"4"
+      }
+    },
+    {
+      "100":{
+        "subfields":[
+          {
+            "a":"Ambrose, Gavin."
+          }
+        ],
+        "ind1":"1",
+        "ind2":" "
+      }
+    },
+    {
+      "245":{
+        "subfields":[
+          {
+            "a":"The fundamentals of typography"
+          },
+          {
+            "h":"[electronic resource] /"
+          },
+          {
+            "c":"Gavin Ambrose, Paul Harris."
+          }
+        ],
+        "ind1":"1",
+        "ind2":"4"
+      }
+    },
+    {
+      "250":{
+        "subfields":[
+          {
+            "a":"2nd ed."
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "260":{
+        "subfields":[
+          {
+            "a":"Lausanne ;"
+          },
+          {
+            "a":"Worthing :"
+          },
+          {
+            "b":"AVA Academia,"
+          },
+          {
+            "c":"2011."
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "300":{
+        "subfields":[
+          {
+            "a":"1 online resource."
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "490":{
+        "subfields":[
+          {
+            "a":"AVA Academia series"
+          }
+        ],
+        "ind1":"1",
+        "ind2":" "
+      }
+    },
+    {
+      "500":{
+        "subfields":[
+          {
+            "a":"Previous ed.: 2006."
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "504":{
+        "subfields":[
+          {
+            "a":"Includes bibliographical references (p. [200]) and index."
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "505":{
+        "subfields":[
+          {
+            "a":"Type and language -- A few basics -- Letterforms -- Words and paragraphs -- Using type."
+          }
+        ],
+        "ind1":"0",
+        "ind2":" "
+      }
+    },
+    {
+      "650":{
+        "subfields":[
+          {
+            "a":"Graphic design (Typography)"
+          }
+        ],
+        "ind1":" ",
+        "ind2":"0"
+      }
+    },
+    {
+      "650":{
+        "subfields":[
+          {
+            "a":"Printing."
+          }
+        ],
+        "ind1":" ",
+        "ind2":"0"
+      }
+    },
+    {
+      "700":{
+        "subfields":[
+          {
+            "a":"Harris, Paul,"
+          },
+          {
+            "d":"1971-"
+          }
+        ],
+        "ind1":"1",
+        "ind2":" "
+      }
+    },
+    {
+      "710":{
+        "subfields":[
+          {
+            "a":"EBSCOhost"
+          }
+        ],
+        "ind1":"2",
+        "ind2":" "
+      }
+    },
+    {
+      "776":{
+        "subfields":[
+          {
+            "c":"Original"
+          },
+          {
+            "z":"9782940411764"
+          },
+          {
+            "z":"294041176X"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "830":{
+        "subfields":[
+          {
+            "a":"AVA academia."
+          }
+        ],
+        "ind1":" ",
+        "ind2":"0"
+      }
+    },
+    {
+      "856":{
+        "subfields":[
+          {
+            "u":"http://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=430135"
+          }
+        ],
+        "ind1":"4",
+        "ind2":"0"
+      }
+    },
+    {
+      "935":{
+        "subfields":[
+          {
+            "a":".o13465259"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "980":{
+        "subfields":[
+          {
+            "a":"130307"
+          },
+          {
+            "b":"7107"
+          },
+          {
+            "e":"7107"
+          },
+          {
+            "f":"243965"
+          },
+          {
+            "g":"1"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "981":{
+        "subfields":[
+          {
+            "b":"OM"
+          },
+          {
+            "c":"nlnet"
+          }
+        ],
+        "ind1":" ",
+        "ind2":" "
+      }
+    },
+    {
+      "005":"20120404100627.6"
+    }
+  ]
+}

--- a/src/test/resources/marc/reorderingResultRecord.json
+++ b/src/test/resources/marc/reorderingResultRecord.json
@@ -1,0 +1,335 @@
+{
+  "leader": "01314nam  22003851a 4500",
+  "fields": [
+    {
+      "001": "ybp7406411"
+    },
+    {
+      "005": "20120404100627.6"
+    },
+    {
+      "040": {
+        "subfields": [
+          {
+            "a": "NhCcYBP"
+          },
+          {
+            "c": "NhCcYBP"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "003": "NhCcYBP"
+    },
+    {
+      "006": "m||||||||d|||||||"
+    },
+    {
+      "007": "cr||n|||||||||"
+    },
+    {
+      "008": "120329s2011    sz a    ob    001 0 eng d"
+    },
+    {
+      "020": {
+        "subfields": [
+          {
+            "a": "2940447241 (electronic bk.)"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "020": {
+        "subfields": [
+          {
+            "a": "9782940447244 (electronic bk.)"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "050": {
+        "subfields": [
+          {
+            "a": "Z246"
+          },
+          {
+            "b": ".A43 2011"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "4"
+      }
+    },
+    {
+      "082": {
+        "subfields": [
+          {
+            "a": "686.22"
+          },
+          {
+            "2": "22"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "100": {
+        "subfields": [
+          {
+            "a": "Ambrose, Gavin."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "245": {
+        "subfields": [
+          {
+            "a": "The fundamentals of typography"
+          },
+          {
+            "h": "[electronic resource] /"
+          },
+          {
+            "c": "Gavin Ambrose, Paul Harris."
+          }
+        ],
+        "ind1": "1",
+        "ind2": "4"
+      }
+    },
+    {
+      "250": {
+        "subfields": [
+          {
+            "a": "2nd ed."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "260": {
+        "subfields": [
+          {
+            "a": "Lausanne ;"
+          },
+          {
+            "a": "Worthing :"
+          },
+          {
+            "b": "AVA Academia,"
+          },
+          {
+            "c": "2011."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "300": {
+        "subfields": [
+          {
+            "a": "1 online resource."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "490": {
+        "subfields": [
+          {
+            "a": "AVA Academia series"
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "500": {
+        "subfields": [
+          {
+            "a": "Previous ed.: 2006."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "504": {
+        "subfields": [
+          {
+            "a": "Includes bibliographical references (p. [200]) and index."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "505": {
+        "subfields": [
+          {
+            "a": "Type and language -- A few basics -- Letterforms -- Words and paragraphs -- Using type."
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "650": {
+        "subfields": [
+          {
+            "a": "Graphic design (Typography)"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "0"
+      }
+    },
+    {
+      "650": {
+        "subfields": [
+          {
+            "a": "Printing."
+          }
+        ],
+        "ind1": " ",
+        "ind2": "0"
+      }
+    },
+    {
+      "700": {
+        "subfields": [
+          {
+            "a": "Harris, Paul,"
+          },
+          {
+            "d": "1971-"
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "710": {
+        "subfields": [
+          {
+            "a": "EBSCOhost"
+          }
+        ],
+        "ind1": "2",
+        "ind2": " "
+      }
+    },
+    {
+      "776": {
+        "subfields": [
+          {
+            "c": "Original"
+          },
+          {
+            "z": "9782940411764"
+          },
+          {
+            "z": "294041176X"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "830": {
+        "subfields": [
+          {
+            "a": "AVA academia."
+          }
+        ],
+        "ind1": " ",
+        "ind2": "0"
+      }
+    },
+    {
+      "856": {
+        "subfields": [
+          {
+            "u": "http://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=430135"
+          }
+        ],
+        "ind1": "4",
+        "ind2": "0"
+      }
+    },
+    {
+      "935": {
+        "subfields": [
+          {
+            "a": ".o13465259"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "980": {
+        "subfields": [
+          {
+            "a": "130307"
+          },
+          {
+            "b": "7107"
+          },
+          {
+            "e": "7107"
+          },
+          {
+            "f": "243965"
+          },
+          {
+            "g": "1"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "981": {
+        "subfields": [
+          {
+            "b": "OM"
+          },
+          {
+            "c": "nlnet"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Purpose
Keep 00X field's position when Creating/Deriving/Editing MARC records

Approach
Implemented reorderMarcRecordFields method to keep the right order of MARC records

Checklist
- [x] I have updated NEWS.md.
- [x] I have added javadocs to new methods.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation e.g. README.md.
- [ ] I have ran karate tests against this feature. 

Closes: MODSOURMAN-1137