### PR TITLE
MODINV-1155 Add missing required interfaces to Module Descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -606,6 +606,18 @@
   ],
   "requires": [
     {
+      "id": "circulation-bff-ecs-request-external",
+      "version": "1.1"
+    },
+    {
+      "id": "circulation-bff-requests",
+      "version": "1.1"
+    },
+    {
+      "id": "staging-users",
+      "version": "1.1"
+    },
+    {
       "id": "holdings-sources",
       "version": "1.0"
     },


### PR DESCRIPTION
### Purpose
[MODINV-1155](https://folio-org.atlassian.net/browse/MODINV-1155) Add missing required interfaces to Module Descriptor