### PR TITLE
MODINV-1114 - Implement marc bib submatch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
-## 21.1.0-SNAPSHOT 2024-xx-xx
+## 21.1.0-SNAPSHOT 2025-xx-xx
 * Provide consistent handling with concurrency two or more Marc Bib Update events for the same bib record [MODINV-1100](https://folio-org.atlassian.net/browse/MODINV-1100)
 * Enable system user for data-import processes [MODINV-1115](https://folio-org.atlassian.net/browse/MODINV-1115)
 * Missing x-okapi-user-id header in communications with inventory-storage [MODINV-1134](https://folio-org.atlassian.net/browse/MODINV-1134)
+* Implement marc bib submatch [MODINV-1114](https://issues.folio.org/browse/MODINV-1114)
 
 ## 21.0.0 2024-10-29
 * Existing "035" field is not retained the original position in imported record [MODINV-1049](https://folio-org.atlassian.net/browse/MODINV-1049)

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMarcMatchEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMarcMatchEventHandler.java
@@ -208,12 +208,10 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
 
     if (qualifier != null) {
       qualifierValue = qualifier.getQualifierValue();
-      qualifierFilterType =
-        qualifier.getQualifierType() != null ?
-        Filter.Qualifier.valueOf(qualifier.getQualifierType().toString()) : null;
-      comparisonPartType =
-        qualifier.getComparisonPart() != null ?
-        ComparisonPartType.valueOf(qualifier.getComparisonPart().toString()) : null;
+      qualifierFilterType = qualifier.getQualifierType() != null
+        ? Filter.Qualifier.valueOf(qualifier.getQualifierType().toString()) : null;
+      comparisonPartType = qualifier.getComparisonPart() != null
+        ? ComparisonPartType.valueOf(qualifier.getComparisonPart().toString()) : null;
     }
 
     Filter matchCriteriaFilter = new Filter()

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/MarcBibliographicMatchEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/MarcBibliographicMatchEventHandler.java
@@ -22,6 +22,7 @@ import org.folio.rest.jaxrs.model.RecordMatchingDto;
 
 import java.io.UnsupportedEncodingException;
 import java.util.List;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -72,9 +73,9 @@ public class MarcBibliographicMatchEventHandler extends AbstractMarcMatchEventHa
   }
 
   @Override
-  protected Future<Void> ensureRelatedEntities(List<Record> records, DataImportEventPayload eventPayload) {
-    if (records.size() == 1) {
-      Record matchedRecord = records.get(0);
+  protected Future<Void> ensureRelatedEntities(Optional<Record> recordOptional, DataImportEventPayload eventPayload) {
+    if (recordOptional.isPresent()) {
+      Record matchedRecord = recordOptional.get();
       String instanceId = ParsedRecordUtil.getAdditionalSubfieldValue(matchedRecord.getParsedRecord(), AdditionalSubfields.I);
       String matchedRecordTenantId = getTenant(eventPayload);
       Context context = EventHandlingUtil.constructContext(matchedRecordTenantId, eventPayload.getToken(), eventPayload.getOkapiUrl(),

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/MarcBibliographicMatchEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/MarcBibliographicMatchEventHandler.java
@@ -6,6 +6,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.Json;
 import org.folio.DataImportEventPayload;
 import org.folio.HoldingsRecord;
+import org.folio.MatchProfile;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.api.request.PagingParameters;
 import org.folio.inventory.consortium.services.ConsortiumService;
@@ -15,6 +16,7 @@ import org.folio.inventory.dataimport.util.ParsedRecordUtil.AdditionalSubfields;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.domain.instances.InstanceCollection;
 import org.folio.inventory.storage.Storage;
+import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.RecordMatchingDto;
 
@@ -60,6 +62,13 @@ public class MarcBibliographicMatchEventHandler extends AbstractMarcMatchEventHa
   @Override
   protected String getMultiMatchResultKey() {
     return INSTANCES_IDS_KEY;
+  }
+
+  @Override
+  protected boolean canSubMatchProfileProcessMultiMatchResult(MatchProfile matchProfile) {
+    return matchProfile.getExistingRecordType() == EntityType.MARC_BIBLIOGRAPHIC
+      || matchProfile.getExistingRecordType() == EntityType.INSTANCE
+      || matchProfile.getExistingRecordType() == EntityType.HOLDINGS;
   }
 
   @Override

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
@@ -37,6 +37,7 @@ import org.folio.inventory.services.InstanceIdStorageService;
 import org.folio.inventory.storage.Storage;
 import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.inventory.support.http.client.Response;
+import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.processing.mapping.mapper.reader.Reader;
@@ -53,6 +54,7 @@ import org.folio.rest.jaxrs.model.MappingRule;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
+import org.hamcrest.junit.internal.ThrowableCauseMatcher;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -79,6 +81,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.completedStage;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.folio.ActionProfile.FolioRecord.INSTANCE;
@@ -90,16 +93,18 @@ import static org.folio.inventory.TestUtil.buildHttpResponseWithBuffer;
 import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.PAYLOAD_USER_ID;
 import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.TAG_005;
 import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.dateTime005Formatter;
-import static org.folio.inventory.dataimport.util.DataImportConstants.UNIQUE_ID_ERROR_MESSAGE;
+import static org.folio.inventory.dataimport.util.DataImportConstants.ALREADY_EXISTS_ERROR_MSG;
 import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -945,9 +950,8 @@ public class CreateInstanceEventHandlerTest {
     future.get(5, TimeUnit.SECONDS);
   }
 
-
-  @Test(expected = Exception.class)
-  public void shouldNotProcessEventEvenIfDuplicatedInventoryStorageErrorExists() throws InterruptedException, ExecutionException, TimeoutException {
+  @Test()
+  public void shouldNotProcessEventEvenIfDuplicatedInventoryStorageErrorExists() {
     Reader fakeReader = Mockito.mock(Reader.class);
 
     String instanceTypeId = "fe19bae4-da28-472b-be90-d442e2428ead";
@@ -965,7 +969,7 @@ public class CreateInstanceEventHandlerTest {
     when(instanceIdStorageService.store(any(), any(), any())).thenReturn(Future.succeededFuture(recordToInstance));
     doAnswer(invocationOnMock -> {
       Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-      failureHandler.accept(new Failure(UNIQUE_ID_ERROR_MESSAGE, 400));
+      failureHandler.accept(new Failure(format(ALREADY_EXISTS_ERROR_MSG, instanceId), 400));
       return null;
     }).when(instanceRecordCollection).add(any(), any(), any());
 
@@ -989,7 +993,8 @@ public class CreateInstanceEventHandlerTest {
 
     CompletableFuture<DataImportEventPayload> future = createInstanceEventHandler.handle(dataImportEventPayload);
 
-    future.get(5, TimeUnit.SECONDS);
+    ExecutionException actualException = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
+    assertThat(actualException, ThrowableCauseMatcher.hasCause(instanceOf(DuplicateEventException.class)));
   }
 
   @Test(expected = Exception.class)


### PR DESCRIPTION
## Purpose
provide support for narrowing down marc-bib multiple match result using a sub-match profile

## Approach
* use instance ids that represent result of multiple matching from previous matching processing to build additional condition for records matching during sub-match profile processing
* add tests
* additionally: update test to verify the deduplication logic of CreateInstanceEventHandler reliably


## Learning
[MODINV-1114](https://issues.folio.org/browse/MODINV-1114)
