### PR TITLE
[MODINVSTOR-1253] Add user-tenants.collection.get to update-ownership API

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -559,7 +559,8 @@
             "inventory-storage.holdings.item.get",
             "inventory-storage.holdings.collection.get",
             "inventory-storage.instances.item.get",
-            "inventory-storage.bound-with-parts.collection.get"
+            "inventory-storage.bound-with-parts.collection.get",
+            "user-tenants.collection.get"
           ]
         },
         {
@@ -574,7 +575,8 @@
             "inventory-storage.items.item.delete",
             "inventory-storage.items.collection.get",
             "inventory-storage.instances.item.get",
-            "inventory-storage.bound-with-parts.collection.get"
+            "inventory-storage.bound-with-parts.collection.get",
+            "user-tenants.collection.get"
           ]
         }
       ]


### PR DESCRIPTION
### Purpose
Allow update ownership without adding user-tenants.collection.get permission to user
### Approach
Add user-tenants.collection.get to update-ownership API
### Jira
https://folio-org.atlassian.net/browse/MODINVSTOR-1253