### PR TITLE
[MODSOURCE-760] Keep staffSuppressed and discoverySuppressed true if delete leader changed using QuickMarc

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/InstanceUpdateDelegate.java
@@ -51,7 +51,7 @@ public class InstanceUpdateDelegate {
 
       return InstanceUtil.findInstanceById(instanceId, instanceCollection)
         .onSuccess(existingInstance -> fillVersion(existingInstance, eventPayload))
-        .compose(existingInstance -> updateInstance(existingInstance, mappedInstance))
+        .compose(existingInstance -> updateInstance(existingInstance, mappedInstance, marcRecord))
         .compose(updatedInstance -> updateInstanceInStorage(updatedInstance, instanceCollection));
     } catch (Exception e) {
       LOGGER.error("Error updating inventory instance", e);
@@ -91,9 +91,14 @@ public class InstanceUpdateDelegate {
       : JsonObject.mapFrom(parsedRecord.getContent());
   }
 
-  private Future<Instance> updateInstance(Instance existingInstance, org.folio.Instance mappedInstance) {
+  private Future<Instance> updateInstance(Instance existingInstance, org.folio.Instance mappedInstance, Record marcRecord) {
     try {
       mappedInstance.setId(existingInstance.getId());
+      if (marcRecord.getAdditionalInfo().getSuppressDiscovery()) {
+        mappedInstance.withStaffSuppress(true);
+        mappedInstance.withDiscoverySuppress(true);
+      }
+
       JsonObject existing = JsonObject.mapFrom(existingInstance);
       JsonObject mapped = JsonObject.mapFrom(mappedInstance);
       JsonObject mergedInstanceAsJson = InstanceUtil.mergeInstances(existing, mapped);


### PR DESCRIPTION
### Purpose
Update "deleted" markers when leader 05 value is changed
### Approach 
Keep staffSuppressed and discoverySuppressed true if delete leader changed using QuickMarc
#### Jira 
https://folio-org.atlassian.net/browse/MODSOURCE-760