### PR TITLE
MODINV-1134 Missing x-okapi-user-id header in communications with inventory-storage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 21.1.0-SNAPSHOT 2024-xx-xx
 * Provide consistent handling with concurrency two or more Marc Bib Update events for the same bib record [MODINV-1100](https://folio-org.atlassian.net/browse/MODINV-1100)
-
+* Missing x-okapi-user-id header in communications with inventory-storage [MODINV-1134](https://folio-org.atlassian.net/browse/MODINV-1134)
 ## 21.0.0 2024-10-29
 * Existing "035" field is not retained the original position in imported record [MODINV-1049](https://folio-org.atlassian.net/browse/MODINV-1049)
 * Update Data Import logic to normalize OCLC 035 values [MODINV-949](https://folio-org.atlassian.net/browse/MODINV-949)

--- a/src/main/java/org/folio/inventory/client/OrdersClient.java
+++ b/src/main/java/org/folio/inventory/client/OrdersClient.java
@@ -69,6 +69,6 @@ public class OrdersClient {
     @SneakyThrows
     private OkapiHttpClient createOkapiHttpClient(Context context) {
         return new OkapiHttpClient(webClient, new URL(context.getOkapiLocation()),
-                context.getTenantId(), context.getToken(), null, null, null);
+                context.getTenantId(), context.getToken(), context.getUserId(), context.getRequestId(), null);
     }
 }

--- a/src/main/java/org/folio/inventory/common/Context.java
+++ b/src/main/java/org/folio/inventory/common/Context.java
@@ -5,4 +5,5 @@ public interface Context {
   String getToken();
   String getOkapiLocation();
   String getUserId();
+  String getRequestId();
 }

--- a/src/main/java/org/folio/inventory/common/MessagingContext.java
+++ b/src/main/java/org/folio/inventory/common/MessagingContext.java
@@ -8,6 +8,8 @@ public class MessagingContext implements Context {
   public static final String TOKEN = "token";
   public static final String OKAPI_LOCATION = "okapiLocation";
   public static final String JOB_ID = "jobId";
+  public static final String USER_ID = "userId";
+  public static final String REQUEST_ID = "requestId";
 
   private final MultiMap headers;
 
@@ -32,7 +34,12 @@ public class MessagingContext implements Context {
 
   @Override
   public String getUserId() {
-    return null;
+    return getHeader(USER_ID);
+  }
+
+  @Override
+  public String getRequestId() {
+    return getHeader(REQUEST_ID);
   }
 
   private String getHeader(String header) {

--- a/src/main/java/org/folio/inventory/common/WebContext.java
+++ b/src/main/java/org/folio/inventory/common/WebContext.java
@@ -37,6 +37,7 @@ public class WebContext implements Context {
     return getHeader(OKAPI_USER_ID_HEADER, "");
   }
 
+  @Override
   public String getRequestId() {
     return getHeader(OKAPI_REQUEST_ID);
   }

--- a/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java
@@ -56,6 +56,7 @@ public class MarcBibUpdateKafkaHandler implements AsyncRecordHandler<String, Str
   private static final String MAPPING_PARAMS_KEY = "MAPPING_PARAMS";
   private static final String CURRENT_RETRY_NUMBER = "CURRENT_RETRY_NUMBER";
   private static final String OKAPI_USER_ID = "x-okapi-user-id";
+  private static final String OKAPI_REQUEST_ID = "x-okapi-request-id";
   private static final int MAX_RETRIES_COUNT = Integer.parseInt(System.getenv().getOrDefault("inventory.di.ol.retry.number", "1"));
 
   private final InstanceUpdateDelegate instanceUpdateDelegate;
@@ -90,7 +91,7 @@ public class MarcBibUpdateKafkaHandler implements AsyncRecordHandler<String, Str
         LOGGER.error(message);
         return Future.failedFuture(message);
       }
-      Context context = EventHandlingUtil.constructContext(instanceEvent.getTenant(), headersMap.get(OKAPI_TOKEN_HEADER), headersMap.get(OKAPI_URL_HEADER), headersMap.get(OKAPI_USER_ID));
+      Context context = EventHandlingUtil.constructContext(instanceEvent.getTenant(), headersMap.get(OKAPI_TOKEN_HEADER), headersMap.get(OKAPI_URL_HEADER), headersMap.get(OKAPI_USER_ID), headersMap.get(OKAPI_REQUEST_ID));
       Record marcBibRecord = instanceEvent.getRecord();
 
       io.vertx.core.Context vertxContext = Vertx.currentContext();

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/util/EventHandlingUtil.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/util/EventHandlingUtil.java
@@ -20,10 +20,10 @@ public final class EventHandlingUtil {
   private EventHandlingUtil() {}
 
   public static Context constructContext(String tenantId, String token, String okapiUrl) {
-    return constructContext(tenantId, token, okapiUrl, null);
+    return constructContext(tenantId, token, okapiUrl, null, null);
   }
 
-  public static Context constructContext(String tenantId, String token, String okapiUrl, String userId) {
+  public static Context constructContext(String tenantId, String token, String okapiUrl, String userId, String requestId) {
     return new Context() {
       @Override
       public String getTenantId() {
@@ -43,6 +43,11 @@ public final class EventHandlingUtil {
       @Override
       public String getUserId() {
         return Optional.ofNullable(userId).orElse("");
+      }
+
+      @Override
+      public String getRequestId() {
+        return Optional.ofNullable(requestId).orElse("");
       }
     };
   }

--- a/src/main/java/org/folio/inventory/domain/CollectionProvider.java
+++ b/src/main/java/org/folio/inventory/domain/CollectionProvider.java
@@ -5,10 +5,10 @@ import org.folio.inventory.domain.items.ItemCollection;
 import org.folio.inventory.domain.user.UserCollection;
 
 public interface CollectionProvider {
-  ItemCollection getItemCollection(String tenantId, String token);
-  HoldingsRecordCollection getHoldingsRecordCollection(String tenantId, String token);
-  InstanceCollection getInstanceCollection(String tenantId, String token);
-  AuthorityRecordCollection getAuthorityCollection(String tenantId, String token);
-  UserCollection getUserCollection(String tenantId, String token);
-  HoldingsRecordsSourceCollection getHoldingsRecordsSourceCollection(String tenantId, String token);
+  ItemCollection getItemCollection(String tenantId, String token, String userId, String requestId);
+  HoldingsRecordCollection getHoldingsRecordCollection(String tenantId, String token, String userId, String requestId);
+  InstanceCollection getInstanceCollection(String tenantId, String token, String userId, String requestId);
+  AuthorityRecordCollection getAuthorityCollection(String tenantId, String token, String userId, String requestId);
+  UserCollection getUserCollection(String tenantId, String token, String userId, String requestId);
+  HoldingsRecordsSourceCollection getHoldingsRecordsSourceCollection(String tenantId, String token, String userId, String requestId);
 }

--- a/src/main/java/org/folio/inventory/storage/Storage.java
+++ b/src/main/java/org/folio/inventory/storage/Storage.java
@@ -47,32 +47,32 @@ public class Storage {
 
   public ItemCollection getItemCollection(Context context) {
     return providerFactory.apply(context).getItemCollection(
-      context.getTenantId(), context.getToken());
+      context.getTenantId(), context.getToken(), context.getUserId(), context.getRequestId());
   }
 
   public InstanceCollection getInstanceCollection(Context context) {
     return providerFactory.apply(context).getInstanceCollection(
-      context.getTenantId(), context.getToken());
+      context.getTenantId(), context.getToken(), context.getUserId(), context.getRequestId());
   }
 
   public HoldingsRecordCollection getHoldingsRecordCollection(Context context) {
     return providerFactory.apply(context).getHoldingsRecordCollection(
-      context.getTenantId(), context.getToken());
+      context.getTenantId(), context.getToken(), context.getUserId(), context.getRequestId());
   }
 
   public HoldingsRecordsSourceCollection getHoldingsRecordsSourceCollection (Context context){
     return providerFactory.apply(context).getHoldingsRecordsSourceCollection(
-      context.getTenantId(), context.getToken()
+      context.getTenantId(), context.getToken(), context.getUserId(), context.getRequestId()
     );
   }
 
   public AuthorityRecordCollection getAuthorityRecordCollection(Context context) {
     return providerFactory.apply(context).getAuthorityCollection(
-      context.getTenantId(), context.getToken());
+      context.getTenantId(), context.getToken(), context.getUserId(), context.getRequestId());
   }
 
   public UserCollection getUserCollection(Context context) {
     return providerFactory.apply(context).getUserCollection(
-      context.getTenantId(), context.getToken());
+      context.getTenantId(), context.getToken(), context.getUserId(), context.getRequestId());
   }
 }

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageCollections.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageCollections.java
@@ -20,38 +20,37 @@ public class ExternalStorageCollections implements CollectionProvider {
   }
 
   @Override
-  public ItemCollection getItemCollection(String tenantId, String token) {
-    return new ExternalStorageModuleItemCollection(baseAddress, tenantId, token,
-      client);
+  public ItemCollection getItemCollection(String tenantId, String token, String userId, String requestId) {
+    return new ExternalStorageModuleItemCollection(baseAddress, tenantId, token, userId, requestId, client);
   }
 
   @Override
-  public HoldingsRecordCollection getHoldingsRecordCollection(String tenantId, String token) {
+  public HoldingsRecordCollection getHoldingsRecordCollection(String tenantId, String token, String userId, String requestId) {
     return new ExternalStorageModuleHoldingsRecordCollection(baseAddress,
-      tenantId, token, client);
+      tenantId, token, userId, requestId, client);
   }
 
   @Override
-  public InstanceCollection getInstanceCollection(String tenantId, String token) {
+  public InstanceCollection getInstanceCollection(String tenantId, String token, String userId, String requestId) {
     return new ExternalStorageModuleInstanceCollection(baseAddress,
-      tenantId, token, client);
+      tenantId, token, userId, requestId, client);
   }
 
   @Override
-  public AuthorityRecordCollection getAuthorityCollection(String tenantId, String token) {
+  public AuthorityRecordCollection getAuthorityCollection(String tenantId, String token, String userId, String requestId) {
     return new ExternalStorageModuleAuthorityRecordCollection(baseAddress,
-        tenantId, token, client);
+        tenantId, token, userId, requestId, client);
   }
 
   @Override
-  public UserCollection getUserCollection(String tenantId, String token) {
+  public UserCollection getUserCollection(String tenantId, String token, String userId, String requestId) {
     return new ExternalStorageModuleUserCollection(baseAddress,
-      tenantId, token, client);
+      tenantId, token, userId, requestId, client);
   }
 
   @Override
-  public HoldingsRecordsSourceCollection getHoldingsRecordsSourceCollection(String tenantId, String token) {
+  public HoldingsRecordsSourceCollection getHoldingsRecordsSourceCollection(String tenantId, String token, String userId, String requestId) {
     return new ExternalStorageModuleHoldingsRecordsSourceCollection(baseAddress,
-      tenantId, token, client);
+      tenantId, token, userId, requestId, client);
   }
 }

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleAuthorityRecordCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleAuthorityRecordCollection.java
@@ -22,10 +22,12 @@ public class ExternalStorageModuleAuthorityRecordCollection
     String baseAddress,
     String tenant,
     String token,
+    String userId,
+    String requestId,
     HttpClient client) {
 
     super(String.format("%s/%s", baseAddress, "authority-storage/authorities"),
-      tenant, token, "authorities", client);
+      tenant, token, userId, requestId,"authorities", client);
   }
 
   @Override

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleCollection.java
@@ -34,6 +34,8 @@ import java.util.stream.Collectors;
 abstract class ExternalStorageModuleCollection<T> {
   private static final String TENANT_HEADER = "X-Okapi-Tenant";
   private static final String TOKEN_HEADER = "X-Okapi-Token";
+  private static final String USER_ID_HEADER = "X-Okapi-User-Id";
+  private static final String REQUEST_ID_HEADER = "X-Okapi-Request-Id";
 
   private static final Logger LOGGER = LogManager.getLogger(ExternalStorageModuleCollection.class);
 
@@ -43,17 +45,23 @@ abstract class ExternalStorageModuleCollection<T> {
   protected final String token;
   protected final String collectionWrapperPropertyName;
   protected final WebClient webClient;
+  protected final String userId;
+  protected final String requestId;
 
   ExternalStorageModuleCollection(
     String storageAddress,
     String tenant,
     String token,
+    String userId,
+    String requestId,
     String collectionWrapperPropertyName,
     HttpClient client) {
 
     this.storageAddress = storageAddress;
     this.tenant = tenant;
     this.token = token;
+    this.userId = userId;
+    this.requestId = requestId;
     this.collectionWrapperPropertyName = collectionWrapperPropertyName;
     this.webClient = WebClient.wrap(client);
   }
@@ -211,7 +219,9 @@ abstract class ExternalStorageModuleCollection<T> {
     return request
       .putHeader(ACCEPT, "application/json, text/plain")
       .putHeader(TENANT_HEADER, tenant)
-      .putHeader(TOKEN_HEADER, token);
+      .putHeader(TOKEN_HEADER, token)
+      .putHeader(USER_ID_HEADER, userId)
+      .putHeader(REQUEST_ID_HEADER, requestId);
   }
 
   protected CompletionStage<Response> mapAsyncResultToCompletionStage(

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollection.java
@@ -30,10 +30,12 @@ class ExternalStorageModuleHoldingsRecordCollection
   ExternalStorageModuleHoldingsRecordCollection(String baseAddress,
                                          String tenant,
                                          String token,
+                                         String userId,
+                                         String requestId,
                                          HttpClient client) {
 
     super(String.format("%s/%s", baseAddress, "holdings-storage/holdings"),
-      tenant, token, "holdingsRecords", client);
+      tenant, token, userId, requestId, "holdingsRecords", client);
   }
 
   @Override

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordsSourceCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordsSourceCollection.java
@@ -22,10 +22,12 @@ public class ExternalStorageModuleHoldingsRecordsSourceCollection
     String baseAddress,
     String tenant,
     String token,
+    String userId,
+    String requestId,
     HttpClient client) {
 
     super(String.format("%s/%s", baseAddress, "holdings-sources"),
-      tenant, token, "holdingsRecordsSources", client);
+      tenant, token, userId, requestId, "holdingsRecordsSources", client);
   }
 
   @Override

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleInstanceCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleInstanceCollection.java
@@ -48,10 +48,12 @@ class ExternalStorageModuleInstanceCollection
     String baseAddress,
     String tenant,
     String token,
+    String userId,
+    String requestId,
     HttpClient client) {
 
     super(format("%s/%s", baseAddress, "instance-storage/instances"),
-      tenant, token, "instances", client);
+      tenant, token, userId, requestId, "instances", client);
 
     batchAddress = format("%s/%s", baseAddress, "instance-storage/batch/instances");
   }

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleItemCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleItemCollection.java
@@ -12,10 +12,10 @@ class ExternalStorageModuleItemCollection
   implements ItemCollection {
 
   ExternalStorageModuleItemCollection(String baseAddress, String tenant,
-    String token, HttpClient client) {
+    String token, String userId, String requestId, HttpClient client) {
 
     super(String.format("%s/%s", baseAddress, "item-storage/items"),
-      tenant, token, "items", client);
+      tenant, token, userId, requestId, "items", client);
   }
 
   @Override

--- a/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleUserCollection.java
+++ b/src/main/java/org/folio/inventory/storage/external/ExternalStorageModuleUserCollection.java
@@ -15,10 +15,12 @@ class ExternalStorageModuleUserCollection
     String baseAddress,
     String tenant,
     String token,
+    String userId,
+    String requestId,
     HttpClient client) {
 
     super(String.format("%s/%s", baseAddress, "users"),
-      tenant, token, "users", client);
+      tenant, token, userId, requestId, "users", client);
   }
 
   @Override

--- a/src/test/java/api/ApiTestSuite.java
+++ b/src/test/java/api/ApiTestSuite.java
@@ -88,6 +88,7 @@ public class ApiTestSuite {
   public static final String USER_ID = "7e115dfb-d1d6-46ac-b2dc-2b3e74cda694";
   public static final String CENTRAL_TENANT_ID_FIELD = "centralTenantId";
   public static final String CONSORTIUM_ID_FIELD = "consortiumId";
+  public static final String REQUEST_ID = "test_request_1234";
 
   private static String bookMaterialTypeId;
   private static String dvdMaterialTypeId;

--- a/src/test/java/org/folio/inventory/storage/external/ExternalInstanceCollectionExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalInstanceCollectionExamples.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external;
 
+import static api.ApiTestSuite.REQUEST_ID;
+import static api.ApiTestSuite.USER_ID;
 import static org.folio.inventory.common.FutureAssistance.fail;
 import static org.folio.inventory.common.FutureAssistance.getOnCompletion;
 import static org.folio.inventory.common.FutureAssistance.succeed;
@@ -35,7 +37,7 @@ public class ExternalInstanceCollectionExamples extends ExternalStorageTests {
 
   private final InstanceCollection collection =
     useHttpClient(client -> new ExternalStorageModuleInstanceCollection(
-      getStorageAddress(), TENANT_ID, TENANT_TOKEN, client));
+      getStorageAddress(), TENANT_ID, TENANT_TOKEN, USER_ID, REQUEST_ID, client));
 
   @Before
   @SneakyThrows

--- a/src/test/java/org/folio/inventory/storage/external/ExternalItemCollectionExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalItemCollectionExamples.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external;
 
+import static api.ApiTestSuite.REQUEST_ID;
+import static api.ApiTestSuite.USER_ID;
 import static org.folio.inventory.common.FutureAssistance.fail;
 import static org.folio.inventory.common.FutureAssistance.getOnCompletion;
 import static org.folio.inventory.common.FutureAssistance.succeed;
@@ -33,7 +35,7 @@ public class ExternalItemCollectionExamples extends ExternalStorageTests {
 
   private final ItemCollection collection = useHttpClient(
     client -> new ExternalStorageModuleItemCollection(getStorageAddress(),
-      TENANT_ID, TENANT_TOKEN, client));
+      TENANT_ID, TENANT_TOKEN, USER_ID, REQUEST_ID, client));
 
   private final Item smallAngryPlanet = smallAngryPlanet();
   private final Item nod = nod();

--- a/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleAuthorityRecordCollectionExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleAuthorityRecordCollectionExamples.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external;
 
+import static api.ApiTestSuite.REQUEST_ID;
+import static api.ApiTestSuite.USER_ID;
 import static org.folio.inventory.common.FutureAssistance.fail;
 import static org.folio.inventory.common.FutureAssistance.getOnCompletion;
 import static org.folio.inventory.common.FutureAssistance.succeed;
@@ -31,7 +33,7 @@ public class ExternalStorageModuleAuthorityRecordCollectionExamples extends Exte
 
   private final ExternalStorageModuleAuthorityRecordCollection storage =
     useHttpClient(client -> new ExternalStorageModuleAuthorityRecordCollection(
-      getStorageAddress(), TENANT_ID, TENANT_TOKEN, client));
+      getStorageAddress(), TENANT_ID, TENANT_TOKEN, USER_ID, REQUEST_ID, client));
 
   @Test
   public void shouldMapFromJson() {

--- a/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollectionExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordCollectionExamples.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external;
 
+import static api.ApiTestSuite.REQUEST_ID;
+import static api.ApiTestSuite.USER_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -16,7 +18,7 @@ public class ExternalStorageModuleHoldingsRecordCollectionExamples extends Exter
 
   private final ExternalStorageModuleHoldingsRecordCollection storage =
     useHttpClient(client -> new ExternalStorageModuleHoldingsRecordCollection(
-      getStorageAddress(), TENANT_ID, TENANT_TOKEN, client));
+      getStorageAddress(), TENANT_ID, TENANT_TOKEN, USER_ID, REQUEST_ID, client));
 
   @Test
   public void shouldMapFromJson() {

--- a/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordsSourceCollectionExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/ExternalStorageModuleHoldingsRecordsSourceCollectionExamples.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external;
 
+import static api.ApiTestSuite.REQUEST_ID;
+import static api.ApiTestSuite.USER_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -14,7 +16,7 @@ import io.vertx.core.json.JsonObject;
 public class ExternalStorageModuleHoldingsRecordsSourceCollectionExamples extends ExternalStorageTests {
   private final ExternalStorageModuleHoldingsRecordsSourceCollection storage =
     useHttpClient(client -> new ExternalStorageModuleHoldingsRecordsSourceCollection(
-      getStorageAddress(), TENANT_ID, TENANT_TOKEN, client));
+      getStorageAddress(), TENANT_ID, TENANT_TOKEN, USER_ID, REQUEST_ID, client));
 
   @Test
   public void shouldMapFromJson() {

--- a/src/test/java/org/folio/inventory/storage/external/failure/ExternalAuthorityCollectionBadRequestExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/failure/ExternalAuthorityCollectionBadRequestExamples.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external.failure;
 
+import static api.ApiTestSuite.REQUEST_ID;
+import static api.ApiTestSuite.USER_ID;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
@@ -190,7 +192,7 @@ class ExternalAuthorityCollectionBadRequestExamples {
     return vertxAssistant.createUsingVertx(
       it -> new ExternalStorageCollections(
         wireMockServer.baseUrl(), it.createHttpClient()))
-      .getAuthorityCollection("test_tenant", "");
+      .getAuthorityCollection("test_tenant", "", USER_ID, REQUEST_ID);
   }
 
   private void assertBadRequest(Failure failure) {

--- a/src/test/java/org/folio/inventory/storage/external/failure/ExternalAuthorityCollectionServerErrorExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/failure/ExternalAuthorityCollectionServerErrorExamples.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external.failure;
 
+import static api.ApiTestSuite.REQUEST_ID;
+import static api.ApiTestSuite.USER_ID;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
@@ -190,7 +192,7 @@ class ExternalAuthorityCollectionServerErrorExamples {
     return vertxAssistant.createUsingVertx(
         it -> new ExternalStorageCollections(
           wireMockServer.baseUrl(), it.createHttpClient()))
-      .getAuthorityCollection("test_tenant", "");
+      .getAuthorityCollection("test_tenant", "", USER_ID, REQUEST_ID);
   }
 
   private void assertServerError(Failure failure) {

--- a/src/test/java/org/folio/inventory/storage/external/failure/ExternalInstanceCollectionBadRequestExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/failure/ExternalInstanceCollectionBadRequestExamples.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external.failure;
 
+import static api.ApiTestSuite.REQUEST_ID;
+import static api.ApiTestSuite.USER_ID;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
@@ -194,7 +196,7 @@ public class ExternalInstanceCollectionBadRequestExamples {
         it -> new ExternalStorageCollections(
           wireMockServer.baseUrl(),
           it.createHttpClient()))
-      .getInstanceCollection("test_tenant", "");
+      .getInstanceCollection("test_tenant", "", USER_ID, REQUEST_ID);
   }
 
   private void assertBadRequest(Failure failure) {

--- a/src/test/java/org/folio/inventory/storage/external/failure/ExternalInstanceCollectionServerErrorExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/failure/ExternalInstanceCollectionServerErrorExamples.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external.failure;
 
+import static api.ApiTestSuite.REQUEST_ID;
+import static api.ApiTestSuite.USER_ID;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
@@ -195,7 +197,7 @@ public class ExternalInstanceCollectionServerErrorExamples {
         it -> new ExternalStorageCollections(
           wireMockServer.baseUrl(),
           it.createHttpClient()))
-      .getInstanceCollection("test_tenant", "");
+      .getInstanceCollection("test_tenant", "", USER_ID, REQUEST_ID);
   }
 
   private void assertServerError(Failure failure) {

--- a/src/test/java/org/folio/inventory/storage/external/failure/ExternalItemCollectionBadRequestExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/failure/ExternalItemCollectionBadRequestExamples.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external.failure;
 
+import static api.ApiTestSuite.REQUEST_ID;
+import static api.ApiTestSuite.USER_ID;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
@@ -200,7 +202,7 @@ public class ExternalItemCollectionBadRequestExamples {
       it -> new ExternalStorageCollections(
         wireMockServer.baseUrl(),
         it.createHttpClient()))
-      .getItemCollection("test_tenant", "");
+      .getItemCollection("test_tenant", "", USER_ID, REQUEST_ID);
   }
 
   private void assertBadRequest(Failure failure) {

--- a/src/test/java/org/folio/inventory/storage/external/failure/ExternalItemCollectionServerErrorExamples.java
+++ b/src/test/java/org/folio/inventory/storage/external/failure/ExternalItemCollectionServerErrorExamples.java
@@ -1,5 +1,7 @@
 package org.folio.inventory.storage.external.failure;
 
+import static api.ApiTestSuite.REQUEST_ID;
+import static api.ApiTestSuite.USER_ID;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
@@ -200,7 +202,7 @@ public class ExternalItemCollectionServerErrorExamples {
         it -> new ExternalStorageCollections(
           wireMockServer.baseUrl(),
           it.createHttpClient()))
-      .getItemCollection("test_tenant", "");
+      .getItemCollection("test_tenant", "", USER_ID, REQUEST_ID);
   }
 
   private void assertServerError(Failure failure) {


### PR DESCRIPTION
### Purpose
[MODINV-1134](https://folio-org.atlassian.net/browse/MODINV-1134) Missing x-okapi-user-id header in communications with inventory-storage

### Approach
* add missing headers
* fix tests