### PR TITLE
fix(snapshot-status): Update the snapshot status from PROCESSING_FINISHED to COMMITTED

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Missing x-okapi-user-id header in communications with inventory-storage [MODINV-1134](https://folio-org.atlassian.net/browse/MODINV-1134)
 * Fix handling optimistic locking behavior for instance update when consuming Marc Bib update event  [MODINV-1125](https://folio-org.atlassian.net/browse/MODINV-1125)
 * Replace usage of deprecated instance-storage-batch API  [MODINV-1101](https://folio-org.atlassian.net/browse/MODINV-1101Л)
+* Update the snapshot status from PROCESSING_FINISHED to COMMITTED in the InstanceIngressEventHandler [MODINV-1161](https://folio-org.atlassian.net/browse/MODINV-1161)
 
 ## 21.0.0 2024-10-29
 * Existing "035" field is not retained the original position in imported record [MODINV-1049](https://folio-org.atlassian.net/browse/MODINV-1049)

--- a/src/main/java/org/folio/inventory/instanceingress/handler/InstanceIngressEventHandler.java
+++ b/src/main/java/org/folio/inventory/instanceingress/handler/InstanceIngressEventHandler.java
@@ -12,7 +12,7 @@ import static org.folio.inventory.dataimport.util.MappingConstants.MARC_BIB_RECO
 import static org.folio.inventory.dataimport.util.MappingConstants.MARC_BIB_RECORD_TYPE;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
-import static org.folio.rest.jaxrs.model.Snapshot.Status.PROCESSING_FINISHED;
+import static org.folio.rest.jaxrs.model.Snapshot.Status.COMMITTED;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.Json;
@@ -21,7 +21,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -159,7 +158,7 @@ public interface InstanceIngressEventHandler {
     var snapshot = new Snapshot()
       .withJobExecutionId(id)
       .withProcessingStartedDate(new Date())
-      .withStatus(PROCESSING_FINISHED);
+      .withStatus(COMMITTED);
     return postSnapshotFunction.apply(context, snapshot);
   }
 }


### PR DESCRIPTION
[MODINV-1161](https://folio-org.atlassian.net/browse/MODINV-1161)
Update the snapshot status from `PROCESSING_FINISHED` to `COMMITTED`, as  the snapshot with the `PROCESSING_FINISHED` status does not work correctly during the process of persisting the record in the SRS module, which results in two records with the `ACTUAL` state for the same `matched_id` in the `records_lb` table.
For example:
<kbd>
![image](https://github.com/user-attachments/assets/08b39b7e-e54d-4499-93b7-6dba0f01873a)
</kbd>
