### PR TITLE
MODINV-1151 Handle deduplication in mod-inventory

### DIFF
--- a/src/main/java/org/folio/inventory/consortium/util/InstanceOperationsHelper.java
+++ b/src/main/java/org/folio/inventory/consortium/util/InstanceOperationsHelper.java
@@ -13,7 +13,7 @@ import org.folio.kafka.exception.DuplicateEventException;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
-import static org.folio.inventory.dataimport.util.DataImportConstants.UNIQUE_ID_ERROR_MESSAGE;
+import static org.folio.inventory.dataimport.util.DataImportConstants.ALREADY_EXISTS_ERROR_MSG;
 
 public class InstanceOperationsHelper {
 
@@ -29,7 +29,7 @@ public class InstanceOperationsHelper {
       insertFailure -> {
         try {
           //This is a temporary solution (verify by error message). It will be improved via another solution by https://issues.folio.org/browse/RMB-899.
-          if (isNotBlank(insertFailure.getReason()) && insertFailure.getReason().contains(UNIQUE_ID_ERROR_MESSAGE)) {
+          if (isNotBlank(insertFailure.getReason()) && insertFailure.getReason().contains(String.format(ALREADY_EXISTS_ERROR_MSG, instance.getId()))) {
             LOGGER.info("addInstance :: Duplicated event received by InstanceId={}. Ignoring...", instance.getId());
             promise.fail(new DuplicateEventException(format("Duplicated event by InstanceId=%s", instance.getId())));
           } else {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
@@ -12,7 +12,7 @@ import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlin
 import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.SUBFIELD_I;
 import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.TAG_999;
 import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.reorderMarcRecordFields;
-import static org.folio.inventory.dataimport.util.DataImportConstants.UNIQUE_ID_ERROR_MESSAGE;
+import static org.folio.inventory.dataimport.util.DataImportConstants.ALREADY_EXISTS_ERROR_MSG;
 import static org.folio.inventory.dataimport.util.LoggerUtil.logParametersEventHandler;
 import static org.folio.inventory.dataimport.util.MappingConstants.INSTANCE_PATH;
 import static org.folio.inventory.dataimport.util.MappingConstants.INSTANCE_REQUIRED_FIELDS;
@@ -228,7 +228,7 @@ public class CreateInstanceEventHandler extends AbstractInstanceEventHandler {
     instanceCollection.add(instance, success -> promise.complete(success.getResult()),
       failure -> {
         //This is temporary solution (verify by error message). It will be improved via another solution by https://issues.folio.org/browse/RMB-899.
-        if (isNotBlank(failure.getReason()) && failure.getReason().contains(UNIQUE_ID_ERROR_MESSAGE)) {
+        if (isNotBlank(failure.getReason()) && failure.getReason().contains(String.format(ALREADY_EXISTS_ERROR_MSG, instance.getId()))) {
           LOGGER.info("Duplicated event received by InstanceId: {}. Ignoring...", instance.getId());
           promise.fail(new DuplicateEventException(format("Duplicated event by Instance id: %s", instance.getId())));
         } else {

--- a/src/main/java/org/folio/inventory/dataimport/util/DataImportConstants.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/DataImportConstants.java
@@ -3,6 +3,7 @@ package org.folio.inventory.dataimport.util;
 public class DataImportConstants {
 
   public static final String UNIQUE_ID_ERROR_MESSAGE = "id value already exists in table";
+  public static final String ALREADY_EXISTS_ERROR_MSG = "Key (id)=(%s) already exists";
 
 
   private DataImportConstants() {


### PR DESCRIPTION
### Purpose 
after introducing transactional saving of an instance in mod-inventory-storage
error responses where returning in different format, as PgUtil can not be used as transactional wrapper
[MODINV-1151](https://folio-org.atlassian.net/browse/MODINV-1151)

### Approach
* handle duplicates
* add test