### PR TITLE
[MODINV-1162] Send in userId in headers for modules clients requests

### DIFF
--- a/src/main/java/org/folio/inventory/client/SourceStorageRecordsClientWrapper.java
+++ b/src/main/java/org/folio/inventory/client/SourceStorageRecordsClientWrapper.java
@@ -1,0 +1,114 @@
+package org.folio.inventory.client;
+
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import org.folio.rest.client.SourceStorageRecordsClient;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.tools.ClientHelpers;
+import org.folio.util.PercentCodec;
+
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.OKAPI_TENANT;
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.OKAPI_TOKEN;
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.OKAPI_URL;
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.OKAPI_USER_ID;
+
+public class SourceStorageRecordsClientWrapper extends SourceStorageRecordsClient {
+  private final String tenantId;
+  private final String token;
+  private final String okapiUrl;
+  private final String userId;
+  private final WebClient webClient;
+
+  public SourceStorageRecordsClientWrapper(String tenantId, String token, String okapiUrl, String userId, HttpClient httpClient) {
+    super(tenantId, token, okapiUrl, httpClient);
+    this.tenantId = tenantId;
+    this.token = token;
+    this.okapiUrl = okapiUrl;
+    this.userId = userId;
+    this.webClient = WebClient.wrap(httpClient);
+  }
+
+  @Override
+  public Future<HttpResponse<Buffer>> postSourceStorageRecords(Record Record) {
+    Buffer buffer = Buffer.buffer();
+    if (Record != null) {
+      buffer.appendString(ClientHelpers.pojo2json(Record));
+    }
+
+    HttpRequest<Buffer> request = this.webClient.requestAbs(HttpMethod.POST, okapiUrl + "/source-storage/records");
+    request.putHeader("Content-type", "application/json");
+    request.putHeader("Accept", "application/json,text/plain");
+
+    populateOkapiHeaders(request);
+
+    return request.sendBuffer(buffer);
+  }
+
+  @Override
+  public Future<HttpResponse<Buffer>> putSourceStorageRecordsById(String id, Record Record) {
+    Buffer buffer = Buffer.buffer();
+    if (Record != null) {
+      buffer.appendString(ClientHelpers.pojo2json(Record));
+    }
+
+    HttpRequest<Buffer> request = this.webClient.requestAbs(HttpMethod.PUT, this.okapiUrl + "/source-storage/records/" + id);
+    request.putHeader("Content-type", "application/json");
+    request.putHeader("Accept", "application/json,text/plain");
+    populateOkapiHeaders(request);
+
+    return request.sendBuffer(buffer);
+  }
+
+  @Override
+  public Future<HttpResponse<Buffer>> putSourceStorageRecordsGenerationById(String id, Record Record) {
+    Buffer buffer = Buffer.buffer();
+    if (Record != null) {
+      buffer.appendString(ClientHelpers.pojo2json(Record));
+    }
+
+    HttpRequest<Buffer> request = this.webClient.requestAbs(HttpMethod.PUT, this.okapiUrl + "/source-storage/records/" + id + "/generation");
+    request.putHeader("Content-type", "application/json");
+    request.putHeader("Accept", "application/json");
+    populateOkapiHeaders(request);
+
+    return request.sendBuffer(buffer);
+  }
+
+  @Override
+  public Future<HttpResponse<Buffer>> putSourceStorageRecordsSuppressFromDiscoveryById(String id, String idType, boolean suppress) {
+    StringBuilder queryParams = new StringBuilder("?");
+    if (idType != null) {
+      queryParams.append("idType=");
+      queryParams.append(PercentCodec.encode(idType));
+      queryParams.append("&");
+    }
+
+    queryParams.append("suppress=");
+    queryParams.append(suppress);
+    HttpRequest<Buffer> request = this.webClient.requestAbs(HttpMethod.PUT, this.okapiUrl + "/source-storage/records/" + id + "/suppress-from-discovery" + queryParams);
+    request.putHeader("Accept", "application/json,text/plain");
+    populateOkapiHeaders(request);
+
+    return request.send();
+  }
+
+  private void populateOkapiHeaders(HttpRequest<Buffer> request) {
+    if (this.tenantId != null) {
+      request.putHeader(OKAPI_TOKEN, this.token);
+      request.putHeader(OKAPI_TENANT, this.tenantId);
+    }
+
+    if (this.userId != null) {
+      request.putHeader(OKAPI_USER_ID, this.userId);
+    }
+
+    if (this.okapiUrl != null) {
+      request.putHeader(OKAPI_URL, this.okapiUrl);
+    }
+  }
+}

--- a/src/main/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImpl.java
+++ b/src/main/java/org/folio/inventory/consortium/handlers/MarcInstanceSharingHandlerImpl.java
@@ -12,6 +12,7 @@ import org.folio.Authority;
 import org.folio.Link;
 import org.folio.LinkingRuleDto;
 import org.folio.Record;
+import org.folio.inventory.client.SourceStorageRecordsClientWrapper;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.api.request.PagingParameters;
 import org.folio.inventory.consortium.entities.SharingInstance;
@@ -282,10 +283,11 @@ public class MarcInstanceSharingHandlerImpl implements InstanceSharingHandler {
 
   public SourceStorageRecordsClient getSourceStorageRecordsClient(String tenant, Map<String, String> kafkaHeaders) {
     LOGGER.info("getSourceStorageRecordsClient :: Creating SourceStorageRecordsClient for tenant={}", tenant);
-    return new SourceStorageRecordsClient(
+    return new SourceStorageRecordsClientWrapper(
       kafkaHeaders.get(OKAPI_URL_HEADER),
       tenant,
       kafkaHeaders.get(OKAPI_TOKEN_HEADER),
+      kafkaHeaders.get(OKAPI_USER_ID),
       vertx.createHttpClient());
   }
 

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
@@ -151,7 +151,8 @@ public class CreateInstanceEventHandler extends AbstractInstanceEventHandler {
                   var content = reorderMarcRecordFields(sourceContent, targetContent);
                   targetRecord.setParsedRecord(targetRecord.getParsedRecord().withContent(content));
                   setSuppressFormDiscovery(targetRecord, instanceAsJson.getBoolean(DISCOVERY_SUPPRESS_PROPERTY, false));
-                  return saveRecordInSrsAndHandleResponse(dataImportEventPayload, targetRecord, createdInstance, instanceCollection, dataImportEventPayload.getTenant());
+                  return saveRecordInSrsAndHandleResponse(dataImportEventPayload, targetRecord, createdInstance, instanceCollection,
+                    dataImportEventPayload.getTenant(), context.getUserId());
                 });
             })
             .onSuccess(ar -> {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
@@ -229,7 +229,8 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
           .compose(instance -> {
             if (instanceToUpdate.getSource().equals(FOLIO.getValue())) {
               executeFieldsManipulation(instance, targetRecord);
-              return saveRecordInSrsAndHandleResponse(dataImportEventPayload, targetRecord, instance, instanceCollection, tenantId);
+              return saveRecordInSrsAndHandleResponse(dataImportEventPayload, targetRecord, instance, instanceCollection,
+                tenantId, context.getUserId());
             }
             if (instanceToUpdate.getSource().equals(MARC.getValue())) {
               setExternalIds(targetRecord, instance);
@@ -238,7 +239,8 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
               JsonObject jsonInstance = new JsonObject(instance.getJsonForStorage().encode());
 
               setSuppressFormDiscovery(targetRecord, jsonInstance.getBoolean(DISCOVERY_SUPPRESS_KEY, false));
-              return putRecordInSrsAndHandleResponse(dataImportEventPayload, targetRecord, instance, targetRecord.getMatchedId(), tenantId);
+              return putRecordInSrsAndHandleResponse(dataImportEventPayload, targetRecord, instance,
+                targetRecord.getMatchedId(), tenantId, context.getUserId());
             }
             return Future.succeededFuture(instance);
           }).compose(ar -> getPrecedingSucceedingTitlesHelper().createPrecedingSucceedingTitles(mappedInstance, context).map(ar))
@@ -332,7 +334,7 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
                                                List<MarcFieldProtectionSetting> marcFieldProtectionSettings,
                                                Instance instance, MappingParameters mappingParameters, String tenantId) {
     if (MARC_INSTANCE_SOURCE.equals(instance.getSource()) || CONSORTIUM_MARC.getValue().equals(instance.getSource())) {
-      SourceStorageRecordsClient client = getSourceStorageRecordsClient(dataImportEventPayload.getOkapiUrl(), dataImportEventPayload.getToken(), tenantId);
+      SourceStorageRecordsClient client = getSourceStorageRecordsClient(dataImportEventPayload.getOkapiUrl(), dataImportEventPayload.getToken(), tenantId, null);
       return getRecordByInstanceId(client, instance.getId())
         .compose(existingRecord -> {
           Record incomingRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/modify/AbstractModifyEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/modify/AbstractModifyEventHandler.java
@@ -12,6 +12,7 @@ import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
 import org.folio.MappingMetadataDto;
 import org.folio.MappingProfile;
+import org.folio.inventory.client.SourceStorageRecordsClientWrapper;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.exceptions.OptimisticLockingException;
@@ -266,7 +267,8 @@ public abstract class AbstractModifyEventHandler implements EventHandler {
   }
 
   public SourceStorageRecordsClient getSourceStorageRecordsClient(Context context) {
-    return new SourceStorageRecordsClient(context.getOkapiLocation(), context.getTenantId(), context.getToken(), client);
+    return new SourceStorageRecordsClientWrapper(context.getOkapiLocation(), context.getTenantId(),
+      context.getToken(), context.getUserId(), client);
   }
 
   private void preparePayload(DataImportEventPayload dataImportEventPayload) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMarcMatchEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMarcMatchEventHandler.java
@@ -12,6 +12,7 @@ import org.folio.DataImportEventPayload;
 import org.folio.DataImportEventTypes;
 import org.folio.MatchDetail;
 import org.folio.MatchProfile;
+import org.folio.inventory.client.SourceStorageRecordsClientWrapper;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.consortium.services.ConsortiumService;
 import org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil;
@@ -47,7 +48,6 @@ import static java.lang.String.format;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.PAYLOAD_USER_ID;
 import static org.folio.processing.value.Value.ValueType.MISSING;
-import static org.folio.rest.jaxrs.model.Filter.*;
 import static org.folio.rest.jaxrs.model.MatchExpression.DataValueType.VALUE_FROM_RECORD;
 import static org.folio.rest.jaxrs.model.ProfileType.MATCH_PROFILE;
 
@@ -95,8 +95,9 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
         LOG.warn("handle:: {}", PAYLOAD_HAS_NO_DATA_MESSAGE);
         return CompletableFuture.failedFuture(new EventProcessingException(PAYLOAD_HAS_NO_DATA_MESSAGE));
       }
+      String userId = context.get(USER_ID_HEADER);
       payload.getEventsChain().add(payload.getEventType());
-      payload.setAdditionalProperty(USER_ID_HEADER, context.get(USER_ID_HEADER));
+      payload.setAdditionalProperty(USER_ID_HEADER, userId);
 
       String recordAsString = context.get(getMarcType());
       MatchDetail matchDetail = retrieveMatchDetail(payload);
@@ -114,7 +115,7 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
       }
 
       RecordMatchingDto recordMatchingDto = buildRecordsMatchingRequest(matchDetail, value);
-      return retrieveMarcRecords(recordMatchingDto, payload.getTenant(), payload)
+      return retrieveMarcRecords(recordMatchingDto, payload.getTenant(), userId, payload)
         .compose(localMatchedRecords -> {
           if (isMatchingOnCentralTenantRequired()) {
             return matchCentralTenantIfNeededAndCombineWithLocalMatchedRecords(recordMatchingDto, payload, localMatchedRecords);
@@ -198,7 +199,7 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
 
     Qualifier qualifier = matchDetail.getExistingMatchExpression().getQualifier();
     Filter.Qualifier qualifierFilterType = null;
-    ComparisonPartType comparisonPartType = null;
+    Filter.ComparisonPartType comparisonPartType = null;
     String qualifierValue = null;
 
     if (qualifier != null) {
@@ -208,7 +209,7 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
         Filter.Qualifier.valueOf(qualifier.getQualifierType().toString()) : null;
       comparisonPartType =
         qualifier.getComparisonPart() != null ?
-        ComparisonPartType.valueOf(qualifier.getComparisonPart().toString()) : null;
+        Filter.ComparisonPartType.valueOf(qualifier.getComparisonPart().toString()) : null;
     }
 
     return new RecordMatchingDto()
@@ -225,10 +226,10 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
       .withReturnTotalRecordsCount(true);
   }
 
-  private Future<Optional<Record>> retrieveMarcRecords(RecordMatchingDto recordMatchingDto, String tenantId,
+  private Future<Optional<Record>> retrieveMarcRecords(RecordMatchingDto recordMatchingDto, String tenantId, String userId,
                                                        DataImportEventPayload payload) {
     SourceStorageRecordsClient sourceStorageRecordsClient =
-      new SourceStorageRecordsClient(payload.getOkapiUrl(), tenantId, payload.getToken(), httpClient);
+      new SourceStorageRecordsClientWrapper(payload.getOkapiUrl(), tenantId, payload.getToken(), userId, httpClient);
 
     return getAllMatchedRecordsIdentifiers(recordMatchingDto, payload, sourceStorageRecordsClient)
       .compose(recordsIdentifiersCollection -> {
@@ -332,7 +333,7 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
           LOG.debug("matchCentralTenantIfNeededAndCombineWithLocalMatchedRecords:: Matching on centralTenant with id: {}",
             consortiumConfigurationOptional.get().getCentralTenantId());
 
-          return retrieveMarcRecords(recordMatchingDto, consortiumConfigurationOptional.get().getCentralTenantId(), payload)
+          return retrieveMarcRecords(recordMatchingDto, consortiumConfigurationOptional.get().getCentralTenantId(), context.getUserId(), payload)
             .map(centralRecordOptional -> {
               centralRecordOptional.ifPresent(r -> payload.getContext().put(CENTRAL_TENANT_ID_KEY, consortiumConfigurationOptional.get().getCentralTenantId()));
               return Stream.concat(localMatchedRecord.stream(), centralRecordOptional.stream()).toList();

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/util/EventHandlingUtil.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/util/EventHandlingUtil.java
@@ -15,6 +15,9 @@ import java.util.Optional;
 
 public final class EventHandlingUtil {
   public static final String PAYLOAD_USER_ID = "userId";
+  public static final String OKAPI_TENANT = "x-okapi-tenant";
+  public static final String OKAPI_TOKEN = "x-okapi-token";
+  public static final String OKAPI_URL = "x-okapi-url";
   public static final String OKAPI_USER_ID = "x-okapi-user-id";
   public static final String OKAPI_REQUEST_ID = "x-okapi-request-id";
   private static final String CENTRAL_TENANT_ID = "CENTRAL_TENANT_ID";

--- a/src/main/java/org/folio/inventory/instanceingress/handler/CreateInstanceIngressEventHandler.java
+++ b/src/main/java/org/folio/inventory/instanceingress/handler/CreateInstanceIngressEventHandler.java
@@ -99,7 +99,7 @@ public class CreateInstanceIngressEventHandler extends CreateInstanceEventHandle
     postSnapshotInSrsAndHandleResponse(srcRecord.getSnapshotId(), context, super::postSnapshotInSrsAndHandleResponse)
       .onFailure(promise::fail)
       .compose(snapshot -> {
-        getSourceStorageRecordsClient(context.getOkapiLocation(), context.getToken(), context.getTenantId())
+        getSourceStorageRecordsClient(context.getOkapiLocation(), context.getToken(), context.getTenantId(), context.getUserId())
           .postSourceStorageRecords(srcRecord)
           .onComplete(ar -> {
             var result = ar.result();

--- a/src/main/java/org/folio/inventory/instanceingress/handler/UpdateInstanceIngressEventHandler.java
+++ b/src/main/java/org/folio/inventory/instanceingress/handler/UpdateInstanceIngressEventHandler.java
@@ -123,7 +123,7 @@ public class UpdateInstanceIngressEventHandler extends ReplaceInstanceEventHandl
 
   private Future<Instance> putRecordInSrsAndHandleResponse(Record targetRecord, Instance instance) {
     Promise<Instance> promise = Promise.promise();
-    var sourceStorageRecordsClient = getSourceStorageRecordsClient(context.getOkapiLocation(), context.getToken(), context.getTenantId());
+    var sourceStorageRecordsClient = getSourceStorageRecordsClient(context.getOkapiLocation(), context.getToken(), context.getTenantId(), context.getUserId());
     postSnapshotInSrsAndHandleResponse(targetRecord.getSnapshotId(), context, super::postSnapshotInSrsAndHandleResponse)
       .onFailure(promise::fail)
       .compose(snapshot -> super.getRecordByInstanceId(sourceStorageRecordsClient, instance.getId()))

--- a/src/main/java/org/folio/inventory/resources/Holdings.java
+++ b/src/main/java/org/folio/inventory/resources/Holdings.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.folio.HoldingsRecord;
 import org.folio.HttpStatus;
+import org.folio.inventory.client.SourceStorageRecordsClientWrapper;
 import org.folio.inventory.common.WebContext;
 import org.folio.inventory.config.InventoryConfiguration;
 import org.folio.inventory.config.InventoryConfigurationImpl;
@@ -38,7 +39,6 @@ import org.folio.inventory.exceptions.NotFoundException;
 import org.folio.inventory.exceptions.UnprocessableEntityException;
 import org.folio.inventory.storage.Storage;
 import org.folio.inventory.support.http.server.FailureResponseConsumer;
-import org.folio.rest.client.SourceStorageRecordsClient;
 
 public class Holdings {
 
@@ -163,7 +163,8 @@ public class Holdings {
 
   private void updateSuppressFromDiscoveryFlag(WebContext wContext, RoutingContext rContext, HoldingsRecord updatedHoldings) {
     try {
-      new SourceStorageRecordsClient(wContext.getOkapiLocation(), wContext.getTenantId(), wContext.getToken(), client)
+      new SourceStorageRecordsClientWrapper(wContext.getOkapiLocation(), wContext.getTenantId(),
+        wContext.getToken(), wContext.getUserId(), client)
         .putSourceStorageRecordsSuppressFromDiscoveryById(updatedHoldings.getId(), HOLDING_ID_TYPE, updatedHoldings.getDiscoverySuppress(), httpClientResponse -> {
           if (httpClientResponse.result().statusCode() == HttpStatus.HTTP_OK.toInt()) {
             LOGGER.info(format("Suppress from discovery flag was updated for record in SRS. Holding id: %s",

--- a/src/test/java/org/folio/inventory/client/SourceStorageRecordsClientWrapperTest.java
+++ b/src/test/java/org/folio/inventory/client/SourceStorageRecordsClientWrapperTest.java
@@ -1,0 +1,135 @@
+package org.folio.inventory.client;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.client.HttpResponse;
+import org.folio.rest.jaxrs.model.Record;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.buffer.Buffer;
+import java.util.UUID;
+
+import static api.ApiTestSuite.TENANT_ID;
+import static com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus.SC_CREATED;
+import static com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus.SC_OK;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.OKAPI_TENANT;
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.OKAPI_TOKEN;
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.OKAPI_USER_ID;
+
+@RunWith(VertxUnitRunner.class)
+public class SourceStorageRecordsClientWrapperTest {
+  public static final String RECORD = "Record";
+  private final Vertx vertx = Vertx.vertx();
+  private SourceStorageRecordsClientWrapper sourceStorageRecordsClientWrapper;
+  private Record stubRecord;
+  private static final String TOKEN = "token";
+  private static final String USER_ID = "userId";
+
+  @Rule
+  public WireMockRule mockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new Slf4jNotifier(true)));
+
+  @Before
+  public void setUp() {
+    sourceStorageRecordsClientWrapper = new SourceStorageRecordsClientWrapper(TENANT_ID, TOKEN, mockServer.baseUrl(), USER_ID,
+      vertx.createHttpClient());
+
+    stubRecord = new Record().withId(UUID.randomUUID().toString());
+
+    WireMock.stubFor(post(new UrlPathPattern(new RegexPattern("/source-storage/records"), true))
+      .withHeader(OKAPI_TOKEN, equalTo(TOKEN))
+      .withHeader(OKAPI_TENANT, equalTo(TENANT_ID))
+      .withHeader(OKAPI_USER_ID, equalTo(USER_ID))
+      .willReturn(WireMock.created()));
+
+    WireMock.stubFor(put(new UrlPathPattern(new RegexPattern("/source-storage/records/" + stubRecord.getId()), true))
+      .withHeader(OKAPI_TOKEN, equalTo(TOKEN))
+      .withHeader(OKAPI_TENANT, equalTo(TENANT_ID))
+      .withHeader(OKAPI_USER_ID, equalTo(USER_ID))
+      .willReturn(WireMock.ok()));
+
+    WireMock.stubFor(put(new UrlPathPattern(new RegexPattern("/source-storage/records/" + stubRecord.getId() + "/generation"), true))
+      .withHeader(OKAPI_TOKEN, equalTo(TOKEN))
+      .withHeader(OKAPI_TENANT, equalTo(TENANT_ID))
+      .withHeader(OKAPI_USER_ID, equalTo(USER_ID))
+      .willReturn(WireMock.ok()));
+
+    WireMock.stubFor(put(new UrlPathPattern(new RegexPattern("/source-storage/records/" + stubRecord.getId() + "/suppress-from-discovery"), true))
+      .withQueryParam("idType", equalTo(RECORD))
+      .withQueryParam("suppress", equalTo("true"))
+      .withHeader(OKAPI_TOKEN, equalTo(TOKEN))
+      .withHeader(OKAPI_TENANT, equalTo(TENANT_ID))
+      .withHeader(OKAPI_USER_ID, equalTo(USER_ID))
+      .willReturn(WireMock.ok()));
+  }
+
+  @Test
+  public void shouldPostSourceStorageRecords(TestContext context) {
+    Async async = context.async();
+
+    Future<HttpResponse<Buffer>> optionalFuture = sourceStorageRecordsClientWrapper.postSourceStorageRecords(stubRecord);
+
+    optionalFuture.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertEquals(ar.result().statusCode(), SC_CREATED);
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldPutSourceStorageRecordsById(TestContext context) {
+    Async async = context.async();
+
+    Future<HttpResponse<Buffer>> optionalFuture = sourceStorageRecordsClientWrapper.putSourceStorageRecordsById(stubRecord.getId(), stubRecord);
+
+    optionalFuture.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertEquals(ar.result().statusCode(), SC_OK);
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldPutSourceStorageRecordsGenerationById(TestContext context) {
+    Async async = context.async();
+
+    Future<HttpResponse<Buffer>> optionalFuture = sourceStorageRecordsClientWrapper.putSourceStorageRecordsGenerationById(stubRecord.getId(), stubRecord);
+
+    optionalFuture.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertEquals(ar.result().statusCode(), SC_OK);
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldPutSourceStorageRecordsSuppressFromDiscoveryById(TestContext context) {
+    Async async = context.async();
+
+    Future<HttpResponse<Buffer>> optionalFuture = sourceStorageRecordsClientWrapper
+      .putSourceStorageRecordsSuppressFromDiscoveryById(stubRecord.getId(), RECORD, true);
+
+    optionalFuture.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertEquals(ar.result().statusCode(), SC_OK);
+      async.complete();
+    });
+  }
+}

--- a/src/test/java/org/folio/inventory/instanceingress/handler/UpdateInstanceIngressEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/instanceingress/handler/UpdateInstanceIngressEventHandlerUnitTest.java
@@ -12,7 +12,7 @@ import static org.folio.inventory.dataimport.util.MappingConstants.MARC_BIB_RECO
 import static org.folio.rest.jaxrs.model.InstanceIngressPayload.SourceType.LINKED_DATA;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -62,6 +62,10 @@ import org.mockito.junit.MockitoRule;
 public class UpdateInstanceIngressEventHandlerUnitTest {
   private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/bib-rules.json";
   private static final String BIB_RECORD_PATH = "src/test/resources/handlers/bib-record.json";
+  public static final String TENANT = "tenant";
+  public static final String OKAPI_URL = "okapiUrl";
+  public static final String TOKEN = "token";
+  public static final String USER_ID = "userId";
 
   @Rule
   public MockitoRule initRule = MockitoJUnit.rule();
@@ -85,9 +89,10 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
 
   @Before
   public void setUp() {
-    doReturn("tenant").when(context).getTenantId();
-    doReturn("okapiUrl").when(context).getOkapiLocation();
-    doReturn("token").when(context).getToken();
+    doReturn(TENANT).when(context).getTenantId();
+    doReturn(OKAPI_URL).when(context).getOkapiLocation();
+    doReturn(TOKEN).when(context).getToken();
+    doReturn(USER_ID).when(context).getUserId();
     doReturn(instanceCollection).when(storage).getInstanceCollection(context);
     handler = spy(new UpdateInstanceIngressEventHandler(precedingSucceedingTitlesHelper,
       mappingMetadataCache, httpClient, context, storage));
@@ -332,7 +337,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     var titles = List.of(JsonObject.of("id", "123"));
     doReturn(succeededFuture(titles)).when(precedingSucceedingTitlesHelper).getExistingPrecedingSucceedingTitles(any(), any());
     doReturn(succeededFuture()).when(precedingSucceedingTitlesHelper).deletePrecedingSucceedingTitles(any(), any());
-    doReturn(sourceStorageClient).when(handler).getSourceStorageRecordsClient(any(), any(), any());
+    doReturn(sourceStorageClient).when(handler).getSourceStorageRecordsClient(any(), any(), any(), any());
     doReturn(sourceStorageSnapshotsClient).when(handler).getSourceStorageSnapshotsClient(any(), any(), any());
     var snapshotHttpResponse = buildHttpResponseWithBuffer(HttpStatus.SC_BAD_REQUEST);
     doReturn(succeededFuture(snapshotHttpResponse)).when(sourceStorageSnapshotsClient).postSourceStorageSnapshots(any());
@@ -375,7 +380,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     var titles = List.of(JsonObject.of("id", "123"));
     doReturn(succeededFuture(titles)).when(precedingSucceedingTitlesHelper).getExistingPrecedingSucceedingTitles(any(), any());
     doReturn(succeededFuture()).when(precedingSucceedingTitlesHelper).deletePrecedingSucceedingTitles(any(), any());
-    doReturn(sourceStorageClient).when(handler).getSourceStorageRecordsClient(any(), any(), any());
+    doReturn(sourceStorageClient).when(handler).getSourceStorageRecordsClient(any(), any(), any(), any());
     doReturn(sourceStorageSnapshotsClient).when(handler).getSourceStorageSnapshotsClient(any(), any(), any());
     var snapshotHttpResponse = buildHttpResponseWithBuffer(HttpStatus.SC_CREATED);
     doReturn(succeededFuture(snapshotHttpResponse)).when(sourceStorageSnapshotsClient).postSourceStorageSnapshots(any());
@@ -421,7 +426,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     var titles = List.of(JsonObject.of("id", "123"));
     doReturn(succeededFuture(titles)).when(precedingSucceedingTitlesHelper).getExistingPrecedingSucceedingTitles(any(), any());
     doReturn(succeededFuture()).when(precedingSucceedingTitlesHelper).deletePrecedingSucceedingTitles(any(), any());
-    doReturn(sourceStorageClient).when(handler).getSourceStorageRecordsClient(any(), any(), any());
+    doReturn(sourceStorageClient).when(handler).getSourceStorageRecordsClient(any(), any(), any(), any());
     doReturn(sourceStorageSnapshotsClient).when(handler).getSourceStorageSnapshotsClient(any(), any(), any());
     var snapshotHttpResponse = buildHttpResponseWithBuffer(HttpStatus.SC_CREATED);
     doReturn(succeededFuture(snapshotHttpResponse)).when(sourceStorageSnapshotsClient).postSourceStorageSnapshots(any());
@@ -468,7 +473,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     var titles = List.of(JsonObject.of("id", "123"));
     doReturn(succeededFuture(titles)).when(precedingSucceedingTitlesHelper).getExistingPrecedingSucceedingTitles(any(), any());
     doReturn(succeededFuture()).when(precedingSucceedingTitlesHelper).deletePrecedingSucceedingTitles(any(), any());
-    doReturn(sourceStorageClient).when(handler).getSourceStorageRecordsClient(any(), any(), any());
+    doReturn(sourceStorageClient).when(handler).getSourceStorageRecordsClient(any(), any(), any(), any());
     doReturn(sourceStorageSnapshotsClient).when(handler).getSourceStorageSnapshotsClient(any(), any(), any());
     var snapshotHttpResponse = buildHttpResponseWithBuffer(HttpStatus.SC_CREATED);
     doReturn(succeededFuture(snapshotHttpResponse)).when(sourceStorageSnapshotsClient).postSourceStorageSnapshots(any());
@@ -522,7 +527,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     var titles = List.of(JsonObject.of("id", "123"));
     doReturn(succeededFuture(titles)).when(precedingSucceedingTitlesHelper).getExistingPrecedingSucceedingTitles(any(), any());
     doReturn(succeededFuture()).when(precedingSucceedingTitlesHelper).deletePrecedingSucceedingTitles(any(), any());
-    doReturn(sourceStorageClient).when(handler).getSourceStorageRecordsClient(any(), any(), any());
+    doReturn(sourceStorageClient).when(handler).getSourceStorageRecordsClient(any(), any(), any(), any());
     doReturn(sourceStorageSnapshotsClient).when(handler).getSourceStorageSnapshotsClient(any(), any(), any());
     var snapshotHttpResponse = buildHttpResponseWithBuffer(HttpStatus.SC_CREATED);
     doReturn(succeededFuture(snapshotHttpResponse)).when(sourceStorageSnapshotsClient).postSourceStorageSnapshots(any());
@@ -546,6 +551,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
 
     var recordCaptor = ArgumentCaptor.forClass(Record.class);
     verify(sourceStorageClient).putSourceStorageRecordsGenerationById(any(), recordCaptor.capture());
+    verify(handler).getSourceStorageRecordsClient(any(), any(), argThat(TENANT::equals), argThat(USER_ID::equals));
     var recordSentToSRS = recordCaptor.getValue();
     assertThat(recordSentToSRS.getId()).isNotNull();
     assertThat(recordSentToSRS.getId()).isNotEqualTo(initialSrsId);


### PR DESCRIPTION
### Purpose
"Source" value in QuickMarc editor is not equal to the name of a user who imported the record
### Approach
 Send in userId in headers for modules clients requests
### Jira
https://folio-org.atlassian.net/browse/MODINV-1162