### PR TITLE
Release v21.0.9: MODINV-1125 - Fix handling optimistic locking behavior for instance update when consuming Marc Bib update event

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 21.0.9 2025-01-23
+* Fix handling optimistic locking behavior for instance update when consuming Marc Bib update event  [MODINV-1125](https://folio-org.atlassian.net/browse/MODINV-1125)
+
 ## 21.0.8 2025-01-23
 * Make dependencies on circulation interfaces optional [MODINV-1159](https://folio-org.atlassian.net/browse/MODINV-1159)
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory</artifactId>
   <groupId>org.folio</groupId>
-  <version>21.0.9-SNAPSHOT</version>
+  <version>21.0.9</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -354,7 +354,7 @@
     <url>https://github.com/folio-org/mod-inventory</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory.git</developerConnection>
-    <tag>v21.0.0</tag>
+    <tag>v21.0.9</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory</artifactId>
   <groupId>org.folio</groupId>
-  <version>21.0.9</version>
+  <version>21.0.10-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -354,7 +354,7 @@
     <url>https://github.com/folio-org/mod-inventory</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory.git</developerConnection>
-    <tag>v21.0.9</tag>
+    <tag>v21.0.0</tag>
   </scm>
 
   <build>

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
@@ -59,7 +59,7 @@ public class InstanceUpdateDelegate {
     }
   }
 
-  public Instance handleBlocking(Map<String, String> eventPayload, Record marcRecord, Context context) {
+  public Instance handleBlocking(Map<String, String> eventPayload, Record marcRecord, Context context) throws Exception {
     logParametersUpdateDelegate(LOGGER, eventPayload, marcRecord, context);
     try {
       JsonObject mappingRules = new JsonObject(eventPayload.get(MAPPING_RULES_KEY));

--- a/src/main/java/org/folio/inventory/domain/SynchronousCollection.java
+++ b/src/main/java/org/folio/inventory/domain/SynchronousCollection.java
@@ -5,5 +5,5 @@ import org.folio.inventory.common.Context;
 
 public interface SynchronousCollection<T> {
 
-  T findByIdAndUpdate(String id, JsonObject entity, Context context);
+  T findByIdAndUpdate(String id, JsonObject entity, Context context) throws Exception;
 }


### PR DESCRIPTION
## Purpose:
Fix handling optimistic locking error on updating inventory instance record while handling Marc Bib Update event and implement proper retry mechanism

## Approach:
Do not wrap OptimisticLocking error inside the other one so that it is possible to handle it in the Marc Bib update event handler

## Learning:
[MODSOURCE-832](https://folio-org.atlassian.net/browse/MODSOURCE-832)
[MODINV-1125](https://folio-org.atlassian.net/browse/MODINV-1125)
[MODELINKS-286](https://folio-org.atlassian.net/browse/MODELINKS-286)