### PR TITLE
MODINV-1272 - Set groupInstanceId property during consumer wrapper creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>3.3.1</version>
+      <version>3.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/src/main/java/org/folio/inventory/support/KafkaConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/support/KafkaConsumerVerticle.java
@@ -20,6 +20,8 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+
 import org.apache.logging.log4j.Logger;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.cache.ProfileSnapshotCache;
@@ -69,6 +71,7 @@ public abstract class KafkaConsumerVerticle extends AbstractVerticle {
       .loadLimit(getLoadLimit(loadLimitPropertyKey))
       .globalLoadSensor(new GlobalLoadSensor())
       .subscriptionDefinition(getSubscriptionDefinition(getKafkaConfig().getEnvId(), eventType, namespacedTopic))
+      .groupInstanceId(getClass().getSimpleName() + "-" + UUID.randomUUID())
       .build();
     consumerWrappers.add(kafkaConsumerWrapper);
     return kafkaConsumerWrapper;


### PR DESCRIPTION
## Purpose
to configure "group.instance.id" property during consumer wrapper creation


## Learning
[MODINV-1272](https://issues.folio.org/browse/MODINV-1272)