### PR TITLE
MODINV-1168 - Actualize condition of deduplication logic for authority creation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 * Add "deleted" field to Instance schema [MODINVSTOR-1342](https://folio-org.atlassian.net/browse/MODINVSTOR-1342)
 * Adjust /mark-deleted endpoint behavior to set the "deleted" flag [MODINV-1138](https://folio-org.atlassian.net/browse/MODINV-1138)
 * Implement marc bib submatch [MODINV-1114](https://issues.folio.org/browse/MODINV-1114)
-* Actualize condition of deduplication logic for authority creation [MODSOURMAN-1282](https://issues.folio.org/browse/MODSOURMAN-1282)
+* Actualize condition of deduplication logic for Authority creation [MODINV-1168](https://issues.folio.org/browse/MODINV-1168)
 
 ## 21.0.0 2024-10-29
 * Existing "035" field is not retained the original position in imported record [MODINV-1049](https://folio-org.atlassian.net/browse/MODINV-1049)

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Add "deleted" field to Instance schema [MODINVSTOR-1342](https://folio-org.atlassian.net/browse/MODINVSTOR-1342)
 * Adjust /mark-deleted endpoint behavior to set the "deleted" flag [MODINV-1138](https://folio-org.atlassian.net/browse/MODINV-1138)
 * Implement marc bib submatch [MODINV-1114](https://issues.folio.org/browse/MODINV-1114)
+* Actualize condition of deduplication logic for authority creation [MODSOURMAN-1282](https://issues.folio.org/browse/MODSOURMAN-1282)
 
 ## 21.0.0 2024-10-29
 * Existing "035" field is not retained the original position in imported record [MODINV-1049](https://folio-org.atlassian.net/browse/MODINV-1049)

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateAuthorityEventHandler.java
@@ -5,7 +5,6 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.folio.ActionProfile.FolioRecord.AUTHORITY;
 import static org.folio.ActionProfile.FolioRecord.MARC_AUTHORITY;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED;
-import static org.folio.inventory.dataimport.util.DataImportConstants.UNIQUE_ID_ERROR_MESSAGE;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 
@@ -25,6 +24,7 @@ import org.folio.rest.jaxrs.model.ProfileType;
 
 public class CreateAuthorityEventHandler extends AbstractAuthorityEventHandler {
 
+  static final String ID_UNIQUENESS_ERROR = "Authority with the given 'id' already exists";
   protected static final String FAILED_CREATING_AUTHORITY_MSG_TEMPLATE =
     "Failed creating Authority. Cause: %s, status: '%s'";
   private static final String CREATING_RELATIONSHIP_ERROR =
@@ -48,7 +48,7 @@ public class CreateAuthorityEventHandler extends AbstractAuthorityEventHandler {
     authorityCollection.add(authority, success -> promise.complete(success.getResult()),
       failure -> {
         //This is temporary solution (verify by error message). It will be improved via another solution by https://issues.folio.org/browse/RMB-899.
-        if (isNotBlank(failure.getReason()) && failure.getReason().contains(UNIQUE_ID_ERROR_MESSAGE)) {
+        if (isNotBlank(failure.getReason()) && failure.getReason().contains(ID_UNIQUENESS_ERROR)) {
           LOGGER.info("Duplicated event received by AuthorityId: {}. Ignoring...", authority.getId());
           promise.fail(new DuplicateEventException(format("Duplicated event by Authority id: %s", authority.getId())));
         } else {


### PR DESCRIPTION
## Purpose
to prevent sending events if id duplication error occurs during authority creation as a result of handling duplicated events

## Approach
* update deduplication logic condition according to response returned on authority creation attempt
* update test

## Learning
[MODSOURMAN-1282](https://issues.folio.org/browse/MODSOURMAN-1282)