### PR TITLE
MODINV-1333: MappingMetadataCacheTest: Client is closed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * Fix statisticalCodeIds and administrativeNotes fields are cleared after update [MODINV-1323](https://folio-org.atlassian.net/browse/MODINV-1323)
 * Cannot Create/Edit MARC holdings record on ECS Sunflower environments (Bugfest, Mobius DR) [MODINV-1327](https://folio-org.atlassian.net/browse/MODINV-1327)
 * Vert.x 4.5.23 fixing CVE-2025-67735 Netty CRLF injection request smuggling [MODINV-1321](https://folio-org.atlassian.net/browse/MODINV-1321)
+* Fix MappingMetadataCacheTest: IllegalStateException: Client is closed [MODINV-1333](https://folio-org.atlassian.net/browse/MODINV-1333)
 
 ## 21.1.0 2025-03-13
 * Update deduplication logic in mod-inventory [MODINV-1151](https://folio-org.atlassian.net/browse/MODINV-1151)

--- a/src/test/java/org/folio/inventory/dataimport/cache/MappingMetadataCacheTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/cache/MappingMetadataCacheTest.java
@@ -14,6 +14,7 @@ import org.folio.inventory.dataimport.exceptions.CacheLoadingException;
 import org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil;
 import org.folio.MappingMetadataDto;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,10 +40,7 @@ public class MappingMetadataCacheTest {
   private static final String MAPPING_METADATA_URL = "/mapping-metadata";
   private static final String MARC_BIB_RECORD_TYPE = "marc-bib";
 
-  private final Vertx vertx = Vertx.vertx();
-
-  private final MappingMetadataCache mappingMetadataCache = MappingMetadataCache.getInstance(vertx,
-    vertx.createHttpClient());
+  private static MappingMetadataCache mappingMetadataCache;
 
   @Rule
   public WireMockRule mockServer = new WireMockRule(
@@ -57,6 +55,12 @@ public class MappingMetadataCacheTest {
     .withMappingRules("rules");
 
   private Context context;
+
+  @BeforeClass
+  public static void beforeClass() {
+    var vertx = Vertx.vertx();
+    mappingMetadataCache = MappingMetadataCache.getInstance(vertx, vertx.createHttpClient());
+  }
 
   @Before
   public void setUp() {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINV-1333

Due to incorrect Vertx setup there can be a race condition in MappingMetadataCacheTest resulting in the failures:

```
[ERROR]   MappingMetadataCacheTest.shouldReturnEmptyOptionalWhenGetNotFoundByRecordType:149 » IllegalState
[ERROR]   MappingMetadataCacheTest.shouldReturnEmptyOptionalWhenGetNotFoundOnSnapshotLoading:137 » IllegalState
[ERROR]   MappingMetadataCacheTest.shouldReturnMappingMetadata:71 » IllegalState Client ...
[ERROR]   MappingMetadataCacheTest.shouldReturnMappingMetadataByRecordType:85 » IllegalState
```

Example: https://jenkins-aws.indexdata.com/job/folio-org/job/mod-inventory/job/MODINV-1332-release-21.0.18-plus/1/execution/node/42/log/

Cause:

```
java.lang.IllegalStateException: Client is closed
	at io.vertx.core.http.impl.HttpClientImpl.checkClosed(HttpClientImpl.java:405)
```

Fix:

Move Vertx setup into @BeforeClass