### PR TITLE
[MODORDSTOR-419] - Add user-tenants permission for kafka process

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -328,7 +328,9 @@
           "permissionsRequired": ["inventory.holdings.item.put"],
           "modulePermissions": [
             "inventory-storage.holdings.item.get",
-            "inventory-storage.holdings.item.put"
+            "inventory-storage.holdings.item.put",
+            "inventory-storage.holdings.collection.get",
+            "inventory-storage.holdings.batch.post"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -542,7 +542,8 @@
           "modulePermissions": [
             "inventory-storage.holdings.item.put",
             "inventory-storage.holdings.collection.get",
-            "inventory-storage.instances.item.get"
+            "inventory-storage.instances.item.get",
+            "user-tenants.collection.get"
           ]
         }
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -307,7 +307,8 @@
             "inventory-storage.items.item.get",
             "inventory-storage.items.collection.get",
             "inventory-storage.items.item.put",
-            "users.item.get"
+            "users.item.get",
+            "user-tenants.collection.get"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -541,6 +541,7 @@
             "inventory-storage.holdings.item.put",
             "inventory-storage.holdings.collection.get",
             "inventory-storage.instances.item.get",
+            "inventory-storage.holdings.batch.post",
             "user-tenants.collection.get"
           ]
         }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -542,9 +542,7 @@
           "modulePermissions": [
             "inventory-storage.holdings.item.put",
             "inventory-storage.holdings.collection.get",
-            "inventory-storage.instances.item.get",
-            "inventory-storage.holdings.batch.post",
-            "user-tenants.collection.get"
+            "inventory-storage.instances.item.get"
           ]
         }
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -330,7 +330,8 @@
             "inventory-storage.holdings.item.get",
             "inventory-storage.holdings.item.put",
             "inventory-storage.holdings.collection.get",
-            "inventory-storage.holdings.batch.post"
+            "inventory-storage.holdings.batch.post",
+            "user-tenants.collection.get"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -529,7 +529,8 @@
           "modulePermissions": [
             "inventory-storage.items.item.put",
             "inventory-storage.items.collection.get",
-            "inventory-storage.holdings.item.get"
+            "inventory-storage.holdings.item.get",
+            "user-tenants.collection.get"
           ]
         },
         {
@@ -539,7 +540,8 @@
           "modulePermissions": [
             "inventory-storage.holdings.item.put",
             "inventory-storage.holdings.collection.get",
-            "inventory-storage.instances.item.get"
+            "inventory-storage.instances.item.get",
+            "user-tenants.collection.get"
           ]
         }
       ]


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODORDSTOR-419
## Purpose:
- kafka consumer in mod-orders-storage fetch central tenant from user-tenants