### PR TITLE
MODINV-1100: Retry instance update on optimistic locking error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-source-record-storage-client</artifactId>
-      <version>5.9.0-SNAPSHOT</version>
+      <version>5.9.0</version>
       <exclusions>
         <!-- This is provided by JDK >= 9 causing a compile error (Eclipse doesn't suppress this compile error):
              "The package org.xml.sax is accessible from more than one module: <unnamed>, java.xml"
@@ -235,7 +235,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-source-record-manager-client</artifactId>
-      <version>3.9.0-SNAPSHOT</version>
+      <version>3.9.0</version>
       <exclusions>
         <!-- This is provided by JDK >= 9 causing a compile error (Eclipse doesn't suppress this compile error):
              "The package org.xml.sax is accessible from more than one module: <unnamed>, java.xml"
@@ -321,7 +321,7 @@
     <liquibase.version>4.9.1</liquibase.version>
     <kafkaclients.version>3.1.0</kafkaclients.version>
     <junit.version>4.13.2</junit.version>
-    <data-import-processing-core.version>4.3.0-SNAPSHOT</data-import-processing-core.version>
+    <data-import-processing-core.version>4.3.0</data-import-processing-core.version>
     <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
   </properties>
 

--- a/src/main/java/org/folio/inventory/InstanceIngressConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/InstanceIngressConsumerVerticle.java
@@ -19,7 +19,7 @@ public class InstanceIngressConsumerVerticle extends KafkaConsumerVerticle {
   public void start(Promise<Void> startPromise) {
     var instanceIngressEventHandler = new InstanceIngressEventConsumer(vertx, getStorage(), getHttpClient(), getMappingMetadataCache());
 
-    var consumerWrapper = createConsumer(INSTANCE_INGRESS_TOPIC, BASE_PROPERTY, true);
+    var consumerWrapper = createConsumer(INSTANCE_INGRESS_TOPIC, BASE_PROPERTY);
 
     consumerWrapper.start(instanceIngressEventHandler, constructModuleName())
       .onFailure(startPromise::fail)

--- a/src/main/java/org/folio/inventory/Launcher.java
+++ b/src/main/java/org/folio/inventory/Launcher.java
@@ -96,7 +96,7 @@ public class Launcher {
     int dataImportConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(DATA_IMPORT_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "3"));
     int instanceHridSetConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(MARC_BIB_INSTANCE_HRID_SET_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "3"));
     int quickMarcConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(QUICK_MARC_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "1"));
-    int marcBibUpdateConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(MARC_BIB_UPDATE_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "3"));
+    int marcBibUpdateConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(MARC_BIB_UPDATE_CONSUMER_VERTICLE_INSTANCES_NUMBER_CONFIG, "1"));
     int consortiumInstanceSharingVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(CONSORTIUM_INSTANCE_SHARING_CONSUMER_VERTICLE_NUMBER_CONFIG, "3"));
     int instanceIngressConsumerVerticleNumber = Integer.parseInt(System.getenv().getOrDefault(INSTANCE_INGRESS_VERTICLE_NUMBER_CONFIG, "3"));
 

--- a/src/main/java/org/folio/inventory/Launcher.java
+++ b/src/main/java/org/folio/inventory/Launcher.java
@@ -107,17 +107,17 @@ public class Launcher {
     CompletableFuture<String> future5 = new CompletableFuture<>();
     CompletableFuture<String> future6 = new CompletableFuture<>();
     vertxAssistant.deployVerticle(DataImportConsumerVerticle.class.getName(),
-      consumerVerticlesConfig, dataImportConsumerVerticleNumber, future1);
+      consumerVerticlesConfig, dataImportConsumerVerticleNumber, null, future1);
     vertxAssistant.deployVerticle(MarcHridSetConsumerVerticle.class.getName(),
-      consumerVerticlesConfig, instanceHridSetConsumerVerticleNumber, future2);
+      consumerVerticlesConfig, instanceHridSetConsumerVerticleNumber, null, future2);
     vertxAssistant.deployVerticle(QuickMarcConsumerVerticle.class.getName(),
-      consumerVerticlesConfig, quickMarcConsumerVerticleNumber, future3);
+      consumerVerticlesConfig, quickMarcConsumerVerticleNumber, null, future3);
     vertxAssistant.deployVerticle(MarcBibUpdateConsumerVerticle.class.getName(),
-      consumerVerticlesConfig, marcBibUpdateConsumerVerticleNumber, future4);
+      consumerVerticlesConfig, marcBibUpdateConsumerVerticleNumber, 1, future4);
     vertxAssistant.deployVerticle(ConsortiumInstanceSharingConsumerVerticle.class.getName(),
-      consumerVerticlesConfig, consortiumInstanceSharingVerticleNumber, future5);
+      consumerVerticlesConfig, consortiumInstanceSharingVerticleNumber, null, future5);
     vertxAssistant.deployVerticle(InstanceIngressConsumerVerticle.class.getName(),
-      consumerVerticlesConfig, instanceIngressConsumerVerticleNumber, future6);
+      consumerVerticlesConfig, instanceIngressConsumerVerticleNumber, null, future6);
 
     consumerVerticleDeploymentId = future1.get(20, TimeUnit.SECONDS);
     marcInstHridSetConsumerVerticleDeploymentId = future2.get(20, TimeUnit.SECONDS);

--- a/src/main/java/org/folio/inventory/Launcher.java
+++ b/src/main/java/org/folio/inventory/Launcher.java
@@ -113,7 +113,7 @@ public class Launcher {
     vertxAssistant.deployVerticle(QuickMarcConsumerVerticle.class.getName(),
       consumerVerticlesConfig, quickMarcConsumerVerticleNumber, null, future3);
     vertxAssistant.deployVerticle(MarcBibUpdateConsumerVerticle.class.getName(),
-      consumerVerticlesConfig, marcBibUpdateConsumerVerticleNumber, 1, future4);
+      consumerVerticlesConfig, marcBibUpdateConsumerVerticleNumber, null, future4);
     vertxAssistant.deployVerticle(ConsortiumInstanceSharingConsumerVerticle.class.getName(),
       consumerVerticlesConfig, consortiumInstanceSharingVerticleNumber, null, future5);
     vertxAssistant.deployVerticle(InstanceIngressConsumerVerticle.class.getName(),

--- a/src/main/java/org/folio/inventory/MarcBibUpdateConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/MarcBibUpdateConsumerVerticle.java
@@ -13,6 +13,7 @@ public class MarcBibUpdateConsumerVerticle extends KafkaConsumerVerticle {
   private static final Logger LOGGER = LogManager.getLogger(MarcBibUpdateConsumerVerticle.class);
   private static final String SRS_MARC_BIB_EVENT = "srs.marc-bib";
   private static final String BASE_PROPERTY = "MarcBibUpdateConsumer";
+  private static final String DEFAULT_LOAD_LIMIT = "2";
 
   @Override
   public void start(Promise<Void> startPromise) {
@@ -20,8 +21,8 @@ public class MarcBibUpdateConsumerVerticle extends KafkaConsumerVerticle {
 
     var marcBibUpdateKafkaHandler = new MarcBibUpdateKafkaHandler(vertx, getMaxDistributionNumber(BASE_PROPERTY),
       getKafkaConfig(), instanceUpdateDelegate, getMappingMetadataCache());
-
-    var marcBibUpdateConsumerWrapper = createConsumer(SRS_MARC_BIB_EVENT, BASE_PROPERTY, false);
+    var loadLimit = getLoadLimit(BASE_PROPERTY, DEFAULT_LOAD_LIMIT);
+    var marcBibUpdateConsumerWrapper = createConsumer(SRS_MARC_BIB_EVENT, loadLimit, false);
 
     marcBibUpdateConsumerWrapper.start(marcBibUpdateKafkaHandler, constructModuleName())
       .onFailure(startPromise::fail)

--- a/src/main/java/org/folio/inventory/common/VertxAssistant.java
+++ b/src/main/java/org/folio/inventory/common/VertxAssistant.java
@@ -55,12 +55,13 @@ public class VertxAssistant {
   public void deployVerticle(String verticleClass,
                              Map<String, Object> config,
                              CompletableFuture<String> deployed) {
-    deployVerticle(verticleClass, config, 1, deployed);
+    deployVerticle(verticleClass, config, 1, null, deployed);
   }
 
   public void deployVerticle(String verticleClass,
                              Map<String, Object> config,
                              int verticleInstancesNumber,
+                             Integer workerPoolSize,
                              CompletableFuture<String> deployed) {
     long startTime = System.currentTimeMillis();
 
@@ -69,6 +70,10 @@ public class VertxAssistant {
     options.setConfig(new JsonObject(config));
     options.setWorker(true);
     options.setInstances(verticleInstancesNumber);
+
+    if (workerPoolSize != null) {
+      options.setWorkerPoolSize(workerPoolSize);
+    }
 
     vertx.deployVerticle(verticleClass, options, result -> {
       if (result.succeeded()) {

--- a/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
@@ -95,7 +95,7 @@ public class MarcBibUpdateKafkaHandler implements AsyncRecordHandler<String, Str
         .map(metadataOptional -> metadataOptional.orElseThrow(() ->
           new EventProcessingException(format(MAPPING_METADATA_NOT_FOUND_MSG, instanceEvent.getJobId()))))
         .onSuccess(mappingMetadataDto -> ensureEventPayloadWithMappingMetadata(metaDataPayload, mappingMetadataDto))
-        .compose(v -> instanceUpdateDelegate.handleBlocking(metaDataPayload, marcBibRecord, context))
+        .compose(v -> instanceUpdateDelegate.handle(metaDataPayload, marcBibRecord, context))
         .onComplete(ar -> processUpdateResult(ar, metaDataPayload, promise, consumerRecord, instanceEvent));
       return promise.future();
     } catch (Exception e) {

--- a/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
@@ -91,19 +91,12 @@ public class MarcBibUpdateKafkaHandler implements AsyncRecordHandler<String, Str
       Context context = EventHandlingUtil.constructContext(instanceEvent.getTenant(), headersMap.get(OKAPI_TOKEN_HEADER), headersMap.get(OKAPI_URL_HEADER));
       Record marcBibRecord = instanceEvent.getRecord();
 
-      io.vertx.core.Context vertxContext = Vertx.currentContext();
-      if(vertxContext == null) {
-        return Future.failedFuture("saveRecords must be executed by a Vertx thread");
-      }
-
-      vertxContext.owner().executeBlocking(() ->
-        mappingMetadataCache.getByRecordType(instanceEvent.getJobId(), context, MARC_BIB_RECORD_TYPE)
-          .map(metadataOptional -> metadataOptional.orElseThrow(() ->
-            new EventProcessingException(format(MAPPING_METADATA_NOT_FOUND_MSG, instanceEvent.getJobId()))))
-          .onSuccess(mappingMetadataDto -> ensureEventPayloadWithMappingMetadata(metaDataPayload, mappingMetadataDto))
-          .compose(v -> instanceUpdateDelegate.handle(metaDataPayload, marcBibRecord, context))
-          .onComplete(ar -> processUpdateResult(ar, metaDataPayload, promise, consumerRecord, instanceEvent))
-      );
+      mappingMetadataCache.getByRecordType(instanceEvent.getJobId(), context, MARC_BIB_RECORD_TYPE)
+        .map(metadataOptional -> metadataOptional.orElseThrow(() ->
+          new EventProcessingException(format(MAPPING_METADATA_NOT_FOUND_MSG, instanceEvent.getJobId()))))
+        .onSuccess(mappingMetadataDto -> ensureEventPayloadWithMappingMetadata(metaDataPayload, mappingMetadataDto))
+        .compose(v -> instanceUpdateDelegate.handleBlocking(metaDataPayload, marcBibRecord, context))
+        .onComplete(ar -> processUpdateResult(ar, metaDataPayload, promise, consumerRecord, instanceEvent));
       return promise.future();
     } catch (Exception e) {
       LOGGER.error(format("Failed to process data import kafka record from topic %s", consumerRecord.topic()), e);

--- a/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
@@ -95,7 +95,7 @@ public class MarcBibUpdateKafkaHandler implements AsyncRecordHandler<String, Str
         .map(metadataOptional -> metadataOptional.orElseThrow(() ->
           new EventProcessingException(format(MAPPING_METADATA_NOT_FOUND_MSG, instanceEvent.getJobId()))))
         .onSuccess(mappingMetadataDto -> ensureEventPayloadWithMappingMetadata(metaDataPayload, mappingMetadataDto))
-        .compose(v -> instanceUpdateDelegate.handle(metaDataPayload, marcBibRecord, context))
+        .compose(v -> instanceUpdateDelegate.handleBlocking(metaDataPayload, marcBibRecord, context))
         .onComplete(ar -> processUpdateResult(ar, metaDataPayload, promise, consumerRecord, instanceEvent));
       return promise.future();
     } catch (Exception e) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
@@ -60,6 +60,8 @@ public class InstanceUpdateDelegate {
         })
         .compose(existingInstance -> {
           LOGGER.info("handleInstanceUpdate:: version before mapping: {}", existingInstance.getVersion());
+          instanceCollection.findByIdAndUpdate(instanceId, existingInstance, context);
+          LOGGER.info("EXISTING: {}", existingInstance);
           return Future.fromCompletionStage(updateInstance(existingInstance, mappedInstance));
         })
         .compose(updatedInstance -> {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
@@ -51,9 +51,18 @@ public class InstanceUpdateDelegate {
       InstanceCollection instanceCollection = storage.getInstanceCollection(context);
 
       return InstanceUtil.findInstanceById(instanceId, instanceCollection)
-        .onSuccess(existingInstance -> fillVersion(existingInstance, eventPayload))
-        .compose(existingInstance -> updateInstance(existingInstance, mappedInstance))
-        .compose(updatedInstance -> updateInstanceInStorage(updatedInstance, instanceCollection));
+        .onSuccess(existingInstance -> {
+          LOGGER.info("handleInstanceUpdate:: current version: {}", existingInstance.getVersion());
+          fillVersion(existingInstance, eventPayload);
+        })
+        .compose(existingInstance -> {
+          LOGGER.info("handleInstanceUpdate:: version before mapping: {}", existingInstance.getVersion());
+          return updateInstance(existingInstance, mappedInstance);
+        })
+        .compose(updatedInstance -> {
+          LOGGER.info("handleInstanceUpdate:: version before update: {}", updatedInstance.getVersion());
+          return updateInstanceInStorage(updatedInstance, instanceCollection);
+        });
     } catch (Exception e) {
       LOGGER.error("Error updating inventory instance", e);
       return Future.failedFuture(e);

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
@@ -22,7 +22,6 @@ import org.folio.rest.jaxrs.model.Record;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static org.folio.inventory.dataimport.util.LoggerUtil.logParametersUpdateDelegate;
@@ -127,7 +126,7 @@ public class InstanceUpdateDelegate {
                 });
               return updateFuture;
             })
-            .get(2, TimeUnit.SECONDS);
+            .get();
           return Future.succeededFuture(updatedInstance);
         } catch (Exception ex) {
           LOGGER.error("Error updating inventory instance: {}", ex.getMessage());

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
@@ -114,7 +114,7 @@ public class InstanceUpdateDelegate {
               LOGGER.info("handleInstanceUpdate:: version before update: {}, jobId: {}", modified.getVersion(), marcRecord.getSnapshotId());
               CompletableFuture<Instance> updateFuture = new CompletableFuture<>();
               instanceCollection.update(modified,
-                success -> updateFuture.complete(modified),
+                success -> updateFuture.thenApply(noInstance -> modified),
                 failure -> {
                   if (failure.getStatusCode() == HttpStatus.SC_CONFLICT) {
                     var ex = new OptimisticLockingException(failure.getReason());

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
@@ -22,6 +22,7 @@ import org.folio.rest.jaxrs.model.Record;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static org.folio.inventory.dataimport.util.LoggerUtil.logParametersUpdateDelegate;
@@ -99,7 +100,7 @@ public class InstanceUpdateDelegate {
                 throw new NotFoundException(format("Can't find Instance by id: %s", instanceId));
               } else {
                 LOGGER.info("handleInstanceUpdate:: current version: {}, jobId: {}", success.getResult().getVersion(), marcRecord.getSnapshotId());
-                getFuture.complete(success.getResult());
+                getFuture.thenApply(noInstance -> success.getResult());  //complete(success.getResult());
               }
             },
             failure -> {
@@ -126,7 +127,7 @@ public class InstanceUpdateDelegate {
                 });
               return updateFuture;
             })
-            .get();
+            .get(2, TimeUnit.SECONDS);
           return Future.succeededFuture(updatedInstance);
         } catch (Exception ex) {
           LOGGER.error("Error updating inventory instance: {}", ex.getMessage());

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
@@ -2,6 +2,7 @@ package org.folio.inventory.dataimport.handlers.actions;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
@@ -10,6 +11,8 @@ import org.folio.inventory.common.Context;
 import org.folio.inventory.dataimport.exceptions.OptimisticLockingException;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.InstanceCollection;
+import org.folio.inventory.exceptions.ExternalResourceFetchException;
+import org.folio.inventory.exceptions.NotFoundException;
 import org.folio.inventory.storage.Storage;
 import org.folio.inventory.support.InstanceUtil;
 import org.folio.processing.mapping.defaultmapper.RecordMapper;
@@ -19,6 +22,8 @@ import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.Record;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static org.folio.inventory.dataimport.util.LoggerUtil.logParametersUpdateDelegate;
@@ -57,7 +62,7 @@ public class InstanceUpdateDelegate {
         })
         .compose(existingInstance -> {
           LOGGER.info("handleInstanceUpdate:: version before mapping: {}", existingInstance.getVersion());
-          return updateInstance(existingInstance, mappedInstance);
+          return Future.fromCompletionStage(updateInstance(existingInstance, mappedInstance));
         })
         .compose(updatedInstance -> {
           LOGGER.info("handleInstanceUpdate:: version before update: {}", updatedInstance.getVersion());
@@ -67,6 +72,78 @@ public class InstanceUpdateDelegate {
       LOGGER.error("Error updating inventory instance", e);
       return Future.failedFuture(e);
     }
+  }
+
+  public Future<Instance> handleBlocking(Map<String, String> eventPayload, Record marcRecord, Context context) {
+    logParametersUpdateDelegate(LOGGER, eventPayload, marcRecord, context);
+    Promise<Instance> promise = Promise.promise();
+    io.vertx.core.Context vertxContext = Vertx.currentContext();
+
+    if(vertxContext == null) {
+      return Future.failedFuture("handle:: operation must be executed by a Vertx thread");
+    }
+
+    vertxContext.owner().executeBlocking(() -> {
+        try {
+          JsonObject mappingRules = new JsonObject(eventPayload.get(MAPPING_RULES_KEY));
+          MappingParameters mappingParameters = new JsonObject(eventPayload.get(MAPPING_PARAMS_KEY)).mapTo(MappingParameters.class);
+          JsonObject parsedRecord = retrieveParsedContent(marcRecord.getParsedRecord());
+          String instanceId = marcRecord.getExternalIdsHolder().getInstanceId();
+          LOGGER.info("Instance update with instanceId: {}", instanceId);
+          RecordMapper<org.folio.Instance> recordMapper = RecordMapperBuilder.buildMapper(MARC_BIB_RECORD_FORMAT);
+          var mappedInstance = recordMapper.mapRecord(parsedRecord, mappingParameters, mappingRules);
+          InstanceCollection instanceCollection = storage.getInstanceCollection(context);
+
+          CompletableFuture<Instance> getfuture = new CompletableFuture<>();
+          instanceCollection.findById(instanceId, success -> {
+              if (success.getResult() == null) {
+                LOGGER.warn("findInstanceById:: Can't find Instance by id: {} ", instanceId);
+                throw new NotFoundException(format("Can't find Instance by id: %s", instanceId));
+              } else {
+                LOGGER.info("handleInstanceUpdate:: current version: {}, jobId: {}", success.getResult().getVersion(), marcRecord.getSnapshotId());
+                getfuture.complete(success.getResult());
+              }
+            },
+            failure -> {
+              LOGGER.warn(format("findInstanceById:: Error retrieving Instance by id %s - %s, status code %s", instanceId, failure.getReason(), failure.getStatusCode()));
+              var ex = new ExternalResourceFetchException(format("Instance fetch by id: %s failed", instanceId), failure.getReason(), failure.getStatusCode(), null);
+              getfuture.completeExceptionally(ex);
+            });
+
+          return getfuture.thenCompose(existing -> updateInstance(existing, mappedInstance))
+            .thenCompose(modified -> {
+              LOGGER.info("handleInstanceUpdate:: version before update: {}, jobId: {}", modified.getVersion(), marcRecord.getSnapshotId());
+              CompletableFuture<Instance> updateFuture = new CompletableFuture<>();
+              instanceCollection.update(modified,
+                success -> updateFuture.complete(modified),
+                failure -> {
+                  if (failure.getStatusCode() == HttpStatus.SC_CONFLICT) {
+                    var ex = new OptimisticLockingException(failure.getReason());
+                    updateFuture.completeExceptionally(ex);
+                  } else {
+                    LOGGER.error(format("Error updating Instance - %s, status code %s", failure.getReason(), failure.getStatusCode()));
+                    var ex = new ExternalResourceFetchException(format("Error updating Instance - %s", failure.getReason()), failure.getReason(), failure.getStatusCode(), null);
+                    updateFuture.completeExceptionally(ex);
+                  }
+                });
+              return updateFuture;
+            })
+            .get(2, TimeUnit.SECONDS);
+        } catch (Exception ex) {
+          LOGGER.error("Error updating inventory instance: {}", ex.getMessage());
+          throw ex;
+        }
+      },
+      r -> {
+        if (r.failed()) {
+          LOGGER.warn("handle:: Error during instance save", r.cause());
+          promise.fail(r.cause());
+        } else {
+          LOGGER.debug("saveRecords:: Instance save was successful");
+          promise.complete(r.result());
+        }
+      });
+    return promise.future();
   }
 
   private void fillVersion(Instance existingInstance, Map<String, String> eventPayload) {
@@ -81,17 +158,17 @@ public class InstanceUpdateDelegate {
       : JsonObject.mapFrom(parsedRecord.getContent());
   }
 
-  private Future<Instance> updateInstance(Instance existingInstance, org.folio.Instance mappedInstance) {
+  private CompletableFuture<Instance> updateInstance(Instance existingInstance, org.folio.Instance mappedInstance) {
     try {
       mappedInstance.setId(existingInstance.getId());
       JsonObject existing = JsonObject.mapFrom(existingInstance);
       JsonObject mapped = JsonObject.mapFrom(mappedInstance);
       JsonObject mergedInstanceAsJson = InstanceUtil.mergeInstances(existing, mapped);
       Instance mergedInstance = Instance.fromJson(mergedInstanceAsJson);
-      return Future.succeededFuture(mergedInstance);
+      return CompletableFuture.completedFuture(mergedInstance);
     } catch (Exception e) {
       LOGGER.error("Error updating instance", e);
-      return Future.failedFuture(e);
+      return CompletableFuture.failedFuture(e);
     }
   }
 

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
@@ -2,6 +2,7 @@ package org.folio.inventory.dataimport.handlers.actions;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
@@ -10,7 +11,6 @@ import org.folio.inventory.common.Context;
 import org.folio.inventory.dataimport.exceptions.OptimisticLockingException;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.InstanceCollection;
-import org.folio.inventory.exceptions.NotFoundException;
 import org.folio.inventory.storage.Storage;
 import org.folio.inventory.support.InstanceUtil;
 import org.folio.processing.mapping.defaultmapper.RecordMapper;
@@ -53,25 +53,21 @@ public class InstanceUpdateDelegate {
       var mappedInstance = recordMapper.mapRecord(parsedRecord, mappingParameters, mappingRules);
       InstanceCollection instanceCollection = storage.getInstanceCollection(context);
 
-      var updated = instanceCollection.findByIdAndUpdate(instanceId, mappedInstance)
-        .toCompletionStage().toCompletableFuture().get();
-      return Future.succeededFuture(updated);
-
-//      return InstanceUtil.findInstanceById(instanceId, instanceCollection)
-//        .onSuccess(existingInstance -> {
-//          LOGGER.info("handleInstanceUpdate:: current version: {}", existingInstance.getVersion());
-//          fillVersion(existingInstance, eventPayload);
-//        })
-//        .compose(existingInstance -> {
-//          LOGGER.info("handleInstanceUpdate:: version before mapping: {}", existingInstance.getVersion());
-//          instanceCollection.findByIdAndUpdate(instanceId, existingInstance, context);
-//          LOGGER.info("EXISTING: {}", existingInstance);
-//          return Future.fromCompletionStage(updateInstance(existingInstance, mappedInstance));
-//        })
-//        .compose(updatedInstance -> {
-//          LOGGER.info("handleInstanceUpdate:: version before update: {}", updatedInstance.getVersion());
-//          return updateInstanceInStorage(updatedInstance, instanceCollection);
-//        });
+      return InstanceUtil.findInstanceById(instanceId, instanceCollection)
+        .onSuccess(existingInstance -> {
+          LOGGER.info("handleInstanceUpdate:: current version: {}", existingInstance.getVersion());
+          fillVersion(existingInstance, eventPayload);
+        })
+        .compose(existingInstance -> {
+          LOGGER.info("handleInstanceUpdate:: version before mapping: {}", existingInstance.getVersion());
+          instanceCollection.findByIdAndUpdate(instanceId, existingInstance, context);
+          LOGGER.info("EXISTING: {}", existingInstance);
+          return Future.fromCompletionStage(updateInstance(existingInstance, mappedInstance));
+        })
+        .compose(updatedInstance -> {
+          LOGGER.info("handleInstanceUpdate:: version before update: {}", updatedInstance.getVersion());
+          return updateInstanceInStorage(updatedInstance, instanceCollection);
+        });
     } catch (Exception e) {
       LOGGER.error("Error updating inventory instance", e);
       return Future.failedFuture(e);
@@ -80,14 +76,14 @@ public class InstanceUpdateDelegate {
 
   public Future<Instance> handleBlocking(Map<String, String> eventPayload, Record marcRecord, Context context) {
     logParametersUpdateDelegate(LOGGER, eventPayload, marcRecord, context);
-//    Promise<Instance> promise = Promise.promise();
-//    io.vertx.core.Context vertxContext = Vertx.currentContext();
-//
-//    if(vertxContext == null) {
-//      return Future.failedFuture("handle:: operation must be executed by a Vertx thread");
-//    }
-//
-//    vertxContext.owner().executeBlocking(() -> {
+    Promise<Instance> promise = Promise.promise();
+    io.vertx.core.Context vertxContext = Vertx.currentContext();
+
+    if(vertxContext == null) {
+      return Future.failedFuture("handle:: operation must be executed by a Vertx thread");
+    }
+
+    vertxContext.owner().executeBlocking(() -> {
         try {
           JsonObject mappingRules = new JsonObject(eventPayload.get(MAPPING_RULES_KEY));
           MappingParameters mappingParameters = new JsonObject(eventPayload.get(MAPPING_PARAMS_KEY)).mapTo(MappingParameters.class);
@@ -98,67 +94,25 @@ public class InstanceUpdateDelegate {
           var mappedInstance = recordMapper.mapRecord(parsedRecord, mappingParameters, mappingRules);
           InstanceCollection instanceCollection = storage.getInstanceCollection(context);
 
-          var existing = instanceCollection.findById(instanceId).get(5, TimeUnit.SECONDS);
-          if (existing == null) {
-            return Future.failedFuture(new NotFoundException(format("Can't find Instance by id: %s", instanceId)));
-          }
-          var modified = updateInstance(existing, mappedInstance).get(5, TimeUnit.SECONDS);
-          var updated = instanceCollection.update(modified).get(5, TimeUnit.SECONDS);
-          return Future.succeededFuture(updated);
-
-//          CompletableFuture<Instance> getFuture = new CompletableFuture<>();
-//          instanceCollection.findById(instanceId, success -> {
-//              if (success.getResult() == null) {
-//                LOGGER.warn("findInstanceById:: Can't find Instance by id: {} ", instanceId);
-//                var ex = new NotFoundException(format("Can't find Instance by id: %s", instanceId));
-//                getFuture.completeExceptionally(ex);
-//              } else {
-//                LOGGER.info("handleInstanceUpdate:: current version: {}, jobId: {}", success.getResult().getVersion(), marcRecord.getSnapshotId());
-//                getFuture.complete(success.getResult());
-//              }
-//            },
-//            failure -> {
-//              LOGGER.warn(format("findInstanceById:: Error retrieving Instance by id %s - %s, status code %s", instanceId, failure.getReason(), failure.getStatusCode()));
-//              var ex = new ExternalResourceFetchException(format("Instance fetch by id: %s failed", instanceId), failure.getReason(), failure.getStatusCode(), null);
-//              getFuture.completeExceptionally(ex);
-//            });
-//
-//          return getFuture.thenCompose(existing -> updateInstance(existing, mappedInstance))
-//            .thenCompose(modified -> {
-//              LOGGER.info("handleInstanceUpdate:: version before update: {}, jobId: {}", modified.getVersion(), marcRecord.getSnapshotId());
-//              CompletableFuture<Instance> updateFuture = new CompletableFuture<>();
-//              instanceCollection.update(modified,
-//                success -> updateFuture.complete(modified),
-//                failure -> {
-//                  if (failure.getStatusCode() == HttpStatus.SC_CONFLICT) {
-//                    var ex = new OptimisticLockingException(failure.getReason());
-//                    updateFuture.completeExceptionally(ex);
-//                  } else {
-//                    LOGGER.error(format("Error updating Instance - %s, status code %s", failure.getReason(), failure.getStatusCode()));
-//                    var ex = new ExternalResourceFetchException(format("Error updating Instance - %s", failure.getReason()), failure.getReason(), failure.getStatusCode(), null);
-//                    updateFuture.completeExceptionally(ex);
-//                  }
-//                });
-//              return updateFuture;
-//            })
-//            .get(2, TimeUnit.SECONDS);
-          //return Future.succeededFuture(updatedInstance);
+          return instanceCollection.findByIdAndUpdate(instanceId, mappedInstance)
+            .toCompletionStage().toCompletableFuture().get(60, TimeUnit.SECONDS);
+          //return Future.succeededFuture(updated);
         } catch (Exception ex) {
           LOGGER.error("Error updating inventory instance: {}", ex.getMessage());
-          return Future.failedFuture(ex);
-          //throw ex;
+          //return Future.failedFuture(ex);
+          throw ex;
         }
-//      },
-//      r -> {
-//        if (r.failed()) {
-//          LOGGER.warn("handle:: Error during instance save", r.cause());
-//          promise.fail(r.cause());
-//        } else {
-//          LOGGER.debug("saveRecords:: Instance save was successful");
-//          promise.complete(r.result());
-//        }
-//      });
-//    return promise.future();
+      },
+      r -> {
+        if (r.failed()) {
+          LOGGER.warn("handle:: Error during instance save", r.cause());
+          promise.fail(r.cause());
+        } else {
+          LOGGER.debug("saveRecords:: Instance save was successful");
+          promise.complete(r.result());
+        }
+      });
+    return promise.future();
   }
 
   private void fillVersion(Instance existingInstance, Map<String, String> eventPayload) {

--- a/src/main/java/org/folio/inventory/domain/instances/InstanceCollection.java
+++ b/src/main/java/org/folio/inventory/domain/instances/InstanceCollection.java
@@ -1,8 +1,11 @@
 package org.folio.inventory.domain.instances;
 
+import io.vertx.core.Future;
+import org.folio.inventory.common.Context;
 import org.folio.inventory.domain.AsynchronousCollection;
 import org.folio.inventory.domain.SearchableCollection;
 
 public interface InstanceCollection
   extends AsynchronousCollection<Instance>, SearchableCollection<Instance> {
+  Future<Instance> findByIdAndUpdate(String id, Instance instance, Context context);
 }

--- a/src/main/java/org/folio/inventory/domain/instances/InstanceCollection.java
+++ b/src/main/java/org/folio/inventory/domain/instances/InstanceCollection.java
@@ -8,4 +8,6 @@ import org.folio.inventory.domain.SearchableCollection;
 public interface InstanceCollection
   extends AsynchronousCollection<Instance>, SearchableCollection<Instance> {
   Future<Instance> findByIdAndUpdate(String id, Instance instance, Context context);
+
+  Future<Instance> findByIdAndUpdate(String id, org.folio.Instance mappedInstance);
 }

--- a/src/main/java/org/folio/inventory/domain/instances/InstanceCollection.java
+++ b/src/main/java/org/folio/inventory/domain/instances/InstanceCollection.java
@@ -7,7 +7,7 @@ import org.folio.inventory.domain.SearchableCollection;
 
 public interface InstanceCollection
   extends AsynchronousCollection<Instance>, SearchableCollection<Instance> {
-  Future<Instance> findByIdAndUpdate(String id, Instance instance, Context context);
+  Future<String> findByIdAndUpdate(String id, org.folio.Instance mappedInstance, Context context);
 
   Future<Instance> findByIdAndUpdate(String id, org.folio.Instance mappedInstance);
 }

--- a/src/main/java/org/folio/inventory/exceptions/ExternalResourceFetchException.java
+++ b/src/main/java/org/folio/inventory/exceptions/ExternalResourceFetchException.java
@@ -4,6 +4,9 @@ import org.folio.inventory.support.http.client.Response;
 
 public class ExternalResourceFetchException extends AbstractInventoryException {
 
+  public ExternalResourceFetchException(String message, String body, int statusCode, String contentType) {
+    super(message, body, statusCode, contentType);
+  }
 
   public ExternalResourceFetchException(String body, int statusCode, String contentType) {
     super("External resource fetch exception:", body, statusCode, contentType);

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleCollection.java
@@ -38,10 +38,10 @@ abstract class ExternalStorageModuleCollection<T> {
   private static final Logger LOGGER = LogManager.getLogger(ExternalStorageModuleCollection.class);
 
 
-  private final String storageAddress;
-  private final String tenant;
-  private final String token;
-  private final String collectionWrapperPropertyName;
+  protected final String storageAddress;
+  protected final String tenant;
+  protected final String token;
+  protected final String collectionWrapperPropertyName;
   protected final WebClient webClient;
 
   ExternalStorageModuleCollection(

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleInstanceCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleInstanceCollection.java
@@ -3,21 +3,28 @@ package org.folio.inventory.storage.external;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.folio.inventory.support.http.ContentType.APPLICATION_JSON;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import io.vertx.core.Future;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.inventory.common.Context;
 import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.common.domain.Success;
 import org.folio.inventory.domain.BatchResult;
 import org.folio.inventory.domain.Metadata;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.instances.InstanceCollection;
+import org.folio.inventory.support.InstanceUtil;
 import org.folio.inventory.support.http.client.Response;
 
 import io.vertx.core.AsyncResult;
@@ -115,5 +122,39 @@ class ExternalStorageModuleInstanceCollection
     String contentHeaderValue = response.getContentType();
     return statusCode == SC_CREATED
       || (statusCode == SC_INTERNAL_SERVER_ERROR && APPLICATION_JSON.equals(contentHeaderValue));
+  }
+
+  @Override
+  public Future<Instance> findByIdAndUpdate(String id, Instance instance, Context context) {
+    try {
+      var client = java.net.http.HttpClient.newHttpClient();
+      var getRequest = java.net.http.HttpRequest.newBuilder()
+        .uri(URI.create(String.format("%s/%s/%s", context.getOkapiLocation(), storageAddress, id)))
+        .headers(OKAPI_TOKEN_HEADER, context.getToken(),
+          OKAPI_TENANT_HEADER, context.getTenantId(),
+          OKAPI_URL_HEADER, context.getOkapiLocation())
+        .GET()
+        .build();
+
+      var response = client.send(getRequest, java.net.http.HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() == 200) {
+         LOGGER.info("body: {}", response.body());
+         LOGGER.info("jsonObject: {}", new JsonObject(response.body()));
+      }
+
+      return Future.succeededFuture();
+    } catch (Exception e) {
+      LOGGER.error("Error updating instance", e);
+      return Future.failedFuture(e);
+    }
+  }
+
+  private CompletableFuture<Instance> updateInstance(Instance existingInstance, org.folio.Instance mappedInstance) {
+    mappedInstance.setId(existingInstance.getId());
+    JsonObject existing = JsonObject.mapFrom(existingInstance);
+    JsonObject mapped = JsonObject.mapFrom(mappedInstance);
+    JsonObject mergedInstanceAsJson = InstanceUtil.mergeInstances(existing, mapped);
+    Instance mergedInstance = Instance.fromJson(mergedInstanceAsJson);
+    return CompletableFuture.completedFuture(mergedInstance);
   }
 }

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleInstanceCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleInstanceCollection.java
@@ -17,6 +17,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Future;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
@@ -130,7 +131,7 @@ class ExternalStorageModuleInstanceCollection
   }
 
   @Override
-  public Future<Instance> findByIdAndUpdate(String id, Instance instance, Context context) {
+  public Future<String> findByIdAndUpdate(String id, org.folio.Instance mappedInstance, Context context) {
     try {
       var client = java.net.http.HttpClient.newHttpClient();
       var getRequest = java.net.http.HttpRequest.newBuilder()
@@ -145,9 +146,15 @@ class ExternalStorageModuleInstanceCollection
       if (response.statusCode() == 200) {
          LOGGER.info("body: {}", response.body());
          LOGGER.info("jsonObject: {}", new JsonObject(response.body()));
+        ObjectMapper objectMapper = new ObjectMapper();
+        var jsonObj = objectMapper.readValue(response.body(), JsonObject.class);
+        var ins = objectMapper.readValue(response.body(), Instance.class);
+
+        LOGGER.info("jsonObj: {}", jsonObj);
+        LOGGER.info("ins: {}", ins);
       }
 
-      return Future.succeededFuture();
+      return Future.succeededFuture(response.body());
     } catch (Exception e) {
       LOGGER.error("Error updating instance", e);
       return Future.failedFuture(e);

--- a/src/main/java/org/folio/inventory/support/KafkaConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/support/KafkaConsumerVerticle.java
@@ -58,15 +58,16 @@ public abstract class KafkaConsumerVerticle extends AbstractVerticle {
   protected abstract Logger getLogger();
 
   protected KafkaConsumerWrapper<String, String> createConsumer(String eventType, String loadLimitPropertyKey) {
-    return createConsumer(eventType, loadLimitPropertyKey, true);
+    var loadLimit = getLoadLimit(loadLimitPropertyKey);
+    return createConsumer(eventType, loadLimit, true);
   }
 
-  protected KafkaConsumerWrapper<String, String> createConsumer(String eventType, String loadLimitPropertyKey, boolean namespacedTopic) {
+  protected KafkaConsumerWrapper<String, String> createConsumer(String eventType, int loadLimit, boolean namespacedTopic) {
     var kafkaConsumerWrapper = KafkaConsumerWrapper.<String, String>builder()
       .context(context)
       .vertx(vertx)
       .kafkaConfig(getKafkaConfig())
-      .loadLimit(getLoadLimit(loadLimitPropertyKey))
+      .loadLimit(loadLimit)
       .globalLoadSensor(new GlobalLoadSensor())
       .subscriptionDefinition(getSubscriptionDefinition(getKafkaConfig().getEnvId(), eventType, namespacedTopic))
       .build();
@@ -125,6 +126,10 @@ public abstract class KafkaConsumerVerticle extends AbstractVerticle {
 
   protected int getMaxDistributionNumber(String property) {
     return getConsumerProperty(MAX_DISTRIBUTION_NUMBER_TEMPLATE, property, MAX_DISTRIBUTION_NUMBER_DEFAULT);
+  }
+
+  protected int getLoadLimit(String propertyKey, String defaultValue) {
+    return getConsumerProperty(LOAD_LIMIT_TEMPLATE, propertyKey, defaultValue);
   }
 
   private JsonObject getConfig() {


### PR DESCRIPTION
**Purpose:**

Optimistic Locking error is being observed while concurrently handling two or more Marc Bib update events (from the topic srs.marc-bib) which are being consumed at the same time and they are related to the update of the one/same Marc Bib record. Separate instances of consumers tries to handle and then update the instance record by calling the PUT /instance-storage/{instanceID} but receive the OL error.

**Approach:**

- use the same retry approach utilized in other consumers to handle the OL error