### PR TITLE
MODINV-1055: Fix Consumer Subscription for MARC Bib Update events

### DIFF
--- a/src/main/java/org/folio/inventory/MarcBibUpdateConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/MarcBibUpdateConsumerVerticle.java
@@ -21,7 +21,7 @@ public class MarcBibUpdateConsumerVerticle extends KafkaConsumerVerticle {
     var marcBibUpdateKafkaHandler = new MarcBibUpdateKafkaHandler(vertx, getMaxDistributionNumber(BASE_PROPERTY),
       getKafkaConfig(), instanceUpdateDelegate, getMappingMetadataCache());
 
-    var marcBibUpdateConsumerWrapper = createConsumer(SRS_MARC_BIB_EVENT, BASE_PROPERTY);
+    var marcBibUpdateConsumerWrapper = createConsumer(SRS_MARC_BIB_EVENT, BASE_PROPERTY, false);
 
     marcBibUpdateConsumerWrapper.start(marcBibUpdateKafkaHandler, constructModuleName())
       .onFailure(startPromise::fail)


### PR DESCRIPTION
### **Purpose:**  
Events for MARC Bib update are not handled by MARC Bib Update Handler (_MarcBibUpdateConsumerVerticle_)

### **Approach:**
Do not use default namespace for the consumer subscription


Closes: [MODINV-1055](https://folio-org.atlassian.net/browse/MODINV-1055)
Related: [MODINV-986](https://folio-org.atlassian.net/browse/MODINV-986)