### PR TITLE
FAT-21615 - Revert "Location" header naming format to fix Karate tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.10</version>
+      <version>3.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -305,7 +305,7 @@
     <lombok.version>1.18.30</lombok.version>
     <postgres.version>42.7.2</postgres.version>
     <liquibase.version>4.9.1</liquibase.version>
-    <kafkaclients.version>3.9.0</kafkaclients.version>
+    <kafkaclients.version>3.9.1</kafkaclients.version>
     <junit.version>4.13.2</junit.version>
     <data-import-processing-core.version>4.5.0-SNAPSHOT</data-import-processing-core.version>
     <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>

--- a/src/main/java/org/folio/inventory/support/http/server/RedirectResponse.java
+++ b/src/main/java/org/folio/inventory/support/http/server/RedirectResponse.java
@@ -2,11 +2,12 @@ package org.folio.inventory.support.http.server;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 
+import static javax.ws.rs.core.HttpHeaders.LOCATION;
 import static org.folio.inventory.client.util.ClientWrapperUtil.APPLICATION_JSON;
+import static org.folio.inventory.client.util.ClientWrapperUtil.CONTENT_TYPE;
 
 public final class RedirectResponse {
 
@@ -70,8 +71,8 @@ public final class RedirectResponse {
 
   private static void locationResponse(HttpServerResponse response, String url,
                                        JsonObject body, int status) {
-    response.headers().set(HttpHeaders.LOCATION, url);
-    response.headers().set(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+    response.headers().set(LOCATION, url);
+    response.headers().set(CONTENT_TYPE, APPLICATION_JSON);
     response.setStatusCode(status);
     response.end(Buffer.buffer(body.encodePrettily()));
   }


### PR DESCRIPTION
## Purpose
to revert the "Location" header naming format (changed here) back to its previous format (where name starts with uppercase)
to fix the failed Karate tests


## Learning
[FAT-21615](https://issues.folio.org/browse/FAT-21615)