### PR TITLE
Clean up dependencies workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-source-record-storage-client</artifactId>
-      <version>6.0.0-SNAPSHOT</version>
+      <version>6.0.0</version>
       <exclusions>
         <!-- This is provided by JDK >= 9 causing a compile error (Eclipse doesn't suppress this compile error):
              "The package org.xml.sax is accessible from more than one module: <unnamed>, java.xml"
@@ -240,28 +240,8 @@
           <groupId>xerces</groupId>
           <artifactId>xmlParserAPIs</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.folio.okapi</groupId>
-          <artifactId>okapi-common</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.ongres.scram</groupId>
-          <artifactId>client</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
-
-    <dependency>
-      <groupId>org.folio.okapi</groupId>
-      <artifactId>okapi-common</artifactId>
-      <version>7.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ongres.scram</groupId>
-      <artifactId>scram-client</artifactId>
-      <version>3.2</version>
-    </dependency>
-
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-source-record-manager-client</artifactId>


### PR DESCRIPTION
## Purpose
during the mod-inventory upgrade to Vertx 5, the workaround for dependencies was added to complete the upgrade while the SRS client was still using Vert.x 4. Now, this workaround is no longer needed and can be cleaned.