### PR TITLE
MODINV-1276: Can't move holdings/items to another instance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 21.2.0 2025-xx-xx
+* ECS: Improve logs in move holdings operation for [MODINV-1276](https://folio-org.atlassian.net/browse/MODINV-1276)
 * ECS: Moving holdings to another instance produces error if the instance does not already have an associated holdings with active affiliation [MODINV-1213](https://folio-org.atlassian.net/browse/MODINV-1213)
 * Error editing the "Temporary" field in the holding [MODINV-1189](https://folio-org.atlassian.net/browse/MODINV-1189)
 * Source of Instance changes from LINKED_DATA to MARC when a linked authority is updated [MODINV-1176](https://folio-org.atlassian.net/browse/MODINV-1176)

--- a/src/main/java/org/folio/inventory/consortium/cache/ConsortiumDataCache.java
+++ b/src/main/java/org/folio/inventory/consortium/cache/ConsortiumDataCache.java
@@ -55,6 +55,7 @@ public class ConsortiumDataCache {
    * if the specified {@code tenantId} is not included to any consortium, then returns future with empty Optional
    */
   public Future<Optional<ConsortiumConfiguration>> getConsortiumData(String tenantId, Map<String, String> headers) {
+    LOG.info("getConsortiumData:: Retrieving consortium data for tenantId: '{}'", tenantId);
     try {
       return Future.fromCompletionStage(cache.get(tenantId, (key, executor) -> loadConsortiumData(key, headers)));
     } catch (Exception e) {
@@ -64,6 +65,7 @@ public class ConsortiumDataCache {
   }
 
   private CompletableFuture<Optional<ConsortiumConfiguration>> loadConsortiumData(String tenantId, Map<String, String> headers) {
+    LOG.info("loadConsortiumData:: Loading consortium data for tenantId: '{}'", tenantId);
     String okapiUrl = headers.get(URL);
     WebClient client = WebClient.wrap(httpClient);
     HttpRequest<Buffer> request = client.requestAbs(GET, okapiUrl + USER_TENANTS_PATH);

--- a/src/main/java/org/folio/inventory/consortium/services/ConsortiumServiceImpl.java
+++ b/src/main/java/org/folio/inventory/consortium/services/ConsortiumServiceImpl.java
@@ -38,6 +38,8 @@ public class ConsortiumServiceImpl implements ConsortiumService {
 
   @Override
   public Future<SharingInstance> createShadowInstance(Context context, String instanceId, ConsortiumConfiguration consortiumConfiguration) {
+    LOGGER.info("createShadowInstance:: Creating shadow instance for instanceId: {} in tenantId: {}",
+      instanceId, context.getTenantId());
     Context centralTenantContext = constructContext(consortiumConfiguration.getCentralTenantId(), context.getToken(), context.getOkapiLocation(), context.getUserId(), context.getRequestId());
     SharingInstance sharingInstance = new SharingInstance();
     sharingInstance.setSourceTenantId(consortiumConfiguration.getCentralTenantId());
@@ -48,6 +50,7 @@ public class ConsortiumServiceImpl implements ConsortiumService {
 
   @Override
   public Future<Optional<ConsortiumConfiguration>> getConsortiumConfiguration(Context context) {
+    LOGGER.info("getConsortiumConfiguration:: Retrieving consortium configuration for tenantId: {}", context.getTenantId());
     Map<String, String> headers = Map.of(XOkapiHeaders.URL, context.getOkapiLocation(),
       XOkapiHeaders.TENANT, context.getTenantId(), XOkapiHeaders.TOKEN, context.getToken());
     return consortiumDataCache.getConsortiumData(context.getTenantId(), headers);
@@ -56,6 +59,9 @@ public class ConsortiumServiceImpl implements ConsortiumService {
   // Returns successful future if the sharing status is "IN_PROGRESS" or "COMPLETE"
   @Override
   public Future<SharingInstance> shareInstance(Context context, String consortiumId, SharingInstance sharingInstance) {
+    LOGGER.info("shareInstance:: Sharing instance with id: {} from sourceTenantId: {} to targetTenantId: {}",
+      sharingInstance.getInstanceIdentifier(), sharingInstance.getSourceTenantId(), sharingInstance.getTargetTenantId());
+
     Map<String, String> headers = Map.of(HttpHeaders.CONTENT_TYPE.toString(), APPLICATION_JSON);
     CompletableFuture<SharingInstance> completableFuture = createOkapiHttpClient(context, httpClient)
       .thenCompose(client ->

--- a/src/main/java/org/folio/inventory/resources/MoveApi.java
+++ b/src/main/java/org/folio/inventory/resources/MoveApi.java
@@ -140,10 +140,6 @@ public class MoveApi extends AbstractInventoryResource {
       .findById(toInstanceId)
       .handle((localInstance, error) -> {
         if (error != null) {
-          if (error.getCause() instanceof BadRequestException) {
-            LOGGER.info("moveHoldings:: Instance {} not found locally, proceeding to check consortium.", toInstanceId);
-            return null;
-          }
           LOGGER.error("moveHoldings:: Failed to query local instance storage for instanceId {}", toInstanceId, error);
           throw new CompletionException(error);
         }


### PR DESCRIPTION
Improved logging for the “move” holdings operation.