### PR TITLE
MODINV-1006 Avoid null values in the ElectronicAccess object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * "PMSystem" displayed as source in "quickmarc" view when record was created by "Non-matches" action of job profile [MODSOURCE-608](https://folio-org.atlassian.net/browse/MODSOURCE-608)
 * The result table is not displayed in the file details log [MODINV-1003](https://folio-org.atlassian.net/browse/MODINV-1003)
 * Invalid values (as it is) created in JSON when value is not matching accepted options provided in Instance field mapping for Nature of Content term [MODINV-1012](https://folio-org.atlassian.net/browse/MODINV-1012)
+* Remove null values from electronicAccess object before returning item [MODINV-1006](https://folio-org.atlassian.net/browse/MODINV-1006)
 
 ## 20.2.0 2023-03-20
 * Inventory cannot process Holdings with virtual fields ([MODINV-941](https://issues.folio.org/browse/MODINV-941))

--- a/src/main/java/org/folio/inventory/resources/ItemRepresentation.java
+++ b/src/main/java/org/folio/inventory/resources/ItemRepresentation.java
@@ -294,7 +294,7 @@ class ItemRepresentation {
     }
   }
 
-  private List toNotNullList(Collection<?> collection) {
+  private List<Iterable<?>> toNotNullList(Collection<?> collection) {
     return collection.stream()
       .map(item -> {
         if (item instanceof Collection<?>) {

--- a/src/main/java/org/folio/inventory/resources/ItemRepresentation.java
+++ b/src/main/java/org/folio/inventory/resources/ItemRepresentation.java
@@ -9,7 +9,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import liquibase.util.StringUtil;
 import org.folio.inventory.common.domain.MultipleRecords;
 import org.folio.inventory.domain.items.Item;
 import org.folio.inventory.domain.items.Status;
@@ -130,7 +132,7 @@ class ItemRepresentation {
     includeIfPresent(representation, Item.ITEM_IDENTIFIER_KEY, item.getItemIdentifier());
     includeIfPresent(representation,Item.TAGS_KEY, new JsonObject().put(Item.TAG_LIST_KEY, new JsonArray(item.getTags())));
     representation.put(Item.YEAR_CAPTION_KEY, item.getYearCaption());
-    representation.put(Item.ELECTRONIC_ACCESS_KEY, item.getElectronicAccess());
+    putNotNull(representation, Item.ELECTRONIC_ACCESS_KEY, item.getElectronicAccess());
     representation.put(Item.STATISTICAL_CODE_IDS_KEY, item.getStatisticalCodeIds());
     representation.put(Item.PURCHASE_ORDER_LINE_IDENTIFIER, item.getPurchaseOrderLineIdentifier());
     includeReferenceIfPresent(representation, "materialType",
@@ -244,7 +246,7 @@ class ItemRepresentation {
     String propertyName,
     JsonArray propertyValue) {
     if (propertyValue != null) {
-      representation.put( propertyName, propertyValue );
+      representation.put(propertyName, propertyValue);
     }
   }
 
@@ -257,9 +259,53 @@ class ItemRepresentation {
     if (from != null) {
       String value = propertyValue.apply(from);
 
-      if(value != null) {
+      if (value != null) {
         representation.put(propertyName, value);
       }
     }
   }
+
+  private JsonObject handleNullNestedFields(JsonObject itemObject) {
+    var keysToRemove = new ArrayList<String>();
+    for (var key : itemObject.fieldNames()) {
+      var value = itemObject.getValue(key);
+      if (value == null) {
+        keysToRemove.add(key);
+      } else if (value instanceof String && StringUtil.isEmpty((String) value)) {
+        keysToRemove.add(key);
+      } else if (value instanceof JsonObject) {
+        handleNullNestedFields((JsonObject) value);
+      }
+    }
+
+    keysToRemove.forEach(itemObject::remove);
+    return itemObject;
+  }
+
+  private void putNotNull(JsonObject representation, String field, Object obj) {
+    if (obj != null) {
+      if (obj instanceof Collection<?>) {
+        representation.put(field, new JsonArray(toNotNullList((Collection<?>) obj)));
+      } else {
+        JsonObject json = JsonObject.mapFrom(obj);
+        handleNullNestedFields(json);
+        representation.put(field, json);
+      }
+    }
+  }
+
+  private List toNotNullList(Collection<?> collection) {
+    return collection.stream()
+      .map(item -> {
+        if (item instanceof Collection<?>) {
+          return toNotNullList((Collection<?>) item);
+        } else {
+          var jsonItem = JsonObject.mapFrom(item);
+          handleNullNestedFields(jsonItem);
+          return jsonItem;
+        }
+      })
+      .collect(Collectors.toList());
+  }
+
 }

--- a/src/main/java/org/folio/inventory/resources/ItemRepresentation.java
+++ b/src/main/java/org/folio/inventory/resources/ItemRepresentation.java
@@ -9,7 +9,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import liquibase.util.StringUtil;
 import org.folio.inventory.common.domain.MultipleRecords;
@@ -296,6 +295,7 @@ class ItemRepresentation {
 
   private List<Iterable<?>> toNotNullList(Collection<?> collection) {
     return collection.stream()
+      .filter(item -> item != null)
       .map(item -> {
         if (item instanceof Collection<?>) {
           return toNotNullList((Collection<?>) item);
@@ -307,5 +307,4 @@ class ItemRepresentation {
       })
       .toList();
   }
-
 }

--- a/src/main/java/org/folio/inventory/resources/ItemRepresentation.java
+++ b/src/main/java/org/folio/inventory/resources/ItemRepresentation.java
@@ -132,7 +132,7 @@ class ItemRepresentation {
     includeIfPresent(representation, Item.ITEM_IDENTIFIER_KEY, item.getItemIdentifier());
     includeIfPresent(representation,Item.TAGS_KEY, new JsonObject().put(Item.TAG_LIST_KEY, new JsonArray(item.getTags())));
     representation.put(Item.YEAR_CAPTION_KEY, item.getYearCaption());
-    putNotNull(representation, Item.ELECTRONIC_ACCESS_KEY, item.getElectronicAccess());
+    putNotNullValues(representation, Item.ELECTRONIC_ACCESS_KEY, item.getElectronicAccess());
     representation.put(Item.STATISTICAL_CODE_IDS_KEY, item.getStatisticalCodeIds());
     representation.put(Item.PURCHASE_ORDER_LINE_IDENTIFIER, item.getPurchaseOrderLineIdentifier());
     includeReferenceIfPresent(representation, "materialType",
@@ -282,7 +282,7 @@ class ItemRepresentation {
     return itemObject;
   }
 
-  private void putNotNull(JsonObject representation, String field, Object obj) {
+  private void putNotNullValues(JsonObject representation, String field, Object obj) {
     if (obj != null) {
       if (obj instanceof Collection<?>) {
         representation.put(field, new JsonArray(toNotNullList((Collection<?>) obj)));
@@ -305,7 +305,7 @@ class ItemRepresentation {
           return jsonItem;
         }
       })
-      .collect(Collectors.toList());
+      .toList();
   }
 
 }

--- a/src/main/java/org/folio/inventory/support/JsonHelper.java
+++ b/src/main/java/org/folio/inventory/support/JsonHelper.java
@@ -11,6 +11,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -90,7 +91,7 @@ public class JsonHelper {
 
   private static List<Iterable<?>> toNotNullList(Collection<?> collection) {
     return collection.stream()
-      .filter(item -> item != null)
+      .filter(Objects::nonNull)
       .map(item -> {
         if (item instanceof Collection<?>) {
           return toNotNullList((Collection<?>) item);

--- a/src/main/java/org/folio/inventory/support/JsonHelper.java
+++ b/src/main/java/org/folio/inventory/support/JsonHelper.java
@@ -47,6 +47,13 @@ public class JsonHelper {
     return new JsonObject(readFile(is));
   }
 
+  /**
+   * Update JsonObject representation with the given property name and only not null values.
+   *
+   * @param representation The JsonObject representation to update.
+   * @param propertyName   The name of the property to set.
+   * @param obj            The value to set the property with.
+   */
   public static void putNotNullValues(JsonObject representation, String propertyName, Object obj) {
     if (obj != null && isNotBlank(propertyName)) {
       if (obj instanceof Collection<?>) {

--- a/src/test/java/org/folio/inventory/resources/ItemRepresentationTest.java
+++ b/src/test/java/org/folio/inventory/resources/ItemRepresentationTest.java
@@ -1,17 +1,18 @@
 package org.folio.inventory.resources;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
-import java.util.UUID;
-
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.folio.inventory.domain.items.Item;
 import org.folio.inventory.domain.items.ItemStatusName;
 import org.folio.inventory.domain.items.Status;
+import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
 import org.junit.Test;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class ItemRepresentationTest {
   @Test
@@ -22,5 +23,20 @@ public class ItemRepresentationTest {
     JsonObject json = new ItemRepresentation()
         .toJson(item, null, instance, null, null, null, null, null, null);
     assertThat(json.getString("_version"), is("123"));
+  }
+
+  @Test
+  public void jsonWithoutNullElectronicAccessValues() {
+    var testValue = "https://test.com";
+    var item = new Item(UUID.randomUUID().toString(), null, null,
+      new Status(ItemStatusName.AVAILABLE), null, null, null);
+    var electronicAccess = new ElectronicAccess(testValue, null, null, null, null);
+    item.withElectronicAccess(List.of(electronicAccess));
+    var json = new ItemRepresentation()
+      .toJson(item, null, new JsonObject().put("contributors", new JsonArray()), null, null, null, null, null, null);
+    var electronicAccessObject = json.getJsonArray("electronicAccess");
+    assertThat(electronicAccessObject.size(), is(1));
+    assertThat(electronicAccessObject.getJsonObject(0).fieldNames().size(), is(1));
+    assertThat(electronicAccessObject.getJsonObject(0).getValue("uri"), is(testValue));
   }
 }

--- a/src/test/java/org/folio/inventory/resources/ItemRepresentationTest.java
+++ b/src/test/java/org/folio/inventory/resources/ItemRepresentationTest.java
@@ -8,6 +8,7 @@ import org.folio.inventory.domain.items.Status;
 import org.folio.inventory.domain.sharedproperties.ElectronicAccess;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -37,7 +38,9 @@ public class ItemRepresentationTest {
       .toJson(item, null, new JsonObject().put("contributors", new JsonArray()), null, null, null, null, null, null);
     var electronicAccessObject = json.getJsonArray(electronicAccessKey);
 
-    item.withElectronicAccess(List.of());
+    var nullableList = new ArrayList<ElectronicAccess>();
+    nullableList.add(null);
+    item.withElectronicAccess(nullableList);
     var nullElectronicAccessJson = new ItemRepresentation()
       .toJson(item, null, new JsonObject().put("contributors", new JsonArray()), null, null, null, null, null, null);
     var emptyElectronicAccessObject = nullElectronicAccessJson.getJsonArray(electronicAccessKey);

--- a/src/test/java/org/folio/inventory/resources/ItemRepresentationTest.java
+++ b/src/test/java/org/folio/inventory/resources/ItemRepresentationTest.java
@@ -26,11 +26,11 @@ public class ItemRepresentationTest {
   }
 
   @Test
-  public void jsonWithoutNullElectronicAccessValues() {
+  public void jsonWithoutNullOrEmptyValues() {
     var testValue = "https://test.com";
     var item = new Item(UUID.randomUUID().toString(), null, null,
       new Status(ItemStatusName.AVAILABLE), null, null, null);
-    var electronicAccess = new ElectronicAccess(testValue, null, null, null, null);
+    var electronicAccess = new ElectronicAccess(testValue, "", null, null, null);
     item.withElectronicAccess(List.of(electronicAccess));
     var json = new ItemRepresentation()
       .toJson(item, null, new JsonObject().put("contributors", new JsonArray()), null, null, null, null, null, null);

--- a/src/test/java/org/folio/inventory/resources/ItemRepresentationTest.java
+++ b/src/test/java/org/folio/inventory/resources/ItemRepresentationTest.java
@@ -28,15 +28,23 @@ public class ItemRepresentationTest {
   @Test
   public void jsonWithoutNullOrEmptyValues() {
     var testValue = "https://test.com";
+    var electronicAccessKey = "electronicAccess";
     var item = new Item(UUID.randomUUID().toString(), null, null,
       new Status(ItemStatusName.AVAILABLE), null, null, null);
     var electronicAccess = new ElectronicAccess(testValue, "", null, null, null);
     item.withElectronicAccess(List.of(electronicAccess));
     var json = new ItemRepresentation()
       .toJson(item, null, new JsonObject().put("contributors", new JsonArray()), null, null, null, null, null, null);
-    var electronicAccessObject = json.getJsonArray("electronicAccess");
+    var electronicAccessObject = json.getJsonArray(electronicAccessKey);
+
+    item.withElectronicAccess(List.of());
+    var nullElectronicAccessJson = new ItemRepresentation()
+      .toJson(item, null, new JsonObject().put("contributors", new JsonArray()), null, null, null, null, null, null);
+    var emptyElectronicAccessObject = nullElectronicAccessJson.getJsonArray(electronicAccessKey);
+
     assertThat(electronicAccessObject.size(), is(1));
     assertThat(electronicAccessObject.getJsonObject(0).fieldNames().size(), is(1));
     assertThat(electronicAccessObject.getJsonObject(0).getValue("uri"), is(testValue));
+    assertThat(emptyElectronicAccessObject, is(new JsonArray()));
   }
 }

--- a/src/test/java/org/folio/inventory/support/JsonHelperTest.java
+++ b/src/test/java/org/folio/inventory/support/JsonHelperTest.java
@@ -13,7 +13,9 @@ import static org.folio.inventory.support.JsonHelper.putNotNullValues;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JsonHelperTest {

--- a/src/test/java/org/folio/inventory/support/JsonHelperTest.java
+++ b/src/test/java/org/folio/inventory/support/JsonHelperTest.java
@@ -1,16 +1,19 @@
 package org.folio.inventory.support;
 
-import static org.folio.inventory.support.JsonHelper.includeIfPresent;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-
 import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+
+import static org.folio.inventory.support.JsonHelper.includeIfPresent;
+import static org.folio.inventory.support.JsonHelper.putNotNullValues;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JsonHelperTest {
@@ -42,5 +45,31 @@ public class JsonHelperTest {
   public void shouldNotIncludeIfValueIsNull() {
     includeIfPresent(representation, "key", null);
     verifyZeroInteractions(representation);
+  }
+
+  @Test
+  public void shouldNotIncludeNullOeEmptyValues() {
+    var nutNullString = "notNull";
+    var key = "key";
+    var rootKey = "root";
+    var arrayKey = "array";
+    var value = new JsonObject();
+    var nestedValue = new JsonObject();
+    var list = new ArrayList<JsonObject>();
+
+    nestedValue.put(nutNullString, nutNullString);
+    nestedValue.put("null", null);
+    nestedValue.put("empty", "");
+    value.put(key, nestedValue);
+    list.add(nestedValue);
+    list.add(null);
+    putNotNullValues(representation, rootKey, value);
+    putNotNullValues(representation, arrayKey, list);
+
+    var objResult = representation.getJsonObject(rootKey).getJsonObject(key);
+    var listResult = representation.getJsonArray(arrayKey);
+    assertThat(objResult.size(), is(1));
+    assertThat(objResult.getValue(nutNullString), is(nutNullString));
+    assertThat(listResult.size(), is(1));
   }
 }


### PR DESCRIPTION
## Purpose
Do not send nulls when the values are empty in electronicAccess field

## Approach
Find null values inside electronicAccess object, and remove them

## Learning
[MODINV-1006](https://folio-org.atlassian.net/browse/MODINV-1006)