### PR TITLE
feat(instance-authority-links): Add instance-authority links logic on MARC Instance update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Error editing the "Temporary" field in the holding [MODINV-1189](https://folio-org.atlassian.net/browse/MODINV-1189)
 * Source of Instance changes from LINKED_DATA to MARC when a linked authority is updated [MODINV-1176](https://folio-org.atlassian.net/browse/MODINV-1176)
 * Adds additionalCallNumbers to the item and holding [MOD-INV-1241](https://folio-org.atlassian.net/browse/MODINV-1241)
+* Add instance-authority links logic on MARC Instance update [MODINV-1068](https://folio-org.atlassian.net/browse/MODINV-1068)
 
 ## 21.1.0 2025-03-13
 * Update deduplication logic in mod-inventory [MODINV-1151](https://folio-org.atlassian.net/browse/MODINV-1151)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -721,10 +721,6 @@
     {
       "id": "authority-storage",
       "version": "2.0"
-    },
-    {
-      "id": "instance-authority-linking-rules",
-      "version": "1.1"
     }
   ],
   "optional": [
@@ -1015,7 +1011,6 @@
         "inventory-storage.preceding-succeeding-titles.item.put",
         "inventory-storage.preceding-succeeding-titles.item.delete",
         "instance-authority-links.instances.collection.get",
-        "instance-authority.linking-rules.collection.get",
         "instance-authority-links.instances.collection.put"
       ]
     }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -688,7 +688,7 @@
     },
     {
       "id": "instance-authority-links",
-      "version": "2.0"
+      "version": "2.1"
     },
     {
       "id": "identifier-types",
@@ -721,6 +721,10 @@
     {
       "id": "authority-storage",
       "version": "2.0"
+    },
+    {
+      "id": "instance-authority-linking-rules",
+      "version": "1.1"
     }
   ],
   "optional": [
@@ -1009,7 +1013,10 @@
         "inventory-storage.preceding-succeeding-titles.item.post",
         "inventory-storage.preceding-succeeding-titles.collection.get",
         "inventory-storage.preceding-succeeding-titles.item.put",
-        "inventory-storage.preceding-succeeding-titles.item.delete"
+        "inventory-storage.preceding-succeeding-titles.item.delete",
+        "instance-authority-links.instances.collection.get",
+        "instance-authority.linking-rules.collection.get",
+        "instance-authority-links.instances.collection.put"
       ]
     }
   },

--- a/src/main/java/org/folio/inventory/client/InstanceLinkClient.java
+++ b/src/main/java/org/folio/inventory/client/InstanceLinkClient.java
@@ -1,0 +1,89 @@
+package org.folio.inventory.client;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import lombok.SneakyThrows;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.HttpStatus;
+import org.folio.InstanceLinkDtoCollection;
+import org.folio.inventory.common.Context;
+import org.folio.inventory.dataimport.exceptions.InstanceLinksException;
+import org.folio.inventory.support.http.client.OkapiHttpClient;
+
+public class InstanceLinkClient {
+  private static final Logger LOGGER = LogManager.getLogger(InstanceLinkClient.class);
+  private static final String LINKS_API_PREFIX = "/links/instances/";
+
+  private final WebClient webClient;
+  private final Function<Context, OkapiHttpClient> okapiHttpClientCreator;
+
+  public InstanceLinkClient(WebClient webClient) {
+    this.webClient = webClient;
+    this.okapiHttpClientCreator = this::createOkapiHttpClient;
+  }
+
+  public CompletableFuture<Optional<InstanceLinkDtoCollection>> getLinksByInstanceId(String instanceId, Context context) {
+    LOGGER.trace("getLinksByInstanceId: okapi url: {}, tenantId: {}, instanceId: {}",
+      context.getOkapiLocation(), context.getTenantId(), instanceId);
+    OkapiHttpClient client = okapiHttpClientCreator.apply(context);
+    String url = context.getOkapiLocation() + LINKS_API_PREFIX + instanceId;
+    return client.get(url)
+      .toCompletableFuture()
+      .thenCompose(httpResponse -> {
+        if (httpResponse.getStatusCode() == HttpStatus.HTTP_OK.toInt()) {
+          LOGGER.info("getLinksByInstanceId: InstanceLinkDtoCollection loaded for instanceId '{}'", instanceId);
+          InstanceLinkDtoCollection dto = Json.decodeValue(httpResponse.getBody(), InstanceLinkDtoCollection.class);
+          return CompletableFuture.completedFuture(Optional.of(dto));
+        } else if (httpResponse.getStatusCode() == HttpStatus.HTTP_NOT_FOUND.toInt()) {
+          LOGGER.warn("getLinksByInstanceId: InstanceLinkDtoCollection not found for instanceId '{}'", instanceId);
+          return CompletableFuture.completedFuture(Optional.empty());
+        } else {
+          String message = String.format("getLinksByInstanceId: Error for instanceId '%s', status code: %d, response: %s",
+            instanceId,
+            httpResponse.getStatusCode(),
+            httpResponse.getBody());
+          LOGGER.warn(message);
+          return CompletableFuture.failedFuture(new InstanceLinksException(message));
+        }
+      });
+  }
+
+  public CompletableFuture<Void> updateInstanceLinks(String instanceId,
+                                                     InstanceLinkDtoCollection instanceLinkCollection,
+                                                     Context context) {
+    LOGGER.trace("updateInstanceLinks: okapi url: {}, tenantId: {}, instanceId: {}",
+      context.getOkapiLocation(), context.getTenantId(), instanceId);
+    var client = okapiHttpClientCreator.apply(context);
+    var url = context.getOkapiLocation() + LINKS_API_PREFIX + instanceId;
+    return client.put(url, JsonObject.mapFrom(instanceLinkCollection))
+      .toCompletableFuture()
+      .thenAccept(httpResponse -> {
+        if (httpResponse.getStatusCode() == HttpStatus.HTTP_NO_CONTENT.toInt()) {
+          LOGGER.info("updateInstanceLinks: InstanceLinkDtoCollection updated for instanceId '{}'", instanceId);
+        } else {
+          var message = String.format("updateInstanceLinks: Error updating for instanceId '%s', status: %d, response: %s",
+            instanceId,
+            httpResponse.getStatusCode(),
+            httpResponse.getBody());
+          LOGGER.warn(message);
+        }
+      });
+  }
+
+  @SneakyThrows
+  private OkapiHttpClient createOkapiHttpClient(Context context) {
+    return new OkapiHttpClient(webClient,
+      new URI(context.getOkapiLocation()).toURL(),
+      context.getTenantId(),
+      context.getToken(),
+      context.getUserId(),
+      context.getRequestId(),
+      null);
+  }
+}

--- a/src/main/java/org/folio/inventory/consortium/util/MarcRecordUtil.java
+++ b/src/main/java/org/folio/inventory/consortium/util/MarcRecordUtil.java
@@ -130,4 +130,29 @@ public final class MarcRecordUtil {
     marcRecord.getParsedRecord().setContent(contentObject);
     return marcRecord;
   }
+
+  /**
+   * Check if any field with the subfield code exists.
+   *
+   * @param sourceRecord - source record.
+   * @param subFieldCode - subfield code.
+   * @return true if exists, otherwise false.
+   */
+  public static boolean isSubfieldExist(Record sourceRecord, char subFieldCode) {
+    try {
+      org.marc4j.marc.Record marcRecord = computeMarcRecord(sourceRecord);
+      if (marcRecord != null) {
+        for (DataField dataField : marcRecord.getDataFields()) {
+          Subfield subfield = dataField.getSubfield(subFieldCode);
+          if (subfield != null) {
+            return true;
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.warn("isSubfieldExist:: Error during the search a subfield in the record", e);
+      return false;
+    }
+    return false;
+  }
 }

--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -10,6 +10,7 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.DataImportEventPayload;
+import org.folio.inventory.client.InstanceLinkClient;
 import org.folio.inventory.client.OrdersClient;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.dao.EntityIdStorageDaoImpl;
@@ -200,6 +201,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
 
   private void registerDataImportProcessingHandlers(Storage storage, HttpClient client) {
     OrdersClient ordersClient = new OrdersClient(WebClient.wrap(client));
+    InstanceLinkClient instanceLinkClient = new InstanceLinkClient(WebClient.wrap(client));
     OrdersPreloaderHelper ordersPreloaderHelper = new OrdersPreloaderHelper(ordersClient);
     InstancePreloader instancePreloader = new InstancePreloader(ordersPreloaderHelper);
     HoldingsPreloader holdingsPreloader = new HoldingsPreloader(ordersPreloaderHelper);
@@ -241,7 +243,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     EventManager.registerEventHandler(new DeleteAuthorityEventHandler(storage));
     EventManager.registerEventHandler(new UpdateItemEventHandler(storage, mappingMetadataCache));
     EventManager.registerEventHandler(new UpdateHoldingEventHandler(storage, mappingMetadataCache));
-    EventManager.registerEventHandler(new ReplaceInstanceEventHandler(storage, precedingSucceedingTitlesHelper, mappingMetadataCache, client, consortiumService));
+    EventManager.registerEventHandler(new ReplaceInstanceEventHandler(storage, precedingSucceedingTitlesHelper, mappingMetadataCache, client, consortiumService, instanceLinkClient));
     EventManager.registerEventHandler(new MarcBibModifiedPostProcessingEventHandler(new InstanceUpdateDelegate(storage), precedingSucceedingTitlesHelper, mappingMetadataCache));
     EventManager.registerEventHandler(new MarcBibModifyEventHandler(mappingMetadataCache, new InstanceUpdateDelegate(storage), precedingSucceedingTitlesHelper, client));
   }

--- a/src/main/java/org/folio/inventory/dataimport/exceptions/InstanceLinksException.java
+++ b/src/main/java/org/folio/inventory/dataimport/exceptions/InstanceLinksException.java
@@ -1,0 +1,9 @@
+package org.folio.inventory.dataimport.exceptions;
+
+public class InstanceLinksException extends RuntimeException {
+
+  public InstanceLinksException(String message) {
+    super(message);
+  }
+}
+

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
@@ -1,17 +1,61 @@
 package org.folio.inventory.dataimport.handlers.actions;
 
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.folio.ActionProfile.Action.UPDATE;
+import static org.folio.ActionProfile.FolioRecord.INSTANCE;
+import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
+import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
+import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
+import static org.folio.inventory.consortium.util.MarcRecordUtil.isSubfieldExist;
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.PAYLOAD_USER_ID;
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.constructContext;
+import static org.folio.inventory.dataimport.util.LoggerUtil.INCOMING_RECORD_ID;
+import static org.folio.inventory.dataimport.util.LoggerUtil.logParametersEventHandler;
+import static org.folio.inventory.dataimport.util.MappingConstants.INSTANCE_PATH;
+import static org.folio.inventory.dataimport.util.MappingConstants.INSTANCE_REQUIRED_FIELDS;
+import static org.folio.inventory.domain.instances.Instance.HRID_KEY;
+import static org.folio.inventory.domain.instances.Instance.METADATA_KEY;
+import static org.folio.inventory.domain.instances.Instance.SOURCE_KEY;
+import static org.folio.inventory.domain.instances.InstanceSource.CONSORTIUM_FOLIO;
+import static org.folio.inventory.domain.instances.InstanceSource.CONSORTIUM_MARC;
+import static org.folio.inventory.domain.instances.InstanceSource.FOLIO;
+import static org.folio.inventory.domain.instances.InstanceSource.LINKED_DATA;
+import static org.folio.inventory.domain.instances.InstanceSource.MARC;
+import static org.folio.okapi.common.XOkapiHeaders.PERMISSIONS;
+import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
+
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
+import org.folio.InstanceLinkDtoCollection;
+import org.folio.Link;
+import org.folio.LinkingRuleDto;
 import org.folio.MappingMetadataDto;
 import org.folio.ParsedRecord;
 import org.folio.Record;
+import org.folio.inventory.client.InstanceLinkClient;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.consortium.services.ConsortiumService;
@@ -29,47 +73,13 @@ import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.processing.mapping.mapper.MappingContext;
+import org.folio.processing.mapping.mapper.writer.marc.MarcBibRecordModifier;
 import org.folio.processing.mapping.mapper.writer.marc.MarcRecordModifier;
 import org.folio.rest.client.SourceStorageRecordsClient;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.MarcFieldProtectionSetting;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Snapshot;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-
-import static java.lang.String.format;
-import static java.util.Objects.nonNull;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-import static org.folio.ActionProfile.Action.UPDATE;
-import static org.folio.ActionProfile.FolioRecord.INSTANCE;
-import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
-import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
-import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
-import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.PAYLOAD_USER_ID;
-import static org.folio.inventory.dataimport.util.LoggerUtil.INCOMING_RECORD_ID;
-import static org.folio.inventory.dataimport.util.LoggerUtil.logParametersEventHandler;
-import static org.folio.inventory.dataimport.util.MappingConstants.INSTANCE_PATH;
-import static org.folio.inventory.dataimport.util.MappingConstants.INSTANCE_REQUIRED_FIELDS;
-import static org.folio.inventory.domain.instances.Instance.HRID_KEY;
-import static org.folio.inventory.domain.instances.Instance.METADATA_KEY;
-import static org.folio.inventory.domain.instances.Instance.SOURCE_KEY;
-import static org.folio.inventory.domain.instances.InstanceSource.CONSORTIUM_FOLIO;
-import static org.folio.inventory.domain.instances.InstanceSource.CONSORTIUM_MARC;
-import static org.folio.inventory.domain.instances.InstanceSource.FOLIO;
-import static org.folio.inventory.domain.instances.InstanceSource.LINKED_DATA;
-import static org.folio.inventory.domain.instances.InstanceSource.MARC;
-import static org.folio.okapi.common.XOkapiHeaders.PERMISSIONS;
-import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 
 public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { // NOSONAR
 
@@ -87,17 +97,20 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
   public static final String INSTANCE_ID_TYPE = "INSTANCE";
   public static final String CENTRAL_TENANT_INSTANCE_UPDATED_FLAG = "CENTRAL_TENANT_INSTANCE_UPDATED";
   public static final String CENTRAL_TENANT_ID = "CENTRAL_TENANT_ID";
-  private final ConsortiumService consortiumService;
   public static final String MARC_BIB_RECORD_CREATED = "MARC_BIB_RECORD_CREATED";
   static final String CENTRAL_RECORD_UPDATE_PERMISSION = "consortia.data-import.central-record-update.execute";
+
+  private final ConsortiumService consortiumService;
+  private final InstanceLinkClient instanceLinkClient;
 
   public ReplaceInstanceEventHandler(Storage storage,
                                      PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper,
                                      MappingMetadataCache mappingMetadataCache,
                                      HttpClient client,
-                                     ConsortiumService consortiumService) {
+                                     ConsortiumService consortiumService, InstanceLinkClient instanceLinkClient) {
     super(storage, precedingSucceedingTitlesHelper, mappingMetadataCache, client);
     this.consortiumService = consortiumService;
+    this.instanceLinkClient = instanceLinkClient;
   }
 
   @Override
@@ -363,45 +376,133 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
       });
   }
 
-  private Future<Void> prepareRecordForMapping(DataImportEventPayload dataImportEventPayload,
+  private Future<Void> prepareRecordForMapping(DataImportEventPayload eventPayload,
                                                List<MarcFieldProtectionSetting> marcFieldProtectionSettings,
                                                Instance instance, MappingParameters mappingParameters, String tenantId) {
     if (MARC_INSTANCE_SOURCE.equals(instance.getSource()) || CONSORTIUM_MARC.getValue().equals(instance.getSource())) {
-      SourceStorageRecordsClient client = getSourceStorageRecordsClient(dataImportEventPayload.getOkapiUrl(), dataImportEventPayload.getToken(), tenantId, null);
+      SourceStorageRecordsClient client = getSourceStorageRecordsClient(eventPayload.getOkapiUrl(), eventPayload.getToken(), tenantId, null);
       return getRecordByInstanceId(client, instance.getId())
         .compose(existingRecord -> {
-          Record incomingRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
-          String updatedContent = new MarcRecordModifier().updateRecord(incomingRecord, existingRecord, marcFieldProtectionSettings);
-          incomingRecord.getParsedRecord().setContent(updatedContent);
+          var linkingRules = Optional.ofNullable(mappingParameters.getLinkingRules());
+          var context = constructContext(eventPayload.getTenant(), eventPayload.getToken(), eventPayload.getOkapiUrl(),
+            eventPayload.getContext().get(PAYLOAD_USER_ID));
+          var incomingRecord = Json.decodeValue(eventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
 
-          if (instance.getSource().equals(MARC.getValue())) {
-            incomingRecord.setMatchedId(existingRecord.getMatchedId());
-            if (nonNull(existingRecord.getGeneration())) {
-              int incrementedGeneration = existingRecord.getGeneration();
-              incomingRecord.setGeneration(++incrementedGeneration);
-            }
-            String updatedIncomingRecord = Json.encode(incomingRecord);
-            org.folio.rest.jaxrs.model.Record targetRecord = Json.decodeValue(updatedIncomingRecord, org.folio.rest.jaxrs.model.Record.class);
+          return loadInstanceLink(existingRecord, instance.getId(), context)
+            .compose(links -> updateMarcRecordContent(incomingRecord, existingRecord, marcFieldProtectionSettings, links, linkingRules.orElse(emptyList())))
+            .map(linksForUpdate -> {
+              if (instance.getSource().equals(MARC.getValue())) {
+                incomingRecord.setMatchedId(existingRecord.getMatchedId());
+                if (nonNull(existingRecord.getGeneration())) {
+                  int incrementedGeneration = existingRecord.getGeneration();
+                  incomingRecord.setGeneration(++incrementedGeneration);
+                }
+                var updatedIncomingRecord = Json.encode(incomingRecord);
+                var targetRecord = Json.decodeValue(updatedIncomingRecord, org.folio.rest.jaxrs.model.Record.class);
 
-            AdditionalFieldsUtil.updateLatestTransactionDate(targetRecord, mappingParameters);
-            AdditionalFieldsUtil.normalize035(targetRecord);
-            AdditionalFieldsUtil.remove035FieldWhenRecordContainsHrId(targetRecord);
-            dataImportEventPayload.getContext().put(MARC_BIBLIOGRAPHIC.value(), Json.encode(targetRecord));
-          } else {
-            dataImportEventPayload.getContext().put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
-          }
-          return Future.succeededFuture();
+                AdditionalFieldsUtil.updateLatestTransactionDate(targetRecord, mappingParameters);
+                AdditionalFieldsUtil.normalize035(targetRecord);
+                AdditionalFieldsUtil.remove035FieldWhenRecordContainsHrId(targetRecord);
+                eventPayload.getContext().put(MARC_BIBLIOGRAPHIC.value(), Json.encode(targetRecord));
+              } else {
+                eventPayload.getContext().put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
+              }
+              return linksForUpdate;
+            })
+            .compose(linksForUpdate -> updateInstanceLinks(instance.getId(), linksForUpdate, context));
         });
     } else if (instance.getSource().equals(FOLIO.getValue())) {
-      String marcBibAsJson = dataImportEventPayload.getContext().get(EntityType.MARC_BIBLIOGRAPHIC.value());
+      String marcBibAsJson = eventPayload.getContext().get(EntityType.MARC_BIBLIOGRAPHIC.value());
       org.folio.rest.jaxrs.model.Record targetRecord = Json.decodeValue(marcBibAsJson, org.folio.rest.jaxrs.model.Record.class);
 
       AdditionalFieldsUtil.updateLatestTransactionDate(targetRecord, mappingParameters);
       AdditionalFieldsUtil.move001To035(targetRecord);
       AdditionalFieldsUtil.normalize035(targetRecord);
-      dataImportEventPayload.getContext().put(MARC_BIBLIOGRAPHIC.value(), Json.encode(targetRecord));
+      eventPayload.getContext().put(MARC_BIBLIOGRAPHIC.value(), Json.encode(targetRecord));
     }
     return Future.succeededFuture();
+  }
+
+  private Future<Optional<InstanceLinkDtoCollection>> updateMarcRecordContent(
+    Record incomingRecord, Record existingRecord, List<MarcFieldProtectionSetting> protectionSettings,
+    Optional<InstanceLinkDtoCollection> links, List<LinkingRuleDto> linkingRules) {
+
+    var promise = Promise.<Optional<InstanceLinkDtoCollection>>promise();
+    try {
+      if (links.isPresent()) {
+        var recordModifier = new MarcBibRecordModifier();
+        recordModifier.setLinks(links.get(), linkingRules);
+        var updatedContent = recordModifier.updateRecord(incomingRecord, existingRecord, protectionSettings);
+        incomingRecord.getParsedRecord().setContent(updatedContent);
+        if (isLinksTheSame(links.get(), recordModifier.getBibAuthorityLinksKept())) {
+          promise.complete(Optional.empty());
+        } else {
+          promise.complete(
+            Optional.of(new InstanceLinkDtoCollection().withLinks(recordModifier.getBibAuthorityLinksKept())));
+        }
+      } else {
+        var recordModifier = new MarcRecordModifier();
+        var updatedContent = recordModifier.updateRecord(incomingRecord, existingRecord, protectionSettings);
+        incomingRecord.getParsedRecord().setContent(updatedContent);
+        promise.complete(Optional.empty());
+      }
+    } catch (Exception e) {
+      promise.fail(e);
+    }
+    return promise.future();
+  }
+
+  private boolean isLinksTheSame(InstanceLinkDtoCollection links, List<Link> bibAuthorityLinksKept) {
+    if (links.getLinks().size() != bibAuthorityLinksKept.size()) {
+      return false;
+    }
+    for (Link link : links.getLinks()) {
+      if (!bibAuthorityLinksKept.contains(link)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private Future<Optional<InstanceLinkDtoCollection>> loadInstanceLink(Record oldRecord, String instanceId,
+                                                                       Context context) {
+    Promise<Optional<InstanceLinkDtoCollection>> promise = Promise.promise();
+    if (isSubfieldExist(oldRecord, '9')) {
+      if (isNull(instanceId) || isBlank(instanceId)) {
+        instanceId = oldRecord.getExternalIdsHolder().getInstanceId();
+      }
+      instanceLinkClient.getLinksByInstanceId(instanceId, context)
+        .whenComplete((instanceLinkDtoCollection, throwable) -> {
+          if (throwable != null) {
+            LOGGER.error(throwable.getMessage());
+            promise.fail(throwable);
+          } else {
+            promise.complete(instanceLinkDtoCollection);
+          }
+        });
+    } else {
+      promise.complete(Optional.empty());
+    }
+
+    return promise.future();
+  }
+
+  private Future<Void> updateInstanceLinks(String instanceId, Optional<InstanceLinkDtoCollection> links,
+                                           Context context) {
+    Promise<Void> promise = Promise.promise();
+    if (links.isPresent()) {
+      instanceLinkClient.updateInstanceLinks(instanceId, links.get(), context)
+        .whenComplete((v, throwable) -> {
+          if (throwable != null) {
+            promise.fail(throwable);
+          } else {
+            promise.complete();
+          }
+        });
+    } else {
+      promise.complete();
+    }
+    return promise.future();
   }
 
   protected Future<Record> getRecordByInstanceId(SourceStorageRecordsClient client, String instanceId) {

--- a/src/main/java/org/folio/inventory/instanceingress/handler/UpdateInstanceIngressEventHandler.java
+++ b/src/main/java/org/folio/inventory/instanceingress/handler/UpdateInstanceIngressEventHandler.java
@@ -40,7 +40,7 @@ public class UpdateInstanceIngressEventHandler extends ReplaceInstanceEventHandl
                                            HttpClient client,
                                            Context context,
                                            Storage storage) {
-    super(storage, precedingSucceedingTitlesHelper, mappingMetadataCache, client, null);
+    super(storage, precedingSucceedingTitlesHelper, mappingMetadataCache, client, null, null);
     this.instanceCollection = storage.getInstanceCollection(context);
     this.context = context;
   }

--- a/src/test/java/org/folio/inventory/client/InstanceLinkClientTest.java
+++ b/src/test/java/org/folio/inventory/client/InstanceLinkClientTest.java
@@ -1,0 +1,143 @@
+package org.folio.inventory.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.UUID;
+import org.folio.InstanceLinkDtoCollection;
+import org.folio.inventory.common.Context;
+import org.folio.inventory.dataimport.exceptions.InstanceLinksException;
+import org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class InstanceLinkClientTest {
+
+  private static final String TENANT_ID = "diku";
+  private static final String LINKS_API_PREFIX = "/links/instances/";
+
+  private final Vertx vertx = Vertx.vertx();
+  private InstanceLinkClient instanceLinkClient;
+  private Context context;
+  private String instanceIdMock;
+
+  @Rule
+  public WireMockRule mockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new Slf4jNotifier(true)));
+
+  @Before
+  public void setUp() {
+    instanceLinkClient = new InstanceLinkClient(io.vertx.ext.web.client.WebClient.wrap(vertx.createHttpClient()));
+    context = EventHandlingUtil.constructContext(TENANT_ID, "token", mockServer.baseUrl());
+    instanceIdMock = UUID.randomUUID().toString();
+  }
+
+  @Test
+  public void shouldReturnInstanceLinkDtoCollectionWhenFound(TestContext testContext) {
+    var async = testContext.async();
+    var dto = new InstanceLinkDtoCollection();
+    var dtoJson = Json.encode(dto);
+
+    stubFor(get(urlEqualTo(LINKS_API_PREFIX + instanceIdMock))
+        .willReturn(ok(dtoJson)));
+
+    var future = instanceLinkClient.getLinksByInstanceId(instanceIdMock, context);
+
+    future.whenComplete((result, throwable) -> {
+      testContext.assertNull(throwable);
+      testContext.assertTrue(result.isPresent());
+      testContext.assertEquals(dtoJson, Json.encode(result.get()));
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnEmptyOptionalWhenNotFound(TestContext testContext) {
+    var async = testContext.async();
+
+    stubFor(get(urlEqualTo(LINKS_API_PREFIX + instanceIdMock))
+        .willReturn(notFound()));
+
+    var future = instanceLinkClient.getLinksByInstanceId(instanceIdMock, context);
+
+    future.whenComplete((result, throwable) -> {
+      testContext.assertNull(throwable);
+      testContext.assertFalse(result.isPresent());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldFailFutureWhenServerError(TestContext testContext) {
+    var async = testContext.async();
+
+    stubFor(get(urlEqualTo(LINKS_API_PREFIX + instanceIdMock))
+        .willReturn(serverError().withBody("Server error")));
+
+    var future = instanceLinkClient.getLinksByInstanceId(instanceIdMock, context);
+
+    future.whenComplete((result, throwable) -> {
+      testContext.assertNull(result);
+      testContext.assertNotNull(throwable);
+      testContext.assertTrue(throwable.getCause() instanceof InstanceLinksException);
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldUpdateInstanceLinksSuccessfully(TestContext testContext) {
+    var async = testContext.async();
+    var dto = new InstanceLinkDtoCollection();
+    var dtoJson = Json.encode(dto);
+
+    stubFor(put(urlEqualTo(LINKS_API_PREFIX + instanceIdMock))
+        .withRequestBody(equalToJson(new JsonObject(dtoJson).encode()))
+        .willReturn(aResponse().withStatus(204)));
+
+    var future = instanceLinkClient.updateInstanceLinks(instanceIdMock, dto, context);
+
+    future.whenComplete((result, throwable) -> {
+      testContext.assertNull(throwable);
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldLogWarningWhenUpdateInstanceLinksFails(TestContext testContext) {
+    var async = testContext.async();
+    var dto = new InstanceLinkDtoCollection();
+    var dtoJson = Json.encode(dto);
+
+    stubFor(put(urlEqualTo(LINKS_API_PREFIX + instanceIdMock))
+        .withRequestBody(equalToJson(new JsonObject(dtoJson).encode()))
+        .willReturn(aResponse().withStatus(500).withBody("Update failed")));
+
+    var future = instanceLinkClient.updateInstanceLinks(instanceIdMock, dto, context);
+
+    future.whenComplete((result, throwable) -> {
+      testContext.assertNull(throwable);
+      async.complete();
+    });
+  }
+}
+

--- a/src/test/java/org/folio/inventory/consortium/util/MarcRecordUtilTest.java
+++ b/src/test/java/org/folio/inventory/consortium/util/MarcRecordUtilTest.java
@@ -96,4 +96,26 @@ public class MarcRecordUtilTest {
       assertFalse(field.containsKey(fieldTagToRemove));
     }
   }
+
+  @Test
+  public void isSubfieldExistReturnsTrue() {
+    var marcJson = "{\"leader\":\"00000cam a2200000 a 4500\",\"fields\":[{\"100\":{\"subfields\":[{\"a\":\"John Doe\"},{\"9\":\"test\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var recordWith9 = new Record();
+    var parsedRecord = new ParsedRecord();
+    parsedRecord.setContent(marcJson);
+    recordWith9.setParsedRecord(parsedRecord);
+    var result = MarcRecordUtil.isSubfieldExist(recordWith9, '9');
+    Assert.assertTrue(result);
+  }
+
+  @Test
+  public void isSubfieldExistReturnsFalse() {
+    var marcJson = "{\"leader\":\"00000cam a2200000 a 4500\",\"fields\":[{\"100\":{\"subfields\":[{\"a\":\"John Doe\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var recordWithout9 = new Record();
+    var parsedRecord = new ParsedRecord();
+    parsedRecord.setContent(marcJson);
+    recordWithout9.setParsedRecord(parsedRecord);
+    var result = MarcRecordUtil.isSubfieldExist(recordWithout9, '9');
+    Assert.assertFalse(result);
+  }
 }

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
@@ -1,5 +1,54 @@
 package org.folio.inventory.dataimport.handlers.actions;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.completedStage;
+import static org.folio.ActionProfile.FolioRecord.INSTANCE;
+import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
+import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED;
+import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_MATCHED;
+import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
+import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
+import static org.folio.inventory.TestUtil.buildHttpResponseWithBuffer;
+import static org.folio.inventory.dataimport.handlers.actions.ReplaceInstanceEventHandler.ACTION_HAS_NO_MAPPING_MSG;
+import static org.folio.inventory.dataimport.handlers.actions.ReplaceInstanceEventHandler.CENTRAL_RECORD_UPDATE_PERMISSION;
+import static org.folio.inventory.dataimport.handlers.actions.ReplaceInstanceEventHandler.MARC_BIB_RECORD_CREATED;
+import static org.folio.inventory.dataimport.handlers.actions.ReplaceInstanceEventHandler.USER_HAS_NO_PERMISSION_MSG;
+import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.PAYLOAD_USER_ID;
+import static org.folio.inventory.dataimport.util.ParsedRecordUtil.LEADER_STATUS_DELETED;
+import static org.folio.inventory.dataimport.util.ParsedRecordUtil.normalize;
+import static org.folio.inventory.domain.instances.InstanceSource.CONSORTIUM_MARC;
+import static org.folio.inventory.domain.instances.InstanceSource.FOLIO;
+import static org.folio.inventory.domain.instances.InstanceSource.MARC;
+import static org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle.TITLE_KEY;
+import static org.folio.okapi.common.XOkapiHeaders.PERMISSIONS;
+import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -15,15 +64,34 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
+import org.folio.InstanceLinkDtoCollection;
 import org.folio.JobProfile;
+import org.folio.Link;
+import org.folio.LinkingRuleDto;
 import org.folio.MappingMetadataDto;
 import org.folio.MappingProfile;
 import org.folio.inventory.TestUtil;
+import org.folio.inventory.client.InstanceLinkClient;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.common.domain.Success;
@@ -69,68 +137,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static java.util.concurrent.CompletableFuture.completedStage;
-import static org.folio.ActionProfile.FolioRecord.INSTANCE;
-import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
-import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED;
-import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_MATCHED;
-import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
-import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
-import static org.folio.inventory.TestUtil.buildHttpResponseWithBuffer;
-import static org.folio.inventory.dataimport.handlers.actions.ReplaceInstanceEventHandler.ACTION_HAS_NO_MAPPING_MSG;
-import static org.folio.inventory.dataimport.handlers.actions.ReplaceInstanceEventHandler.CENTRAL_RECORD_UPDATE_PERMISSION;
-import static org.folio.inventory.dataimport.handlers.actions.ReplaceInstanceEventHandler.MARC_BIB_RECORD_CREATED;
-import static org.folio.inventory.dataimport.handlers.actions.ReplaceInstanceEventHandler.USER_HAS_NO_PERMISSION_MSG;
-import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.PAYLOAD_USER_ID;
-import static org.folio.inventory.dataimport.util.ParsedRecordUtil.LEADER_STATUS_DELETED;
-import static org.folio.inventory.dataimport.util.ParsedRecordUtil.normalize;
-import static org.folio.inventory.domain.instances.InstanceSource.CONSORTIUM_MARC;
-import static org.folio.inventory.domain.instances.InstanceSource.FOLIO;
-import static org.folio.inventory.domain.instances.InstanceSource.MARC;
-import static org.folio.inventory.domain.instances.titles.PrecedingSucceedingTitle.TITLE_KEY;
-import static org.folio.okapi.common.XOkapiHeaders.PERMISSIONS;
-import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 public class ReplaceInstanceEventHandlerTest {
 
   private static final String PARSED_CONTENT = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"titleValue\"}]}},{\"336\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"b\":\"b6698d38-149f-11ec-82a8-0242ac130003\"}]}},{\"780\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"Houston oil directory\"}]}},{\"785\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"t\":\"SAIS review of international affairs\"},{\"x\":\"1945-4724\"}]}},{\"500\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Adaptation of Xi xiang ji by Wang Shifu.\"}]}},{\"520\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"Ben shu miao shu le cui ying ying he zhang sheng wei zheng qu hun yin zi you li jin qu zhe jian xin zhi hou, zhong cheng juan shu de ai qing gu shi. jie lu le bao ban hun yin he feng jian li jiao de zui e.\"}]}}]}";
@@ -165,6 +171,8 @@ public class ReplaceInstanceEventHandlerTest {
   private OkapiHttpClient mockedClient;
   @Mock
   private ConsortiumServiceImpl consortiumServiceImpl;
+  @Mock
+  private InstanceLinkClient instanceLinkClient;
   @Spy
   private MarcBibReaderFactory fakeReaderFactory = new MarcBibReaderFactory();
   @Mock
@@ -308,14 +316,18 @@ public class ReplaceInstanceEventHandlerTest {
 
     WireMock.stubFor(get(new UrlPathPattern(new RegexPattern(MAPPING_METADATA_URL + "/.*"), true))
       .willReturn(WireMock.ok().withBody(Json.encode(new MappingMetadataDto()
-        .withMappingParams(Json.encode(new MappingParameters()))
+        .withMappingParams(Json.encode(new MappingParameters()
+          .withLinkingRules(List.of(new LinkingRuleDto()
+            .withId(1)
+            .withBibField("100")
+            .withAuthorityField("100")))))
         .withMappingRules(mappingRules.toString())))));
 
     precedingSucceedingTitlesHelper = spy(new PrecedingSucceedingTitlesHelper(ctxt -> mockedClient));
 
     Vertx vertx = Vertx.vertx();
     replaceInstanceEventHandler = spy(new ReplaceInstanceEventHandler(storage, precedingSucceedingTitlesHelper, MappingMetadataCache.getInstance(vertx,
-      vertx.createHttpClient(), true), vertx.createHttpClient(), consortiumServiceImpl));
+      vertx.createHttpClient(), true), vertx.createHttpClient(), consortiumServiceImpl, instanceLinkClient));
 
     var recordUUID = UUID.randomUUID().toString();
     HttpResponse<Buffer> recordHttpResponse = buildHttpResponseWithBuffer(BufferImpl.buffer(String.format(EXISTING_SRS_CONTENT, recordUUID, recordUUID, 0)), HttpStatus.SC_OK);
@@ -575,7 +587,7 @@ public class ReplaceInstanceEventHandlerTest {
 
     JsonObject precedingSucceedingTitles = new JsonObject().put(PRECEDING_SUCCEEDING_TITLES_KEY, new JsonArray().add(existingPrecedingTitle));
     when(mockedClient.get(anyString()))
-      .thenReturn(CompletableFuture.completedFuture(createResponse(HttpStatus.SC_OK, precedingSucceedingTitles.encode())));
+      .thenReturn(completedFuture(createResponse(HttpStatus.SC_OK, precedingSucceedingTitles.encode())));
 
     String instanceTypeId = UUID.randomUUID().toString();
     String title = "titleValue";
@@ -1233,7 +1245,7 @@ public class ReplaceInstanceEventHandlerTest {
 
     mockInstance(MARC_INSTANCE_SOURCE);
 
-    when(instanceRecordCollection.findById(anyString())).thenReturn(CompletableFuture.completedFuture(returnedInstance));
+    when(instanceRecordCollection.findById(anyString())).thenReturn(completedFuture(returnedInstance));
 
     doAnswer(invocationOnMock -> {
       Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
@@ -1821,6 +1833,98 @@ public class ReplaceInstanceEventHandlerTest {
   @Test
   public void shouldReturnPostProcessingInitializationEventType() {
     assertEquals(DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING.value(), replaceInstanceEventHandler.getPostProcessingInitializationEventType());
+  }
+
+  @Test
+  @SneakyThrows
+  public void shouldNotUpdateLinksWhenIncomingZeroSubfieldIsSameAsExisting() {
+    // given
+    var incomingParsedContent =
+      "{\"leader\":\"02340cam a2200301Ki 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+        "{\"100\":{\"subfields\":[{\"a\":\"Chin, Staceyann Test,\"},{\"e\":\"author updated.\"},{\"0\":\"http://id.loc.gov/authorities/names/n2008052404\"}],\"ind1\":\"1\",\"ind2\":\" \"}}]}";
+    var expectedParsedContent =
+      "{\"leader\":\"00220cam a2200061Ki 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+        "{\"100\":{\"subfields\":[{\"a\":\"Chin, Staceyann Test,\"},{\"e\":\"author updated.\"},{\"0\":\"http://id.loc.gov/authorities/names/n2008052404\"},{\"9\":\"5a56ffa8-e274-40ca-8620-34a23b5b45dd\"}],\"ind1\":\"1\",\"ind2\":\" \"}}]}";
+
+    var fakeReader = Mockito.mock(Reader.class);
+    var instanceTypeId = UUID.randomUUID().toString();
+    var title = "titleValue";
+
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(instanceTypeId), StringValue.of(title));
+    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+    when(storage.getInstanceCollection(any())).thenReturn(instanceRecordCollection);
+
+    MappingManager.registerReaderFactory(fakeReaderFactory);
+    MappingManager.registerWriterFactory(new InstanceWriterFactory());
+
+    var context = new HashMap<String, String>();
+    var recordId = UUID.randomUUID().toString();
+    var incomingRecord = new Record().withId(recordId).withMatchedId(recordId).withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
+    context.put(INSTANCE.value(), new JsonObject()
+      .put("id", instanceId)
+      .put("hrid", UUID.randomUUID().toString())
+      .put("source", MARC_INSTANCE_SOURCE)
+      .put("_version", INSTANCE_VERSION)
+      .put("discoverySuppress", false)
+      .encode());
+
+    mockInstance(MARC_INSTANCE_SOURCE);
+
+    var expectedRecord = new Record()
+      .withId(recordId)
+      .withMatchedId(recordId)
+      .withParsedRecord(new ParsedRecord()
+        .withId(recordId)
+        .withContent(new JsonObject(expectedParsedContent)));
+    var buffer = BufferImpl.buffer(JsonObject.mapFrom(expectedRecord).encode());
+    var respForPass = buildHttpResponseWithBuffer(buffer, HttpStatus.SC_OK);
+    when(sourceStorageClient.getSourceStorageRecordsFormattedById(any(), any()))
+      .thenReturn(Future.succeededFuture(respForPass));
+    when(sourceStorageClient.putSourceStorageRecordsGenerationById(any(), any())).thenReturn(Future.succeededFuture(respForPass));
+
+    var authorityId = "5a56ffa8-e274-40ca-8620-34a23b5b45dd";
+    var links = new InstanceLinkDtoCollection()
+      .withLinks(List.of(new Link()
+        .withInstanceId(instanceId.toString())
+        .withId(2)
+        .withLinkingRuleId(1)
+        .withAuthorityId(authorityId)
+        .withAuthorityNaturalId("n2008052404")));
+    when(instanceLinkClient.getLinksByInstanceId(eq(instanceId.toString()), any())).thenReturn(completedFuture(Optional.of(links)));
+
+    var dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_INSTANCE_CREATED.value())
+      .withContext(context)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0))
+      .withTenant(TENANT_ID)
+      .withOkapiUrl(mockServer.baseUrl())
+      .withToken(TOKEN)
+      .withJobExecutionId(UUID.randomUUID().toString());
+
+    var future = replaceInstanceEventHandler.handle(dataImportEventPayload);
+    var actualDataImportEventPayload = future.get(20, TimeUnit.SECONDS);
+
+    assertEquals(DI_INVENTORY_INSTANCE_UPDATED.value(), actualDataImportEventPayload.getEventType());
+    assertNotNull(actualDataImportEventPayload.getContext().get(INSTANCE.value()));
+    var createdInstance = new JsonObject(actualDataImportEventPayload.getContext().get(INSTANCE.value()));
+    assertNotNull(createdInstance.getString("id"));
+    assertEquals(title, createdInstance.getString("title"));
+    assertEquals(instanceTypeId, createdInstance.getString("instanceTypeId"));
+    assertEquals(MARC_INSTANCE_SOURCE, createdInstance.getString("source"));
+    assertTrue(actualDataImportEventPayload.getContext().containsKey(MARC_BIB_RECORD_CREATED));
+    assertFalse(Boolean.parseBoolean(actualDataImportEventPayload.getContext().get(MARC_BIB_RECORD_CREATED)));
+    assertThat(createdInstance.getString("_version"), is(INSTANCE_VERSION_AS_STRING));
+    var updatedBib = actualDataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value());
+    var updatedBibContent = new JsonObject(updatedBib).getJsonObject("parsedRecord").getString("content");
+    assertThat(updatedBibContent, is(expectedParsedContent));
+    verify(sourceStorageClient).getSourceStorageRecordsFormattedById(anyString(), eq(INSTANCE.value()));
+    verify(1, getRequestedFor(new UrlPathPattern(new RegexPattern(MAPPING_METADATA_URL + "/.*"), true)));
+
+    var recordCaptor = ArgumentCaptor.forClass(Record.class);
+    verify(sourceStorageClient).putSourceStorageRecordsGenerationById(any(), recordCaptor.capture());
+    assertThat(recordCaptor.getValue().getParsedRecord().getContent().toString(), containsString(authorityId));
+    verify(instanceLinkClient, times(0)).updateInstanceLinks(any(), any(), any());
   }
 
   private Response createResponse(int statusCode, String body) {

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
@@ -868,7 +868,6 @@ public class ReplaceInstanceEventHandlerTest {
     verify(storage).getInstanceCollection(contextCaptor.capture());
     assertEquals(consortiumTenant, contextCaptor.getValue().getTenantId());
 
-    ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
     verify(sourceStorageClient).postSourceStorageRecords(recordCaptor.capture());
     verify(replaceInstanceEventHandler).getSourceStorageRecordsClient(any(), any(), argThat(tenantId -> tenantId.equals(consortiumTenant)), argThat(USER_ID::equals));
     verify(replaceInstanceEventHandler).getSourceStorageSnapshotsClient(any(), any(), argThat(tenantId -> tenantId.equals(consortiumTenant)), argThat(USER_ID::equals));
@@ -938,7 +937,6 @@ public class ReplaceInstanceEventHandlerTest {
     verify(storage).getInstanceCollection(contextCaptor.capture());
     assertEquals(consortiumTenant, contextCaptor.getValue().getTenantId());
 
-    ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
     verify(sourceStorageClient).putSourceStorageRecordsGenerationById(any(), recordCaptor.capture());
     verify(replaceInstanceEventHandler, times(2)).getSourceStorageRecordsClient(any(), any(), argThat(tenantId -> tenantId.equals(consortiumTenant)), any());
     verify(replaceInstanceEventHandler).getSourceStorageSnapshotsClient(any(), any(), argThat(tenantId -> tenantId.equals(consortiumTenant)), any());
@@ -1334,7 +1332,6 @@ public class ReplaceInstanceEventHandlerTest {
     assertTrue(Boolean.parseBoolean(actualDataImportEventPayload.getContext().get(MARC_BIB_RECORD_CREATED)));
     verify(0, getRequestedFor(new UrlPathPattern(new RegexPattern(SOURCE_RECORDS_PATH + "/.{36}"), true)));
 
-    ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
     verify(sourceStorageClient).postSourceStorageRecords(recordCaptor.capture());
     assertNotNull(recordId, recordCaptor.getValue().getMatchedId());
   }
@@ -1921,7 +1918,6 @@ public class ReplaceInstanceEventHandlerTest {
     verify(sourceStorageClient).getSourceStorageRecordsFormattedById(anyString(), eq(INSTANCE.value()));
     verify(1, getRequestedFor(new UrlPathPattern(new RegexPattern(MAPPING_METADATA_URL + "/.*"), true)));
 
-    var recordCaptor = ArgumentCaptor.forClass(Record.class);
     verify(sourceStorageClient).putSourceStorageRecordsGenerationById(any(), recordCaptor.capture());
     assertThat(recordCaptor.getValue().getParsedRecord().getContent().toString(), containsString(authorityId));
     verify(instanceLinkClient, times(0)).updateInstanceLinks(any(), any(), any());


### PR DESCRIPTION
## Purpose
Add instance-authority links logic on MARC Instance update
[MODINV-1068](https://folio-org.atlassian.net/browse/MODINV-1068)

## Approach
- Implement links client
- Use MarcBibRecordModifier on Instance replacement when Instance source is MARC

## Testing
Tested on dev Rancher with telepresence, works as expected, $9 is not removed from record, record editable via quick-marc
<img width="990" height="212" alt="Screenshot from 2025-07-22 12-34-24" src="https://github.com/user-attachments/assets/7a6ec73e-c8f9-4b15-8c64-adeef9b8c839" />
<img width="612" height="662" alt="Screenshot from 2025-07-22 12-35-00" src="https://github.com/user-attachments/assets/dcd2a93d-2ae2-4bb5-bfce-7b7e224f66b5" />
