### PR TITLE
MODINV-1079 holdings-storage and bound-with-parts-storage update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,8 @@
 * Fix mod-inventory OOM issue [MODINV-1023](https://folio-org.atlassian.net/browse/MODINV-1023)
 * Replace GET with POST request for fetching instances and holdings on /items endpoint to omit 414 error [MODINV-943](https://folio-org.atlassian.net/browse/MODINV-943)
 * Call suppress-on-discovery for source record on holding update if discoverySuppress is true [MODINV-977](https://folio-org.atlassian.net/browse/MODINV-977)
-* Requires `holdings-storage 2.0 3.0 4.0 5.0 6.0 7.0`
+* Requires `holdings-storage 2.0 3.0 4.0 5.0 6.0 7.0 8.0`
+* Requires `bound-with-parts-storage 2.0`
 * InstanceIngress create events consumption [MODINV-986](https://folio-org.atlassian.net/browse/MODINV-986)
 * Additional Requirements - Update Data Import logic to normalize OCLC 035 values [MODINV-1044](https://folio-org.atlassian.net/browse/MODINV-1044)
 * Implement endpoint to update ownership of Holdings [MODINV-1031](https://folio-org.atlassian.net/browse/MODINV-1031)
@@ -24,6 +25,7 @@
 * Extend Authority with Additional fields [MODINV-1071](https://folio-org.atlassian.net/browse/MODINV-1071)
 * Keep original UUIDs when updating ownership of Holdings/Items [MODINV-1074](https://folio-org.atlassian.net/browse/MODINV-1074)
 * API version update [MODINV-1080](https://folio-org.atlassian.net/browse/MODINV-1080)
+* Add `inventory-storage.instances.retrieve.collection.post` and `inventory-storage.holdings.retrieve.collection.post` permissions
 
 ## 20.2.0 2023-03-20
 * Inventory cannot process Holdings with virtual fields ([MODINV-941](https://issues.folio.org/browse/MODINV-941))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -22,7 +22,9 @@
             "inventory-storage.holdings.item.get",
             "inventory-storage.instances.collection.get",
             "inventory-storage.instances.item.get",
-            "inventory-storage.bound-with-parts.collection.get"
+            "inventory-storage.bound-with-parts.collection.get",
+            "inventory-storage.holdings.retrieve.collection.post",
+            "inventory-storage.instances.retrieve.collection.post"
           ]
         },
         {
@@ -362,7 +364,9 @@
             "inventory-storage.holdings.collection.get",
             "inventory-storage.holdings.item.get",
             "inventory-storage.instances.collection.get",
-            "inventory-storage.instances.item.get"
+            "inventory-storage.instances.item.get",
+            "inventory-storage.holdings.retrieve.collection.post",
+            "inventory-storage.instances.retrieve.collection.post"
           ]
         },
         {
@@ -615,7 +619,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "2.0 3.0 4.0 5.0 6.0 7.0"
+      "version": "2.0 3.0 4.0 5.0 6.0 7.0 8.0"
     },
     {
       "id": "material-types",
@@ -663,7 +667,7 @@
     },
     {
       "id": "bound-with-parts-storage",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "authority-storage",


### PR DESCRIPTION
[MODINV-1079](https://folio-org.atlassian.net/browse/MODINV-1079)

## Purpose
Update interfaces versions
`holdings-storage 8.0`
`bound-with-parts-storage 2.0`

Update the module permissions in ModuleDescriptor-template.json file for those endpoints that use the mod-inventory-storage endpoints listed below with new permissions:

	  	  
      "methods": ["POST"],
      "pathPattern": "/instance-storage/instances/retrieve",
      "permissionsRequired": ["inventory-storage.instances.retrieve.collection.post"]
	  	  
	  "methods": ["POST"],
      "pathPattern": "/holdings-storage/holdings/retrieve",
      "permissionsRequired": ["inventory-storage.holdings.retrieve.collection.post"]