### PR TITLE
MODINV-1056: Additional test fixing for di-core MODDICORE-405.

### DIFF
--- a/src/test/java/org/folio/inventory/dataimport/consumers/DataImportConsumerVerticleTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/consumers/DataImportConsumerVerticleTest.java
@@ -135,9 +135,10 @@ public class DataImportConsumerVerticleTest {
       .kafkaHost(hostAndPort[0])
       .kafkaPort(hostAndPort[1])
       .build();
-    EventManager.registerKafkaEventPublisher(kafkaConfig, vertx, 1);
 
     vertx = Vertx.vertx();
+    EventManager.registerKafkaEventPublisher(kafkaConfig, vertx, 1);
+
     DeploymentOptions options = new DeploymentOptions()
       .setConfig(new JsonObject()
         .put(KAFKA_HOST, hostAndPort[0])


### PR DESCRIPTION
Main goal is to fix tests for this PR: https://github.com/folio-org/data-import-processing-core/pull/339/files
This will fix these tests: 
![image](https://github.com/user-attachments/assets/02459251-aeb0-40c0-a05e-a80b409b7483)
**BTW** - there will be 1 test that fails in maven build DataImportKafkaHandlerTest:shouldReturnSucceededFutureWhenProcessingCoreHandlerSucceeded: 
![image](https://github.com/user-attachments/assets/0099b1d5-e950-43c9-8996-83357fad61d8)
If run it separately - everything will be OK.