### PR TITLE
MODINV-1072 Create inventory.items-by-holdings-id.collection.get permission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -348,7 +348,7 @@
         {
           "methods": ["GET"],
           "pathPattern": "/inventory/items-by-holdings-id",
-          "permissionsRequired": ["inventory.items.collection.get"],
+          "permissionsRequired": ["inventory.items-by-holdings-id.collection.get"],
           "modulePermissions": [
             "inventory-storage.bound-with-parts.collection.get",
             "inventory-storage.bound-with-parts.item.get",
@@ -761,7 +761,11 @@
       "displayName": "Inventory - update an item ownership",
       "description": "Update an item ownership"
     },
-
+    {
+      "permissionName": "inventory.items-by-holdings-id.collection.get",
+      "displayName": "Inventory - get item collection by holdings id",
+      "description": "Get item collection by holdings id"
+    },
     {
       "permissionName": "inventory.holdings.move.item.post",
       "displayName": "Inventory - move holdings record to another instance",
@@ -866,7 +870,8 @@
         "inventory.items.move.item.post",
         "inventory.holdings.move.item.post",
         "inventory.items.update-ownership.item.post",
-        "inventory.holdings.update-ownership.item.post"
+        "inventory.holdings.update-ownership.item.post",
+        "inventory.items-by-holdings-id.collection.get"
       ]
     },
     {


### PR DESCRIPTION
Following permission naming convention:

Module-Specific Prefix: inventory.
Resource Identifier: items-by-holdings-id (as it references this specific resource).
Entity Scope: collection (since it involves potentially multiple items linked to holdings).
Action Verb: get (since this is a retrieval operation).
Thus, the new permission name should be inventory.items-by-holdings-id.collection.get

Learning:
[MODINV-1072](https://folio-org.atlassian.net/browse/MODINV-1072)
[Naming convention](https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/156368925/Permissions+naming+convention)