### PR TITLE
FAT-18739 - Fix check for case if no records matching criteria on non-consortium tenant

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMarcMatchEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMarcMatchEventHandler.java
@@ -414,7 +414,7 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
         recordsMatchingContext.getCentralTenantId());
       return getAllMatchedRecordsIdentifiers(recordMatchingDto, payload, recordsMatchingContext.getCentralTenantRecordsClient());
     }
-    return Future.succeededFuture(new RecordsIdentifiersCollection());
+    return Future.succeededFuture(new RecordsIdentifiersCollection().withTotalRecords(0));
   }
 
   @Override


### PR DESCRIPTION
## Purpose
to fix check for the case when there are no records matching criteria on a tenant in a non-consortium environment


## Learning
[FAT-18739](https://issues.folio.org/browse/FAT-18739)