### PR TITLE
MODINV-1205: Use tenant specific cache for MappingMetadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 21.1.3
+* Use a separate cache for MappingMetadata for each tenant [MODINV-1205] (https://folio-org.atlassian.net/browse/MODINV-1205)
+
 ## 21.1.2 2025-04-16
 * Upgrade dependencies kafka-client 3.9.0, Vert.x 4.5.13 for fixing vulnerabilities [MODINV-1182](https://folio-org.atlassian.net/browse/MODINV-1182)
 * Cannot edit MARC bib record on non-ECS environment due to error [MODINV-1190](https://folio-org.atlassian.net/browse/MODINV-1190)

--- a/src/main/java/org/folio/inventory/instanceingress/handler/InstanceIngressEventHandler.java
+++ b/src/main/java/org/folio/inventory/instanceingress/handler/InstanceIngressEventHandler.java
@@ -82,8 +82,9 @@ public interface InstanceIngressEventHandler {
 
   default Future<Optional<MappingMetadataDto>> getMappingMetadata(
     Context context, Supplier<MappingMetadataCache> mappingMetadataCacheSupplier) {
+    var cacheKey = InstanceIngressEventConsumer.class.getSimpleName() + "-" + context.getTenantId();
     return mappingMetadataCacheSupplier.get()
-      .getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .getByRecordType(cacheKey, context, MARC_BIB_RECORD_TYPE);
   }
 
   default Future<Instance> validateInstance(org.folio.Instance instance,

--- a/src/test/java/org/folio/inventory/instanceingress/handler/CreateInstanceIngressEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/instanceingress/handler/CreateInstanceIngressEventHandlerUnitTest.java
@@ -149,7 +149,7 @@ public class CreateInstanceIngressEventHandlerUnitTest {
       );
     doReturn(succeededFuture(null)).when(idStorageService).store(anyString(), anyString(), anyString());
     doReturn(succeededFuture(Optional.empty())).when(mappingMetadataCache)
-      .getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
     var expectedMessage = "MappingMetadata was not found for marc-bib record type";
 
     // when
@@ -174,7 +174,7 @@ public class CreateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
 
     doReturn(sourceStorageSnapshotsClient).when(handler).getSourceStorageSnapshotsClient(any(), any(), any(), argThat(USER_ID::equals));
     var snapshotHttpResponse = buildHttpResponseWithBuffer(buffer(Json.encode(new Snapshot())), HttpStatus.SC_CREATED);
@@ -205,7 +205,7 @@ public class CreateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
     doReturn(sourceStorageSnapshotsClient).when(handler).getSourceStorageSnapshotsClient(any(), any(), any(), argThat(USER_ID::equals));
     var snapshotHttpResponse = buildHttpResponseWithBuffer(buffer(Json.encode(new Snapshot())), HttpStatus.SC_CREATED);
     doReturn(succeededFuture(snapshotHttpResponse)).when(sourceStorageSnapshotsClient).postSourceStorageSnapshots(any());
@@ -239,7 +239,7 @@ public class CreateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
     doReturn(sourceStorageSnapshotsClient).when(handler).getSourceStorageSnapshotsClient(any(), any(), any(), argThat(USER_ID::equals));
     var snapshotHttpResponse = buildHttpResponseWithBuffer(buffer(Json.encode(new Snapshot())), HttpStatus.SC_CREATED);
     doReturn(succeededFuture(snapshotHttpResponse)).when(sourceStorageSnapshotsClient).postSourceStorageSnapshots(any());
@@ -273,7 +273,7 @@ public class CreateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
     doReturn(sourceStorageSnapshotsClient).when(handler).getSourceStorageSnapshotsClient(any(), any(), any(), argThat(USER_ID::equals));
     doAnswer(i -> {
       Consumer<Success<Instance>> successHandler = i.getArgument(1);
@@ -308,7 +308,7 @@ public class CreateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
     doReturn(sourceStorageSnapshotsClient).when(handler).getSourceStorageSnapshotsClient(any(), any(), any(), argThat(USER_ID::equals));
     var snapshotHttpResponse = buildHttpResponseWithBuffer(buffer(Json.encode(new Snapshot())), HttpStatus.SC_CREATED);
     doReturn(succeededFuture(snapshotHttpResponse)).when(sourceStorageSnapshotsClient).postSourceStorageSnapshots(any());
@@ -351,7 +351,7 @@ public class CreateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
     doReturn(sourceStorageSnapshotsClient).when(handler).getSourceStorageSnapshotsClient(any(), any(), any(), argThat(USER_ID::equals));
     var snapshotHttpResponse = buildHttpResponseWithBuffer(buffer(Json.encode(new Snapshot())), HttpStatus.SC_CREATED);
     doReturn(succeededFuture(snapshotHttpResponse)).when(sourceStorageSnapshotsClient).postSourceStorageSnapshots(any());
@@ -384,5 +384,9 @@ public class CreateInstanceIngressEventHandlerUnitTest {
     assertThat(recordSentToSRS.getRecordType()).isEqualTo(Record.RecordType.MARC_BIB);
     assertThat(AdditionalFieldsUtil.getValue(recordSentToSRS, TAG_999, SUBFIELD_I)).hasValue(instance.getId());
     assertThat(AdditionalFieldsUtil.getValue(recordSentToSRS, TAG_999, SUBFIELD_L)).hasValue(linkedDataId);
+  }
+
+  private String metadataCacheKey() {
+    return InstanceIngressEventConsumer.class.getSimpleName() + "-" + TENANT;
   }
 }

--- a/src/test/java/org/folio/inventory/instanceingress/handler/UpdateInstanceIngressEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/instanceingress/handler/UpdateInstanceIngressEventHandlerUnitTest.java
@@ -124,7 +124,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
         .withSourceType(LINKED_DATA)
       );
     doReturn(succeededFuture(Optional.empty())).when(mappingMetadataCache)
-      .getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
     var expectedMessage = "MappingMetadata was not found for marc-bib record type";
 
     // when
@@ -148,7 +148,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
     var expectedMessage = "Error retrieving inventory Instance";
     doAnswer(i -> {
       Consumer<Failure> failureHandler = i.getArgument(2);
@@ -177,7 +177,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
    var existedInstance = new Instance(event.getId(), "1",
       UUID.randomUUID().toString(), null, null, null);
     doAnswer(i -> {
@@ -209,7 +209,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
    var existedInstance = new Instance(event.getId(), "1",
       UUID.randomUUID().toString(), null, null, null);
     doAnswer(i -> {
@@ -245,7 +245,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
    var existedInstance = new Instance(event.getId(), "1",
       UUID.randomUUID().toString(), null, null, null);
     doAnswer(i -> {
@@ -282,7 +282,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
    var existedInstance = new Instance(event.getId(), "1",
       UUID.randomUUID().toString(), null, null, null);
     doAnswer(i -> {
@@ -321,7 +321,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
    var existedInstance = new Instance(event.getId(), "1",
       UUID.randomUUID().toString(), null, null, null);
     doAnswer(i -> {
@@ -364,7 +364,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
    var existedInstance = new Instance(event.getId(), "1",
       UUID.randomUUID().toString(), null, null, null);
     doAnswer(i -> {
@@ -410,7 +410,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
    var existedInstance = new Instance(event.getId(), "1",
       UUID.randomUUID().toString(), null, null, null);
     doAnswer(i -> {
@@ -457,7 +457,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
    var existedInstance = new Instance(event.getId(), "1",
       UUID.randomUUID().toString(), null, null, null);
     doAnswer(i -> {
@@ -511,7 +511,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     doReturn(succeededFuture(Optional.of(new MappingMetadataDto()
       .withMappingRules(mappingRules.encode())
       .withMappingParams(Json.encode(new MappingParameters())))))
-      .when(mappingMetadataCache).getByRecordType(InstanceIngressEventConsumer.class.getSimpleName(), context, MARC_BIB_RECORD_TYPE);
+      .when(mappingMetadataCache).getByRecordType(metadataCacheKey(), context, MARC_BIB_RECORD_TYPE);
    var existedInstance = new Instance(event.getId(), "1",
       UUID.randomUUID().toString(), null, null, null);
     doAnswer(i -> {
@@ -563,4 +563,7 @@ public class UpdateInstanceIngressEventHandlerUnitTest {
     assertThat(AdditionalFieldsUtil.getValue(recordSentToSRS, TAG_999, 's')).hasValue(initialSrsId);
   }
 
+  private String metadataCacheKey() {
+    return InstanceIngressEventConsumer.class.getSimpleName() + "-" + TENANT;
+  }
 }


### PR DESCRIPTION
Earlier,  a single cache for used for caching `MappingMetadata` across all the tenants. This caused the MARC record processing to fail when the reference data ID in one tenant differed from the reference data ID in another tenant.

With the new approach, the `MappingMetadata` is cached for each tenant separately. As a result, the MARC processing should work even when different tenants have different reference data IDs.


**Another optimization we could do in future:**
[Here](https://github.com/folio-org/mod-inventory/blob/master/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java#L118) we use `jobId` as the cache Key. May be use tenantId instead? This way, both [InstanceIngressEventHandler.java](https://github.com/folio-org/mod-inventory/pull/834/files#diff-7908f7101f1d127f9c2471ef3265b818a834cef5f5ca89df512e9c7192b1b0bf) and [MarcBibUpdateKafkaHandler.java](https://github.com/folio-org/mod-inventory/blob/master/src/main/java/org/folio/inventory/dataimport/consumers/MarcBibUpdateKafkaHandler.java) use the same cache for MappingMetadata. This will be a more optimal approach I think.

Should I create a ticket for this @KaterynaSenchenko?