### PR TITLE
MODINV-1078 - POST to /inventory/instances does not return newly-created object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@
 * Adds additionalCallNumbers to the item and holding [MODINV-1241](https://folio-org.atlassian.net/browse/MODINV-1241)
 * Addition of the order field to the existing item APIs [MODINV-1249](https://folio-org.atlassian.net/browse/MODINV-1249)
 * Add instance-authority links logic on MARC Instance update [MODINV-1068](https://folio-org.atlassian.net/browse/MODINV-1068)
-* Subscribe to JobExecution status change and add cache  [MODINV-973](https://folio-org.atlassian.net/browse/MODINV-973)
+* Subscribe to JobExecution status change and add cache [MODINV-973](https://folio-org.atlassian.net/browse/MODINV-973)
+* POST to /inventory/instances does not return newly-created object [MODINV-1078](https://folio-org.atlassian.net/browse/MODINV-1078)
 
 ## 21.1.0 2025-03-13
 * Update deduplication logic in mod-inventory [MODINV-1151](https://folio-org.atlassian.net/browse/MODINV-1151)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory",
-      "version": "14.4",
+      "version": "14.3",
       "handlers": [
         {
           "methods": ["GET"],

--- a/src/main/java/org/folio/inventory/resources/AbstractInstances.java
+++ b/src/main/java/org/folio/inventory/resources/AbstractInstances.java
@@ -99,10 +99,10 @@ public abstract class AbstractInstances {
 
     JsonObject json = result.getJson();
     List<JsonObject> relationsList = JsonArrayHelper.toList(json.getJsonArray("instanceRelationships"));
-    Map<String, InstanceRelationship> existingRelationships = new HashMap();
+    Map<String, InstanceRelationship> existingRelationships = new HashMap<>();
     relationsList.stream().map(InstanceRelationship::new).forEachOrdered(relObj ->
       existingRelationships.put(relObj.id, relObj));
-    Map<String, InstanceRelationship> updatingRelationships = new HashMap();
+    Map<String, InstanceRelationship> updatingRelationships = new HashMap<>();
     if (instance.getParentInstances() != null) {
       instance.getParentInstances().forEach(parent -> {
         String id = (parent.id == null ? UUID.randomUUID().toString() : parent.id);
@@ -200,7 +200,7 @@ public abstract class AbstractInstances {
   private Map<String, PrecedingSucceedingTitle> getExistedPrecedingSucceedingTitles(
     List<JsonObject> relationsList) {
 
-    Map<String, PrecedingSucceedingTitle> existingPrecedingSucceedingTitles = new HashMap();
+    Map<String, PrecedingSucceedingTitle> existingPrecedingSucceedingTitles = new HashMap<>();
     relationsList.stream().map(PrecedingSucceedingTitle::from).forEachOrdered(relObj ->
       existingPrecedingSucceedingTitles.put(relObj.id, relObj));
 
@@ -244,7 +244,7 @@ public abstract class AbstractInstances {
   }
 
   private Map<String, PrecedingSucceedingTitle> getUpdatingPrecedingSucceedingTitles(Instance instance) {
-    Map<String, PrecedingSucceedingTitle> updatingPrecedingSucceedingTitles = new HashMap();
+    Map<String, PrecedingSucceedingTitle> updatingPrecedingSucceedingTitles = new HashMap<>();
 
     updatePrecedingTitles(instance, updatingPrecedingSucceedingTitles);
     updateSucceedingTitles(instance, updatingPrecedingSucceedingTitles);

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -174,7 +174,7 @@ public class Instances extends AbstractInstances {
 
   private void update(RoutingContext rContext) {
     WebContext wContext = new WebContext(rContext);
-    JsonObject instanceRequest = rContext.getBodyAsJson();
+    JsonObject instanceRequest = rContext.body().asJsonObject();
     Instance updatedInstance = Instance.fromJson(instanceRequest);
     InstanceCollection instanceCollection = storage.getInstanceCollection(wContext);
 
@@ -761,12 +761,12 @@ public class Instances extends AbstractInstances {
       List<CompletableFuture<PrecedingSucceedingTitle>> precedingTitleCompletableFutures =
         relationsList.stream().filter(rel -> isPrecedingTitle(instance, rel))
           .map(rel -> getPrecedingSucceedingTitle(routingContext, context, rel,
-            PrecedingSucceedingTitle.PRECEDING_INSTANCE_ID_KEY)).collect(Collectors.toList());
+            PrecedingSucceedingTitle.PRECEDING_INSTANCE_ID_KEY)).toList();
 
       List<CompletableFuture<PrecedingSucceedingTitle>> succeedingTitleCompletableFutures =
         relationsList.stream().filter(rel -> isSucceedingTitle(instance, rel))
           .map(rel -> getPrecedingSucceedingTitle(routingContext, context, rel,
-            PrecedingSucceedingTitle.SUCCEEDING_INSTANCE_ID_KEY)).collect(Collectors.toList());
+            PrecedingSucceedingTitle.SUCCEEDING_INSTANCE_ID_KEY)).toList();
 
       return completedFuture(instance)
         .thenCompose(r -> withPrecedingTitles(instance, precedingTitleCompletableFutures))

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -165,10 +165,9 @@ public class Instances extends AbstractInstances {
         try {
           URL url = context.absoluteUrl(format("%s/%s",
             INSTANCES_PATH, response.getId()));
-          RedirectResponse.created(routingContext.response(), url.toString());
+          RedirectResponse.created(routingContext.response(), url.toString(), response.getJsonForResponse(context));
         } catch (MalformedURLException e) {
-          log.warn(
-            format("Failed to create self link for instance: %s", e.toString()));
+          log.warn("Failed to create self link for instance, cause:", e);
         }
         }).exceptionally(doExceptionally(routingContext));
   }

--- a/src/main/java/org/folio/inventory/resources/Instances.java
+++ b/src/main/java/org/folio/inventory/resources/Instances.java
@@ -141,7 +141,7 @@ public class Instances extends AbstractInstances {
   private void create(RoutingContext routingContext) {
     WebContext context = new WebContext(routingContext);
 
-    JsonObject instanceRequest = routingContext.getBodyAsJson();
+    JsonObject instanceRequest = routingContext.body().asJsonObject();
 
     if (StringUtils.isBlank(instanceRequest.getString(Instance.TITLE_KEY))) {
       ClientErrorResponse.badRequest(routingContext.response(),

--- a/src/main/java/org/folio/inventory/support/http/server/RedirectResponse.java
+++ b/src/main/java/org/folio/inventory/support/http/server/RedirectResponse.java
@@ -2,18 +2,24 @@ package org.folio.inventory.support.http.server;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+
+import static org.folio.inventory.client.util.ClientWrapperUtil.APPLICATION_JSON;
 
 public class RedirectResponse {
 
   /**
-   * Ends up response with CREATED(201) status and writes "Location" header to the response body before ending.
+   * Ends up response with CREATED(201) status, writes "Location" header,
+   * and includes response body before ending.
    *
    * @param response http server response
    * @param location value to put to "Location" header
+   * @param body     response body
    */
-  public static void created(HttpServerResponse response, String location) {
-    locationResponse(response, location, HttpResponseStatus.CREATED.code());
+  public static void created(HttpServerResponse response, String location, JsonObject body) {
+    locationResponse(response, location, body, HttpResponseStatus.CREATED.code());
   }
 
   /**
@@ -51,11 +57,18 @@ public class RedirectResponse {
   private static void locationResponse(
     HttpServerResponse response,
     String url,
-    Integer status) {
+    int status) {
 
     response.headers().add("Location", url);
     response.setStatusCode(status);
     response.end();
   }
 
+  private static void locationResponse(HttpServerResponse response, String url,
+                                       JsonObject body, int status) {
+    response.headers().set(HttpHeaders.LOCATION, url);
+    response.headers().set(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+    response.setStatusCode(status);
+    response.end(Buffer.buffer(body.encodePrettily()));
+  }
 }

--- a/src/main/java/org/folio/inventory/support/http/server/RedirectResponse.java
+++ b/src/main/java/org/folio/inventory/support/http/server/RedirectResponse.java
@@ -8,7 +8,11 @@ import io.vertx.core.json.JsonObject;
 
 import static org.folio.inventory.client.util.ClientWrapperUtil.APPLICATION_JSON;
 
-public class RedirectResponse {
+public final class RedirectResponse {
+
+  private RedirectResponse() {
+    throw new UnsupportedOperationException("Cannot instantiate utility class");
+  }
 
   /**
    * Ends up response with CREATED(201) status, writes "Location" header,

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -79,7 +79,6 @@ public class InstancesApiExamples extends ApiTests {
   @Test
   public void canCreateInstanceWithoutAnIDAndHRID()
     throws InterruptedException,
-    MalformedURLException,
     TimeoutException,
     ExecutionException {
 
@@ -116,14 +115,9 @@ public class InstancesApiExamples extends ApiTests {
 
     assertThat(postResponse.getStatusCode(), is(201));
     assertThat(location, is(notNullValue()));
+    assertThat(postResponse.getBody(), is(notNullValue()));
 
-    final var getCompleted = okapiClient.get(location);
-
-    Response getResponse = getCompleted.toCompletableFuture().get(5, SECONDS);
-
-    assertThat(getResponse.getStatusCode(), is(200));
-
-    JsonObject createdInstance = getResponse.getJson();
+    JsonObject createdInstance = postResponse.getJson();
 
     assertThat(createdInstance.containsKey("administrativeNotes"), is(true));
 

--- a/src/test/java/api/InstancesApiExamples.java
+++ b/src/test/java/api/InstancesApiExamples.java
@@ -168,7 +168,6 @@ public class InstancesApiExamples extends ApiTests {
   @Test
   public void canCreateAnInstanceWithAnIDAndHRID()
     throws InterruptedException,
-    MalformedURLException,
     TimeoutException,
     ExecutionException {
 
@@ -364,7 +363,6 @@ public class InstancesApiExamples extends ApiTests {
   @Test
   public void instanceTitleIsMandatory()
     throws InterruptedException,
-    MalformedURLException,
     TimeoutException,
     ExecutionException {
 
@@ -582,15 +580,12 @@ public class InstancesApiExamples extends ApiTests {
   }
 
   @Test
-  public void canNotUpdateAnExistingMARCInstanceIfBlockedFieldsAreChanged()
-    throws MalformedURLException {
-
+  public void canNotUpdateAnExistingMARCInstanceIfBlockedFieldsAreChanged() {
     UUID id = UUID.randomUUID();
     createInstance(treasureIslandInstance(id));
     JsonObject instanceForUpdate = marcInstanceWithDefaultBlockedFields(id);
 
     for (String field : config.getInstanceBlockedFields()) {
-      URL instanceLocation = new URL(String.format("%s/%s", ApiRoot.instances(), id));
       // Put Instance for update
       Response putResponse = updateInstance(instanceForUpdate);
 
@@ -684,7 +679,6 @@ public class InstancesApiExamples extends ApiTests {
   @Test
   public void canDeleteAllInstances()
     throws InterruptedException,
-    MalformedURLException,
     TimeoutException,
     ExecutionException {
 
@@ -818,7 +812,6 @@ public class InstancesApiExamples extends ApiTests {
   @Test
   public void canGetAllInstances()
     throws InterruptedException,
-    MalformedURLException,
     TimeoutException,
     ExecutionException {
 
@@ -922,7 +915,6 @@ public class InstancesApiExamples extends ApiTests {
   @Test
   public void cannotFindAnUnknownInstance()
     throws InterruptedException,
-    MalformedURLException,
     TimeoutException,
     ExecutionException {
 
@@ -935,7 +927,7 @@ public class InstancesApiExamples extends ApiTests {
   }
 
   @Test
-  public void cannotChangeHRID() throws Exception {
+  public void cannotChangeHRID() {
     UUID instanceId = UUID.randomUUID();
     JsonObject createdInstance = createInstance(smallAngryPlanet(instanceId));
 
@@ -955,7 +947,7 @@ public class InstancesApiExamples extends ApiTests {
   }
 
   @Test
-  public void cannotRemoveHRID() throws Exception {
+  public void cannotRemoveHRID() {
     UUID instanceId = UUID.randomUUID();
     JsonObject createdInstance = createInstance(smallAngryPlanet(instanceId));
 

--- a/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
+++ b/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
@@ -213,7 +213,6 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
 
   @Test
   public void titleIsRequiredToCreateInstancesUsingBatch() {
-
     final JsonObject instanceWithValidPrecedingTitle = smallAngryPlanet(UUID.randomUUID())
       .put(PRECEDING_TITLES_KEY, new JsonArray()
         .add(createOpenBibliographyUnconnectedTitle(UUID.randomUUID().toString())));

--- a/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
+++ b/src/test/java/api/PrecedingSucceedingTitlesApiExamples.java
@@ -34,10 +34,7 @@ import io.vertx.core.json.JsonObject;
 public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
 
   @Test
-  public void canCreateAnInstanceWithUnconnectedPrecedingTitles()
-    throws InterruptedException, MalformedURLException, TimeoutException,
-    ExecutionException {
-
+  public void canCreateAnInstanceWithUnconnectedPrecedingTitles() {
     String precedingSucceedingTitleId1 = UUID.randomUUID().toString();
     String precedingSucceedingTitleId2 = UUID.randomUUID().toString();
     JsonArray precedingTitles = getUnconnectedPrecedingSucceedingTitle(
@@ -57,10 +54,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   @Test
-  public void canCreateAnInstanceWithUnconnectedSucceedingTitles()
-    throws InterruptedException, MalformedURLException, TimeoutException,
-    ExecutionException {
-
+  public void canCreateAnInstanceWithUnconnectedSucceedingTitles() {
     String precedingSucceedingTitleId1 = UUID.randomUUID().toString();
     String precedingSucceedingTitleId2 = UUID.randomUUID().toString();
     JsonArray succeedingTitles = getUnconnectedPrecedingSucceedingTitle(
@@ -218,8 +212,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   @Test
-  public void titleIsRequiredToCreateInstancesUsingBatch()
-    throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+  public void titleIsRequiredToCreateInstancesUsingBatch() {
 
     final JsonObject instanceWithValidPrecedingTitle = smallAngryPlanet(UUID.randomUUID())
       .put(PRECEDING_TITLES_KEY, new JsonArray()
@@ -306,10 +299,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   @Test
-  public void canCreateAnInstanceWithConnectedPrecedingTitles()
-    throws InterruptedException, MalformedURLException, TimeoutException,
-    ExecutionException {
-
+  public void canCreateAnInstanceWithConnectedPrecedingTitles() {
     UUID nodId = UUID.randomUUID();
     UUID uprootedId = UUID.randomUUID();
     String nodPrecedingTitleId = UUID.randomUUID().toString();
@@ -328,7 +318,10 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
 
     IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
 
-    JsonArray actualPrecedingTitles = createdInstance.getJson().getJsonArray("precedingTitles");
+    // Fetch the created instance because POST response body does not include all data for the preceding/succeeding titles fields
+    Response getResponse = instancesClient.getById(createdInstance.getId());
+    assertThat(getResponse.getStatusCode(), is(200));
+    JsonArray actualPrecedingTitles = getResponse.getJson().getJsonArray("precedingTitles");
     JsonObject actualPrecedingTitle1 = getRecordById(actualPrecedingTitles, nodPrecedingTitleId);
     JsonObject actualPrecedingTitle2 = getRecordById(actualPrecedingTitles, uprootedPrecedingTitleId);
 
@@ -340,10 +333,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   @Test
-  public void canCreateAnInstanceWithConnectedSucceedingTitles()
-    throws InterruptedException, MalformedURLException, TimeoutException,
-    ExecutionException {
-
+  public void canCreateAnInstanceWithConnectedSucceedingTitles() {
     UUID nodId = UUID.randomUUID();
     UUID uprootedId = UUID.randomUUID();
     String nodPrecedingTitleId = UUID.randomUUID().toString();
@@ -362,7 +352,9 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
 
     IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
 
-    JsonArray actualSucceedingTitles = createdInstance.getJson().getJsonArray("succeedingTitles");
+    Response getResponse = instancesClient.getById(createdInstance.getId());
+    assertThat(getResponse.getStatusCode(), is(200));
+    JsonArray actualSucceedingTitles = getResponse.getJson().getJsonArray("succeedingTitles");
     JsonObject actualSucceedingTitle1 = getRecordById(actualSucceedingTitles, nodPrecedingTitleId);
     JsonObject actualSucceedingTitle2 = getRecordById(actualSucceedingTitles, uprootedPrecedingTitleId);
 
@@ -472,10 +464,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   @Test
-  public void canCreateAnInstanceWithConnectedSucceedingAndPrecedingTitles()
-    throws InterruptedException, MalformedURLException, TimeoutException,
-    ExecutionException {
-
+  public void canCreateAnInstanceWithConnectedSucceedingAndPrecedingTitles() {
     UUID nodId = UUID.randomUUID();
     UUID uprootedId = UUID.randomUUID();
     String nodPrecedingTitleId = UUID.randomUUID().toString();
@@ -503,14 +492,16 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
 
     IndividualResource createdInstance = instancesClient.create(smallAngryPlanetJson);
 
-    JsonArray actualPrecedingTitles = createdInstance.getJson().getJsonArray("precedingTitles");
+    Response getResponse = instancesClient.getById(createdInstance.getId());
+    assertThat(getResponse.getStatusCode(), is(200));
+    JsonArray actualPrecedingTitles = getResponse.getJson().getJsonArray("precedingTitles");
     JsonObject actualPrecedingTitle1 = getRecordById(actualPrecedingTitles, nodPrecedingTitleId);
     JsonObject actualPrecedingTitle2 = getRecordById(actualPrecedingTitles, unconnectedPrecedingTitleId);
 
     assertPrecedingTitles(actualPrecedingTitle1, nod.getJson(), nod.getId().toString());
     assertPrecedingTitles(actualPrecedingTitle2, unconnectedPrecedingTitle, null);
 
-    JsonArray actualSucceedingTitles = createdInstance.getJson().getJsonArray("succeedingTitles");
+    JsonArray actualSucceedingTitles = getResponse.getJson().getJsonArray("succeedingTitles");
     JsonObject actualSucceedingTitle1 = getRecordById(actualSucceedingTitles, uprootedSucceedingTitleId);
     JsonObject actualSucceedingTitle2 = getRecordById(actualSucceedingTitles, unconnectedSucceedingTitleId);
 
@@ -522,8 +513,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   @Test
-  public void canCreateBatchOfInstancesWithPrecedingSucceedingTitles()
-    throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+  public void canCreateBatchOfInstancesWithPrecedingSucceedingTitles() {
     String precedingSucceedingTitleId1 = UUID.randomUUID().toString();
     String precedingSucceedingTitleId2 = UUID.randomUUID().toString();
     JsonArray precedingTitles = getUnconnectedPrecedingSucceedingTitle(
@@ -562,8 +552,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   private void verifyRelatedInstancePrecedingTitle(IndividualResource precedingInstance,
-    IndividualResource succeedingInstance) throws MalformedURLException,
-    InterruptedException, ExecutionException, TimeoutException {
+    IndividualResource succeedingInstance) {
 
     Response response = instancesClient.getById(precedingInstance.getId());
     JsonArray precedingTitles = response.getJson().getJsonArray("precedingTitles");
@@ -572,8 +561,7 @@ public class PrecedingSucceedingTitlesApiExamples extends ApiTests {
   }
 
   private void verifyRelatedInstanceSucceedingTitle(IndividualResource succeedingInstance,
-    IndividualResource precedingInstance) throws MalformedURLException,
-    InterruptedException, ExecutionException, TimeoutException {
+    IndividualResource precedingInstance) {
 
     Response response = instancesClient.getById(succeedingInstance.getId());
     JsonArray succeedingTitles = response.getJson().getJsonArray("succeedingTitles");


### PR DESCRIPTION
## Purpose
to include newly created instance in a response on the `POST /inventory/instances` endpoint


## Approach
* send created instance in a response
* update tests



## Learning
[MODINV-1078](https://issues.folio.org/browse/MODINV-1078)


## Misc
The "inventory" interface version increment made in the #855 has been reverted because for Trillium, the version had already been bumped in the previous PR #845.