### PR TITLE
MODINV-1232 - Deleted from Inventory MARC records are not matching during update

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/util/ParsedRecordUtil.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/ParsedRecordUtil.java
@@ -113,7 +113,7 @@ public final class ParsedRecordUtil {
       StringBuilder builder = new StringBuilder(leader);
       builder.setCharAt(LEADER_STATUS_SUBFIELD_POSITION, status);
       marcJson.put(LEADER, builder.toString());
-      parsedRecord.setContent(normalize(marcJson));
+      parsedRecord.setContent(marcJson.encode());
     }
   }
 

--- a/src/test/java/org/folio/inventory/dataimport/util/ParsedRecordUtilTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/util/ParsedRecordUtilTest.java
@@ -7,6 +7,9 @@ import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.inventory.dataimport.util.ParsedRecordUtil.AdditionalSubfields;
 import org.folio.rest.jaxrs.model.Record;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -80,7 +83,10 @@ public class ParsedRecordUtilTest {
     ParsedRecordUtil.updateLeaderStatus(parsedRecord, newStatus);
 
     // then
+    assertThat(parsedRecord.getContent(), instanceOf(String.class));
     JsonObject updatedContent = ParsedRecordUtil.normalize(parsedRecord.getContent());
+    assertEquals(2, updatedContent.fieldNames().size());
+    assertThat(updatedContent.fieldNames(), containsInAnyOrder("fields", "leader"));
     assertEquals("01240bvs a2200397   4500", updatedContent.getString("leader"));
   }
 


### PR DESCRIPTION
## Purpose
to fix issue when MARC record becomes corrupted after update of instance that was previously set for deletion

## Approach
* put parsed content as String instead of JsonObject to properly serialize it for request body, as it is done by other util methods that change marc content fields
* add tests


## Learning
[MODSOURCE-898](https://issues.folio.org/browse/MODSOURCE-898)
[MODINV-1232](https://issues.folio.org/browse/MODINV-1232)