### PR TITLE
FAT-19198 - Corrected response check on record undelete request

### DIFF
--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -231,7 +231,7 @@ public class Instances extends AbstractInstances {
     var id = updatedInstance.getId();
     try {
       srsClient.postSourceStorageRecordsUnDeleteById(id, INSTANCE_ID_TYPE, httpClientResponse -> {
-        if (httpClientResponse.result().statusCode() == HttpStatus.HTTP_OK.toInt()) {
+        if (httpClientResponse.result().statusCode() == HttpStatus.HTTP_NO_CONTENT.toInt()) {
           log.info(format("The instance was successfully undeleted in SRS. InstanceID: %s", id));
         } else {
           log.error(format("The instance wasn't undeleted in SRS. InstanceID: %s, SC: %s", id,


### PR DESCRIPTION
## Purpose
correct the response check to avoid false positive error message when, in fact, a record is successfully updated.

> The instance wasn't undeleted in SRS. InstanceID: 3b99cb77-db4f-4f7b-88da-22dbae6d4684, SC: 204
