### PR TITLE
[MODINV-1175] Set item locations null during updateOwnership

### DIFF
--- a/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
+++ b/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
@@ -610,7 +610,9 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
   private Item mapToItem(JsonObject itemJson, String targetHoldingId) {
     return ItemUtil.fromStoredItemRepresentation(itemJson)
       .withHrid(null)
-      .withHoldingId(targetHoldingId);
+      .withHoldingId(targetHoldingId)
+      .withTemporaryLocationId(null)
+      .withPermanentLocationId(null);
   }
 
   private List<HoldingsRecord> getHoldingsToDelete(List<NotUpdatedEntity> notUpdatedEntities,

--- a/src/test/java/api/support/builders/ItemRequestBuilder.java
+++ b/src/test/java/api/support/builders/ItemRequestBuilder.java
@@ -350,7 +350,7 @@ public class ItemRequestBuilder extends AbstractBuilder {
       this.administrativeNotes);
   }
 
-  private ItemRequestBuilder withTemporaryLocation(JsonObject location) {
+  public ItemRequestBuilder withTemporaryLocation(JsonObject location) {
     return new ItemRequestBuilder(
       this.id,
       this.holdingId,
@@ -377,7 +377,7 @@ public class ItemRequestBuilder extends AbstractBuilder {
       this.administrativeNotes);
   }
 
-    private ItemRequestBuilder withPermanentLocation(JsonObject location) {
+    public ItemRequestBuilder withPermanentLocation(JsonObject location) {
     return new ItemRequestBuilder(
       this.id,
       this.holdingId,


### PR DESCRIPTION
### Purpose
Unable to update ownership of item with filled temporary/permanent location

### Approach
Set item locations null during updateOwnership

### Jira 
https://folio-org.atlassian.net/browse/MODINV-1175