### PR TITLE
MODINV-1001 The sorting for Items on Instance details page is not worked

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 20.3.0-SNAPSHOT 2024-xx-xx
+* The sorting for Items on Instance details page is not worked [MODINV-1001](https://folio-org.atlassian.net/browse/MODINV-1001)
 * "PMSystem" displayed as source in "quickmarc" view when record was created by "Non-matches" action of job profile [MODSOURCE-608](https://folio-org.atlassian.net/browse/MODSOURCE-608)
 * The result table is not displayed in the file details log [MODINV-1003](https://folio-org.atlassian.net/browse/MODINV-1003)
 

--- a/src/main/java/org/folio/inventory/resources/ItemsByHoldingsRecordId.java
+++ b/src/main/java/org/folio/inventory/resources/ItemsByHoldingsRecordId.java
@@ -29,7 +29,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -95,7 +94,7 @@ public class ItemsByHoldingsRecordId extends Items {
         webContext, routingContext))
       .thenCompose(listOfItems -> maybeAppendSingleTitleItems(listOfItems, holdingsRecordId,
         webContext, routingContext))
-      .thenAccept(combinedListOfItems -> sortAndRespond(combinedListOfItems,
+      .thenAccept(combinedListOfItems -> respondWithPagedManyItems(combinedListOfItems,
         webContext, routingContext));
   }
 
@@ -177,12 +176,9 @@ public class ItemsByHoldingsRecordId extends Items {
     return futureListOfItems;
   }
 
-  private void sortAndRespond(List<Item> itemList, WebContext webContext, RoutingContext routingContext) {
+  private void respondWithPagedManyItems(List<Item> itemList, WebContext webContext, RoutingContext routingContext) {
     PagingParameters pagingParameters = getPagingParameters(webContext);
-    List<Item> sortedList = itemList.stream().sorted(
-      Comparator.comparing(i -> i.getBarcode() == null ? "~" : i.getBarcode()))
-      .toList();
-    MultipleRecords<Item> items = new MultipleRecords<>(getPage(sortedList,
+    MultipleRecords<Item> items = new MultipleRecords<>(getPage(itemList,
       pagingParameters.offset, pagingParameters.limit), itemList.size());
     respondWithManyItems(routingContext, webContext, items);
   }


### PR DESCRIPTION
### Purpose
The sorting for Items on Instance details page is not worked [MODINV-1001](https://folio-org.atlassian.net/browse/MODINV-1001)

### Approach
remove sort by barcode logic