### PR TITLE
[MODINV-1051] Disallow updating holdings ownership with related boundwith

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@
 * Requires `holdings-storage 2.0 3.0 4.0 5.0 6.0 7.0`
 * InstanceIngress create events consumption [MODINV-986](https://folio-org.atlassian.net/browse/MODINV-986)
 * Additional Requirements - Update Data Import logic to normalize OCLC 035 values [MODINV-1044](https://folio-org.atlassian.net/browse/MODINV-1044)
+* Implement endpoint to update ownership of Holdings [MODINV-1031](https://folio-org.atlassian.net/browse/MODINV-1031)
+* Handle assignment of ids during update ownership of holdings [MODINV-1053](https://folio-org.atlassian.net/browse/MODINV-1053)
+* Implement endpoint for updating ownership of Items [MODINV-955](https://folio-org.atlassian.net/browse/MODINV-955)
+* Disallow updating holdings ownership with related boundwith [MODINV-1051](https://folio-org.atlassian.net/browse/MODINV-1051)
 
 ## 20.2.0 2023-03-20
 * Inventory cannot process Holdings with virtual fields ([MODINV-941](https://issues.folio.org/browse/MODINV-941))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -564,7 +564,8 @@
             "inventory-storage.items.item.post",
             "inventory-storage.items.item.delete",
             "inventory-storage.items.collection.get",
-            "inventory-storage.instances.item.get"
+            "inventory-storage.instances.item.get",
+            "inventory-storage.bound-with-parts.collection.get"
           ]
         }
       ]

--- a/src/main/java/org/folio/inventory/support/MoveApiUtil.java
+++ b/src/main/java/org/folio/inventory/support/MoveApiUtil.java
@@ -25,6 +25,8 @@ import static org.folio.inventory.support.http.server.JsonResponse.success;
 public final class MoveApiUtil {
   public static final String HOLDINGS_STORAGE = "/holdings-storage/holdings";
   public static final String HOLDINGS_RECORDS_PROPERTY = "holdingsRecords";
+  public static final String BOUND_WITH_PARTS_STORAGE = "/inventory-storage/bound-with-parts";
+  public static final String BOUND_WITH_PARTS_RECORDS_PROPERTY = "boundWithParts";
   public static final String TARGET_TENANT_ID = "targetTenantId";
   public static final String ITEM_STORAGE = "/item-storage/items";
   public static final String ITEMS_PROPERTY = "items";
@@ -59,6 +61,11 @@ public final class MoveApiUtil {
     return createStorageClient(client, context, HOLDINGS_STORAGE);
   }
 
+  public static CollectionResourceClient createBoundWithPartsStorageClient(OkapiHttpClient client, WebContext context)
+    throws MalformedURLException {
+    return createStorageClient(client, context, BOUND_WITH_PARTS_STORAGE);
+  }
+
   public static CollectionResourceClient createItemStorageClient(OkapiHttpClient client, WebContext context)
     throws MalformedURLException {
     return createStorageClient(client, context, ITEM_STORAGE);
@@ -66,6 +73,10 @@ public final class MoveApiUtil {
 
   public static MultipleRecordsFetchClient createHoldingsRecordsFetchClient(CollectionResourceClient client) {
     return createFetchClient(client, HOLDINGS_RECORDS_PROPERTY);
+  }
+
+  public static MultipleRecordsFetchClient createBoundWithPartsFetchClient(CollectionResourceClient client) {
+    return createFetchClient(client, BOUND_WITH_PARTS_RECORDS_PROPERTY);
   }
 
   public static MultipleRecordsFetchClient createItemsFetchClient(CollectionResourceClient client) {

--- a/src/test/java/api/BoundWithTests.java
+++ b/src/test/java/api/BoundWithTests.java
@@ -5,7 +5,6 @@ import api.support.InstanceSamples;
 import api.support.builders.HoldingRequestBuilder;
 import api.support.builders.ItemRequestBuilder;
 
-import api.support.http.ResourceClient;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.folio.inventory.support.http.client.IndividualResource;

--- a/src/test/java/api/BoundWithTests.java
+++ b/src/test/java/api/BoundWithTests.java
@@ -25,17 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.fail;
 
-public class BoundWithTests extends ApiTests
-{
-  protected final ResourceClient boundWithPartsStorageClient;
-  protected final ResourceClient boundWithItemsClient;
-
-  public BoundWithTests () {
-    super();
-    boundWithPartsStorageClient = ResourceClient.forBoundWithPartsStorage(okapiClient);
-    boundWithItemsClient = ResourceClient.forBoundWithItems( okapiClient );
-  }
-
+public class BoundWithTests extends ApiTests {
   @Test
   public void boundWithFlagsArePresentOnInstancesAndItemsAsExpected() throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException
   {
@@ -401,7 +391,7 @@ public class BoundWithTests extends ApiTests
 
   }
 
-  private JsonObject makeObjectBoundWithPart (String itemId, String holdingsRecordId) {
+  public static JsonObject makeObjectBoundWithPart (String itemId, String holdingsRecordId) {
     JsonObject boundWithPart = new JsonObject();
     boundWithPart.put("itemId", itemId);
     boundWithPart.put("holdingsRecordId", holdingsRecordId);

--- a/src/test/java/api/support/ApiTests.java
+++ b/src/test/java/api/support/ApiTests.java
@@ -38,7 +38,7 @@ public abstract class ApiTests {
   protected final ResourceClient consortiumHoldingsStorageClient;
   protected final ResourceClient collegeItemsClient;
   protected final ResourceClient collegeHoldingsStorageClient;
-
+  protected final ResourceClient boundWithPartsStorageClient;
   protected final InstanceRelationshipTypeFixture instanceRelationshipTypeFixture;
   protected final MarkItemFixture markItemFixture;
 
@@ -57,6 +57,7 @@ public abstract class ApiTests {
     instanceRelationshipClient = ResourceClient.forInstanceRelationship(okapiClient);
     requestStorageClient = ResourceClient.forRequestStorage(okapiClient);
     sourceRecordStorageClient = ResourceClient.forSourceRecordStorage(okapiClient);
+    boundWithPartsStorageClient = ResourceClient.forBoundWithPartsStorage(okapiClient);
     instanceRelationshipTypeFixture = new InstanceRelationshipTypeFixture(okapiClient);
     markItemFixture = new MarkItemFixture(okapiClient);
 


### PR DESCRIPTION
### Purpose
Disallow updating holdings ownership with related boundwith

### Approach
Check for boundWiths relations with incoming holdingsRecordIds, send error message for such holdings
Jira: https://folio-org.atlassian.net/browse/MODINV-1051