### PR TITLE
[MODINV-1180] Fix Suppressing from discovery MARC instances makes records also staff suppressed

### DIFF
--- a/src/main/java/org/folio/inventory/domain/instances/Instance.java
+++ b/src/main/java/org/folio/inventory/domain/instances/Instance.java
@@ -793,6 +793,7 @@ public class Instance {
             .setPreviouslyHeld(previouslyHeld)
             .setStaffSuppress(staffSuppress)
             .setDiscoverySuppress(discoverySuppress)
+            .setDeleted(deleted)
             .setStatisticalCodeIds(statisticalCodeIds)
             .setSourceRecordFormat(sourceRecordFormat)
             .setStatusId(statusId)

--- a/src/test/java/org/folio/inventory/eventhandlers/UpdateInstanceQuickMarcEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/UpdateInstanceQuickMarcEventHandlerTest.java
@@ -249,9 +249,6 @@ public class UpdateInstanceQuickMarcEventHandlerTest {
   @Test
   public void shouldSetInstanceSuppressedIfRecordLeaderUpdatedToDeleted() {
     HashMap<String, String> eventPayload = new HashMap<>();
-    JsonObject deletedRecord = JsonObject.mapFrom(this.deletedRecord.mapTo(Record.class)
-      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(true))
-      .withDeleted(true));
 
     eventPayload.put("RECORD_TYPE", "MARC_BIB");
     eventPayload.put("MARC_BIB", deletedRecord.encode());
@@ -289,9 +286,6 @@ public class UpdateInstanceQuickMarcEventHandlerTest {
   @Test
   public void shouldKeepSuppressedFlagsIfRecordWithDeletedLeaderUpdated() {
     HashMap<String, String> eventPayload = new HashMap<>();
-    JsonObject deletedRecord = JsonObject.mapFrom(this.deletedRecord.mapTo(Record.class)
-      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(true))
-      .withDeleted(true));
 
     doAnswer(invocationOnMock -> {
       Consumer<Success<Instance>> successHandler = invocationOnMock.getArgument(1);

--- a/src/test/java/org/folio/inventory/eventhandlers/UpdateInstanceQuickMarcEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/UpdateInstanceQuickMarcEventHandlerTest.java
@@ -53,6 +53,7 @@ public class UpdateInstanceQuickMarcEventHandlerTest {
   private static final String MAPPING_RULES_PATH = "src/test/resources/handlers/bib-rules.json";
   private static final String INSTANCE_PATH = "src/test/resources/handlers/instance.json";
   private static final String RECORD_PATH = "src/test/resources/handlers/bib-record.json";
+  private static final String DELETED_RECORD_PATH = "src/test/resources/handlers/deleted-bib-record.json";
   private static final String INSTANCE_ID = "ddd266ef-07ac-4117-be13-d418b8cd6902";
   private static final String INSTANCE_VERSION = "1";
 
@@ -70,11 +71,18 @@ public class UpdateInstanceQuickMarcEventHandlerTest {
   private PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper;
   private JsonObject mappingRules;
   private JsonObject record;
+  private JsonObject deletedRecord;
   private Instance existingInstance;
+  private Instance deletedInstance;
 
   @Before
   public void setUp() throws IOException {
     existingInstance = Instance.fromJson(new JsonObject(TestUtil.readFileFromPath(INSTANCE_PATH)));
+    deletedInstance = Instance.fromJson(new JsonObject(TestUtil.readFileFromPath(INSTANCE_PATH)))
+      .setDeleted(true)
+      .setDiscoverySuppress(true)
+      .setStaffSuppress(true);
+
     instanceUpdateDelegate = Mockito.spy(new InstanceUpdateDelegate(storage));
     precedingSucceedingTitlesHelper = Mockito.spy(new PrecedingSucceedingTitlesHelper(ctxt -> okapiHttpClient));
     updateInstanceEventHandler =
@@ -103,6 +111,7 @@ public class UpdateInstanceQuickMarcEventHandlerTest {
 
     mappingRules = new JsonObject(TestUtil.readFileFromPath(MAPPING_RULES_PATH));
     record = new JsonObject(TestUtil.readFileFromPath(RECORD_PATH));
+    deletedRecord = new JsonObject(TestUtil.readFileFromPath(DELETED_RECORD_PATH));
   }
 
   @Test
@@ -192,10 +201,18 @@ public class UpdateInstanceQuickMarcEventHandlerTest {
   }
 
   @Test
-  public void shouldSetSuppressedIfRecordStaffSuppressed() {
+  public void shouldKeepInstanceSuppressedIfRecordLeaderUpdatedToNotDeleted() {
     HashMap<String, String> eventPayload = new HashMap<>();
     JsonObject staffSuppressedRecord = JsonObject.mapFrom(record.mapTo(Record.class)
-      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(true)));
+      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(true))
+      .withDeleted(false));
+
+    doAnswer(invocationOnMock -> {
+      Consumer<Success<Instance>> successHandler = invocationOnMock.getArgument(1);
+      successHandler.accept(new Success<>(deletedInstance));
+      return null;
+    }).when(instanceRecordCollection).findById(anyString(), any(), any());
+
     eventPayload.put("RECORD_TYPE", "MARC_BIB");
     eventPayload.put("MARC_BIB", staffSuppressedRecord.encode());
     eventPayload.put("MAPPING_RULES", mappingRules.encode());
@@ -221,6 +238,94 @@ public class UpdateInstanceQuickMarcEventHandlerTest {
     Assert.assertEquals("Adding a note", updatedInstance.getNotes().get(0).note);
     Assert.assertEquals(true, updatedInstance.getDiscoverySuppress());
     Assert.assertEquals(true, updatedInstance.getStaffSuppress());
+
+    ArgumentCaptor<Context> argument = ArgumentCaptor.forClass(Context.class);
+    verify(instanceUpdateDelegate).handle(any(), any(), argument.capture());
+    Assert.assertEquals("token", argument.getValue().getToken());
+    Assert.assertEquals("dummy", argument.getValue().getTenantId());
+    Assert.assertEquals("http://localhost", argument.getValue().getOkapiLocation());
+  }
+
+  @Test
+  public void shouldSetInstanceSuppressedIfRecordLeaderUpdatedToDeleted() {
+    HashMap<String, String> eventPayload = new HashMap<>();
+    JsonObject deletedRecord = JsonObject.mapFrom(this.deletedRecord.mapTo(Record.class)
+      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(true))
+      .withDeleted(true));
+
+    eventPayload.put("RECORD_TYPE", "MARC_BIB");
+    eventPayload.put("MARC_BIB", deletedRecord.encode());
+    eventPayload.put("MAPPING_RULES", mappingRules.encode());
+    eventPayload.put("MAPPING_PARAMS", new JsonObject().encode());
+    eventPayload.put("RELATED_RECORD_VERSION", INSTANCE_VERSION);
+
+    Future<Instance> future = updateInstanceEventHandler.handle(eventPayload);
+    Instance updatedInstance = future.result();
+
+    Assert.assertNotNull(updatedInstance);
+    Assert.assertEquals(INSTANCE_ID, updatedInstance.getId());
+    Assert.assertEquals(INSTANCE_VERSION, updatedInstance.getVersion());
+    Assert.assertEquals("Victorian environmental nightmares and something else/", updatedInstance.getIndexTitle());
+    Assert.assertNotNull(
+      updatedInstance.getIdentifiers().stream().filter(i -> "(OCoLC)1060180367".equals(i.value)).findFirst().orElse(null));
+    Assert.assertNotNull(
+      updatedInstance.getContributors().stream().filter(c -> "Mazzeno, Laurence W., 1234566".equals(c.name)).findFirst()
+        .orElse(null));
+    Assert.assertNotNull(updatedInstance.getSubjects());
+    Assert.assertEquals(1, updatedInstance.getSubjects().size());
+    assertThat(updatedInstance.getSubjects().get(0).getValue(), Matchers.containsString("additional subfield"));
+    Assert.assertNotNull(updatedInstance.getNotes());
+    Assert.assertEquals("Adding a note", updatedInstance.getNotes().get(0).note);
+    Assert.assertEquals(true, updatedInstance.getDiscoverySuppress());
+    Assert.assertEquals(true, updatedInstance.getStaffSuppress());
+
+    ArgumentCaptor<Context> argument = ArgumentCaptor.forClass(Context.class);
+    verify(instanceUpdateDelegate).handle(any(), any(), argument.capture());
+    Assert.assertEquals("token", argument.getValue().getToken());
+    Assert.assertEquals("dummy", argument.getValue().getTenantId());
+    Assert.assertEquals("http://localhost", argument.getValue().getOkapiLocation());
+  }
+
+  @Test
+  public void shouldKeepSuppressedFlagsIfRecordWithDeletedLeaderUpdated() {
+    HashMap<String, String> eventPayload = new HashMap<>();
+    JsonObject deletedRecord = JsonObject.mapFrom(this.deletedRecord.mapTo(Record.class)
+      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(true))
+      .withDeleted(true));
+
+    doAnswer(invocationOnMock -> {
+      Consumer<Success<Instance>> successHandler = invocationOnMock.getArgument(1);
+      successHandler.accept(new Success<>(deletedInstance.copyInstance()
+        .setStaffSuppress(false)
+        .setDiscoverySuppress(true)));
+      return null;
+    }).when(instanceRecordCollection).findById(anyString(), any(), any());
+
+    eventPayload.put("RECORD_TYPE", "MARC_BIB");
+    eventPayload.put("MARC_BIB", deletedRecord.encode());
+    eventPayload.put("MAPPING_RULES", mappingRules.encode());
+    eventPayload.put("MAPPING_PARAMS", new JsonObject().encode());
+    eventPayload.put("RELATED_RECORD_VERSION", INSTANCE_VERSION);
+
+    Future<Instance> future = updateInstanceEventHandler.handle(eventPayload);
+    Instance updatedInstance = future.result();
+
+    Assert.assertNotNull(updatedInstance);
+    Assert.assertEquals(INSTANCE_ID, updatedInstance.getId());
+    Assert.assertEquals(INSTANCE_VERSION, updatedInstance.getVersion());
+    Assert.assertEquals("Victorian environmental nightmares and something else/", updatedInstance.getIndexTitle());
+    Assert.assertNotNull(
+      updatedInstance.getIdentifiers().stream().filter(i -> "(OCoLC)1060180367".equals(i.value)).findFirst().orElse(null));
+    Assert.assertNotNull(
+      updatedInstance.getContributors().stream().filter(c -> "Mazzeno, Laurence W., 1234566".equals(c.name)).findFirst()
+        .orElse(null));
+    Assert.assertNotNull(updatedInstance.getSubjects());
+    Assert.assertEquals(1, updatedInstance.getSubjects().size());
+    assertThat(updatedInstance.getSubjects().get(0).getValue(), Matchers.containsString("additional subfield"));
+    Assert.assertNotNull(updatedInstance.getNotes());
+    Assert.assertEquals("Adding a note", updatedInstance.getNotes().get(0).note);
+    Assert.assertEquals(true, updatedInstance.getDiscoverySuppress());
+    Assert.assertEquals(false, updatedInstance.getStaffSuppress());
 
     ArgumentCaptor<Context> argument = ArgumentCaptor.forClass(Context.class);
     verify(instanceUpdateDelegate).handle(any(), any(), argument.capture());

--- a/src/test/resources/handlers/bib-rules.json
+++ b/src/test/resources/handlers/bib-rules.json
@@ -1,11 +1,5 @@
 {
-  "001": [
-    {
-      "target": "hrid",
-      "description": "The human readable ID",
-      "subfield": [],
-      "rules": []
-    },
+  "LDR": [
     {
       "target": "modeOfIssuanceId",
       "description": "",
@@ -15,8 +9,7 @@
           "description": "Issuance mode based on 7 leader`s byte",
           "conditions": [
             {
-              "type": "set_issuance_mode_id",
-              "LDR": true
+              "type": "set_issuance_mode_id"
             }
           ]
         }
@@ -31,8 +24,7 @@
           "description": "Discovery suppress flag based on whether 5 leader`s byte equals to 'd'",
           "conditions": [
             {
-              "type": "set_deleted",
-              "LDR": true
+              "type": "set_deleted"
             }
           ]
         }
@@ -47,8 +39,7 @@
           "description": "Staff suppress flag based on whether 5 leader`s byte equals to 'd'",
           "conditions": [
             {
-              "type": "set_deleted",
-              "LDR": true
+              "type": "set_deleted"
             }
           ]
         }
@@ -63,12 +54,19 @@
           "description": "Deleted flag based on whether 5 leader`s byte equals to 'd'",
           "conditions": [
             {
-              "type": "set_deleted",
-              "LDR": true
+              "type": "set_deleted"
             }
           ]
         }
       ]
+    }
+  ],
+  "001": [
+    {
+      "target": "hrid",
+      "description": "The human readable ID",
+      "subfield": [],
+      "rules": []
     }
   ],
   "008": [

--- a/src/test/resources/handlers/deleted-bib-record.json
+++ b/src/test/resources/handlers/deleted-bib-record.json
@@ -1,0 +1,448 @@
+{
+  "id": "4ce19d38-9f8b-4faa-89c0-aa7a7b41e8a7",
+  "snapshotId": "a32de245-aa4f-4e24-aa36-ff2370beb083",
+  "matchedId": "69afc410-ea05-4530-9847-e8f3b2b734d3",
+  "generation": 3,
+  "recordType": "MARC_BIB",
+  "parsedRecord": {
+    "id": "64deac7f-b6b4-46c9-a357-3e80dc8f52c8",
+    "content": {
+      "fields": [
+        {
+          "001": "in00000000003"
+        },
+        {
+          "003": "OCoLC"
+        },
+        {
+          "005": "20190710064447.6"
+        },
+        {
+          "008": "190517s2019    sz a     b    001 0 eng d"
+        },
+        {
+          "020": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "9783030140410"
+              },
+              {
+                "q": "hardback"
+              }
+            ]
+          }
+        },
+        {
+          "020": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "z": "9783030140427 (PDF ebook)"
+              }
+            ]
+          }
+        },
+        {
+          "035": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "(OCoLC)1103977579"
+              }
+            ]
+          }
+        },
+        {
+          "035": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "1103977579"
+              }
+            ]
+          }
+        },
+        {
+          "035": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "(OCoLC)1060180367"
+              }
+            ]
+          }
+        },
+        {
+          "040": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "UKMGB"
+              },
+              {
+                "b": "eng"
+              },
+              {
+                "e": "rda"
+              },
+              {
+                "c": "UKMGB"
+              },
+              {
+                "d": "OCLCO"
+              },
+              {
+                "d": "BDX"
+              },
+              {
+                "d": "EYM"
+              },
+              {
+                "d": "YDX"
+              }
+            ]
+          }
+        },
+        {
+          "050": {
+            "ind1": " ",
+            "ind2": "4",
+            "subfields": [
+              {
+                "a": "PR468.E34"
+              },
+              {
+                "b": "V53 2019"
+              }
+            ]
+          }
+        },
+        {
+          "082": {
+            "ind1": "0",
+            "ind2": "4",
+            "subfields": [
+              {
+                "a": "820.93609034"
+              },
+              {
+                "2": "23"
+              }
+            ]
+          }
+        },
+        {
+          "245": {
+            "ind1": "0",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "Victorian environmental nightmares and something else/"
+              },
+              {
+                "c": "Laurence W. Mazzeno, Ronald D. Morrison, editors."
+              }
+            ]
+          }
+        },
+        {
+          "255": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Adding a note"
+              }
+            ]
+          }
+        },
+        {
+          "264": {
+            "ind1": " ",
+            "ind2": "1",
+            "subfields": [
+              {
+                "a": "Cham, Switzerland :"
+              },
+              {
+                "b": "Palgrave Macmillan,"
+              },
+              {
+                "c": "[2019]"
+              }
+            ]
+          }
+        },
+        {
+          "300": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "xii, 273 pages :"
+              },
+              {
+                "b": "illustrations (black and white) ;"
+              },
+              {
+                "c": "21 cm"
+              }
+            ]
+          }
+        },
+        {
+          "336": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "still image"
+              },
+              {
+                "b": "sti"
+              },
+              {
+                "2": "rdacontent"
+              }
+            ]
+          }
+        },
+        {
+          "336": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "text"
+              },
+              {
+                "b": "txt"
+              },
+              {
+                "2": "rdacontent"
+              }
+            ]
+          }
+        },
+        {
+          "337": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "unmediated"
+              },
+              {
+                "b": "n"
+              },
+              {
+                "2": "rdamedia"
+              }
+            ]
+          }
+        },
+        {
+          "338": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "volume"
+              },
+              {
+                "b": "nc"
+              },
+              {
+                "2": "rdacarrier"
+              }
+            ]
+          }
+        },
+        {
+          "504": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Includes bibliographical references and index."
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "English literature"
+              },
+              {
+                "y": "19th century"
+              },
+              {
+                "x": "History and criticism."
+              },
+              {
+                "z": "additional subfield"
+              }
+            ]
+          }
+        },
+        {
+          "700": {
+            "ind1": "1",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Mazzeno, Laurence W., 1234566"
+              },
+              {
+                "e": "editor."
+              }
+            ]
+          }
+        },
+        {
+          "700": {
+            "ind1": "1",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Morrison, Ronald D.,"
+              },
+              {
+                "e": "editor."
+              }
+            ]
+          }
+        },
+        {
+          "776": {
+            "ind1": "0",
+            "ind2": "8",
+            "subfields": [
+              {
+                "i": "ebook version :"
+              },
+              {
+                "z": "9783030140427"
+              }
+            ]
+          }
+        },
+        {
+          "935": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "10001-1"
+              }
+            ]
+          }
+        },
+        {
+          "935": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "10001-2"
+              }
+            ]
+          }
+        },
+        {
+          "949": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "BC-12834629734012"
+              }
+            ]
+          }
+        },
+        {
+          "980": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "40029162881"
+              },
+              {
+                "b": "USHIST"
+              },
+              {
+                "d": "KU/CC/DI/M"
+              },
+              {
+                "e": "YBP"
+              },
+              {
+                "g": "509541"
+              },
+              {
+                "h": "98990"
+              },
+              {
+                "i": "190715"
+              },
+              {
+                "j": "89.09"
+              },
+              {
+                "l": "Cloth"
+              },
+              {
+                "m": "109.99"
+              },
+              {
+                "q": "1"
+              }
+            ]
+          }
+        },
+        {
+          "999": {
+            "ind1": "f",
+            "ind2": "f",
+            "subfields": [
+              {
+                "s": "69afc410-ea05-4530-9847-e8f3b2b734d3"
+              },
+              {
+                "i": "ddd266ef-07ac-4117-be13-d418b8cd6902"
+              }
+            ]
+          }
+        }
+      ],
+      "leader": "01418dam a2200361 i 4500"
+    }
+  },
+  "deleted": false,
+  "order": 2,
+  "externalIdsHolder": {
+    "instanceId": "ddd266ef-07ac-4117-be13-d418b8cd6902"
+  },
+  "additionalInfo": {
+    "suppressDiscovery": false
+  },
+  "state": "ACTUAL",
+  "metadata": {
+    "createdDate": "2020-05-18T14:42:50.229+0000",
+    "createdByUserId": "85de4107-9988-5ae8-972a-0df5295d5af8",
+    "updatedDate": "2020-05-18T14:42:50.229+0000",
+    "updatedByUserId": "85de4107-9988-5ae8-972a-0df5295d5af8"
+  }
+}

--- a/src/test/resources/handlers/deleted-bib-record.json
+++ b/src/test/resources/handlers/deleted-bib-record.json
@@ -430,13 +430,13 @@
       "leader": "01418dam a2200361 i 4500"
     }
   },
-  "deleted": false,
+  "deleted": true,
   "order": 2,
   "externalIdsHolder": {
     "instanceId": "ddd266ef-07ac-4117-be13-d418b8cd6902"
   },
   "additionalInfo": {
-    "suppressDiscovery": false
+    "suppressDiscovery": true
   },
   "state": "ACTUAL",
   "metadata": {


### PR DESCRIPTION
### Purpose
Fix Suppressing from discovery MARC instances makes records also staff suppressed
### Approach
Change staff suppressed and discovery suppressed to true only if the leader changed from valid to 'd' otherwise keep existing values