### PR TITLE
MODINV-1373: Instance updated to source=MARC even when SRS creation fails

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/AbstractInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/AbstractInstanceEventHandler.java
@@ -150,6 +150,77 @@ public abstract class AbstractInstanceEventHandler implements EventHandler {
     return promise.future();
   }
 
+  /**
+   * Creates a new MARC record in SRS without modifying the Instance.
+   * Use this method for UPDATE operations where the instance is managed separately.
+   * If SRS creation fails, the operation fails without any instance modifications.
+   *
+   * @param payload          data import event payload
+   * @param srcRecord        MARC record to create in SRS
+   * @param tenantId         tenant identifier
+   * @param userId           user identifier
+   * @param requestId        request identifier
+   * @return future that completes when SRS operation finishes (success or failure)
+   */
+  protected Future<Void> saveRecordInSrsOnly(DataImportEventPayload payload, Record srcRecord,
+                                             String tenantId, String userId, String requestId) {
+    Promise<Void> promise = Promise.promise();
+    getSourceStorageRecordsClient(payload.getOkapiUrl(), payload.getToken(), tenantId, userId, requestId)
+      .postSourceStorageRecords(srcRecord)
+      .onComplete(ar -> {
+        var result = ar.result();
+        if (ar.succeeded() && result.statusCode() == HttpStatus.HTTP_CREATED.toInt()) {
+          payload.getContext().put(EntityType.MARC_BIBLIOGRAPHIC.value(),
+            Json.encode(encodeParsedRecordContent(result.bodyAsJson(Record.class))));
+          LOGGER.info("saveRecordInSrsOnly:: Created MARC record in SRS with id: '{}', from tenant: {}, jobExecutionId: {}",
+            srcRecord.getId(), payload.getTenant(), payload.getJobExecutionId());
+          promise.complete();
+        } else {
+          String msg = format("Failed to create MARC record in SRS, jobExecutionId: '%s', status code: %s, Record: %s",
+            payload.getJobExecutionId(), result != null ? result.statusCode() : "", result != null ? result.bodyAsString() : "");
+          LOGGER.error("saveRecordInSrsOnly:: {}", msg);
+          promise.fail(msg);
+        }
+      });
+    return promise.future();
+  }
+
+  /**
+   * Updates an existing MARC record in SRS without modifying the Instance.
+   * Use this method for UPDATE operations where the instance is managed separately.
+   * If SRS update fails, the operation fails without any instance modifications.
+   *
+   * @param payload          data import event payload
+   * @param srcRecord        MARC record to update in SRS
+   * @param matchedId        matched record identifier
+   * @param tenantId         tenant identifier
+   * @param userId           user identifier
+   * @param requestId        request identifier
+   * @return future that completes when SRS operation finishes (success or failure)
+   */
+  protected Future<Void> putRecordInSrsOnly(DataImportEventPayload payload, Record srcRecord,
+                                            String matchedId, String tenantId, String userId, String requestId) {
+    Promise<Void> promise = Promise.promise();
+    getSourceStorageRecordsClient(payload.getOkapiUrl(), payload.getToken(), tenantId, userId, requestId)
+      .putSourceStorageRecordsGenerationById(matchedId, srcRecord)
+      .onComplete(ar -> {
+        var result = ar.result();
+        if (ar.succeeded() && result.statusCode() == HttpStatus.HTTP_OK.toInt()) {
+          payload.getContext().put(EntityType.MARC_BIBLIOGRAPHIC.value(),
+            Json.encode(encodeParsedRecordContent(result.bodyAsJson(Record.class))));
+          LOGGER.info("putRecordInSrsOnly:: Updated MARC record in SRS with id: '{}', from tenant: {}, jobExecutionId: {}",
+            srcRecord.getId(), payload.getTenant(), payload.getJobExecutionId());
+          promise.complete();
+        } else {
+          String msg = format("Failed to update MARC record in SRS, jobExecutionId: '%s', status code: %s, Record: %s",
+            payload.getJobExecutionId(), result != null ? result.statusCode() : "", result != null ? result.bodyAsString() : "");
+          LOGGER.error("putRecordInSrsOnly:: {}", msg);
+          promise.fail(msg);
+        }
+      });
+    return promise.future();
+  }
+
   protected Future<Snapshot> postSnapshotInSrsAndHandleResponse(Context context, Snapshot snapshot) {
     return snapshotService.postSnapshotInSrsAndHandleResponse(context, snapshot);
   }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/AbstractInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/AbstractInstanceEventHandler.java
@@ -127,29 +127,6 @@ public abstract class AbstractInstanceEventHandler implements EventHandler {
     return promise.future();
   }
 
-  protected Future<Instance> putRecordInSrsAndHandleResponse(DataImportEventPayload payload, Record srcRecord,
-                                                             Instance instance, String matchedId, String tenantId, String userId, String requestId) {
-    Promise<Instance> promise = Promise.promise();
-    getSourceStorageRecordsClient(payload.getOkapiUrl(), payload.getToken(), tenantId, userId, requestId)
-      .putSourceStorageRecordsGenerationById(matchedId ,srcRecord)
-      .onComplete(ar -> {
-        var result = ar.result();
-        if (ar.succeeded() && result.statusCode() == HttpStatus.HTTP_OK.toInt()) {
-          payload.getContext().put(EntityType.MARC_BIBLIOGRAPHIC.value(),
-            Json.encode(encodeParsedRecordContent(result.bodyAsJson(Record.class))));
-          LOGGER.info("Update MARC record in SRS with id: '{}', instanceId: '{}', from tenant: {}, jobExecutionId: {}",
-            srcRecord.getId(), instance.getId(), payload.getTenant(), payload.getJobExecutionId());
-          promise.complete(instance);
-        } else {
-          String msg = format("Failed to update MARC record in SRS, instanceId: '%s', jobExecutionId: '%s', status code: %s, Record: %s",
-            instance.getId(), payload.getJobExecutionId(), result != null ? result.statusCode() : "", result != null ? result.bodyAsString() : "");
-          LOGGER.warn(msg);
-          promise.fail(msg);
-        }
-      });
-    return promise.future();
-  }
-
   /**
    * Creates a new MARC record in SRS without modifying the Instance.
    * Use this method for UPDATE operations where the instance is managed separately.
@@ -196,10 +173,11 @@ public abstract class AbstractInstanceEventHandler implements EventHandler {
    * @param tenantId         tenant identifier
    * @param userId           user identifier
    * @param requestId        request identifier
+   * @param instanceId       instance identifier for logging
    * @return future that completes when SRS operation finishes (success or failure)
    */
-  protected Future<Void> putRecordInSrsOnly(DataImportEventPayload payload, Record srcRecord,
-                                            String matchedId, String tenantId, String userId, String requestId) {
+  protected Future<Void> putRecordInSrs(DataImportEventPayload payload, Record srcRecord,
+                                        String matchedId, String tenantId, String userId, String requestId, String instanceId) {
     Promise<Void> promise = Promise.promise();
     getSourceStorageRecordsClient(payload.getOkapiUrl(), payload.getToken(), tenantId, userId, requestId)
       .putSourceStorageRecordsGenerationById(matchedId, srcRecord)
@@ -208,12 +186,12 @@ public abstract class AbstractInstanceEventHandler implements EventHandler {
         if (ar.succeeded() && result.statusCode() == HttpStatus.HTTP_OK.toInt()) {
           payload.getContext().put(EntityType.MARC_BIBLIOGRAPHIC.value(),
             Json.encode(encodeParsedRecordContent(result.bodyAsJson(Record.class))));
-          LOGGER.info("putRecordInSrsOnly:: Updated MARC record in SRS with id: '{}', from tenant: {}, jobExecutionId: {}",
-            srcRecord.getId(), payload.getTenant(), payload.getJobExecutionId());
+          LOGGER.info("putRecordInSrsOnly:: Updated MARC record in SRS with id: '{}' for instanceId: '{}', from tenant: {}, jobExecutionId: {}",
+            instanceId, srcRecord.getId(), payload.getTenant(), payload.getJobExecutionId());
           promise.complete();
         } else {
-          String msg = format("Failed to update MARC record in SRS, jobExecutionId: '%s', status code: %s, Record: %s",
-            payload.getJobExecutionId(), result != null ? result.statusCode() : "", result != null ? result.bodyAsString() : "");
+          String msg = format("Failed to update MARC record in SRS for instanceId: '%s', jobExecutionId: '%s', status code: %s, Record: %s",
+            instanceId, payload.getJobExecutionId(), result != null ? result.statusCode() : "", result != null ? result.bodyAsString() : "");
           LOGGER.error("putRecordInSrsOnly:: {}", msg);
           promise.fail(msg);
         }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
@@ -39,6 +39,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.Date;
+import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -262,42 +263,86 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
         }
 
         markInstanceAndRecordAsDeletedIfNeeded(mappedInstance, targetRecord);
-        return updateInstanceAndRetryIfOlExists(mappedInstance, instanceCollection, dataImportEventPayload)
-          .compose(updatedInstance -> getPrecedingSucceedingTitlesHelper().getExistingPrecedingSucceedingTitles(mappedInstance, context))
-          .map(precedingSucceedingTitles -> precedingSucceedingTitles.stream()
-            .map(titleJson -> titleJson.getString("id"))
-            .collect(Collectors.toSet()))
-          .compose(titlesIds -> getPrecedingSucceedingTitlesHelper().deletePrecedingSucceedingTitles(titlesIds, context))
-          .map(mappedInstance)
-          .compose(instance -> {
-            if (dataImportEventPayload.getContext().containsKey(CENTRAL_TENANT_ID)) {
-              return copySnapshotToOtherTenant(targetRecord.getSnapshotId(), dataImportEventPayload, tenantId).map(instance);
-            }
-            return Future.succeededFuture(instance);
-          })
-          .compose(instance -> {
+        
+        // Step 1: Copy snapshot to central tenant if needed (consortium scenario)
+        Future<Void> snapshotFuture;
+        if (dataImportEventPayload.getContext().containsKey(CENTRAL_TENANT_ID)) {
+          LOGGER.debug("processInstanceUpdate:: Copying snapshot to central tenant for consortium instance");
+          snapshotFuture = copySnapshotToOtherTenant(targetRecord.getSnapshotId(), dataImportEventPayload, tenantId)
+            .mapEmpty();
+        } else {
+          snapshotFuture = Future.succeededFuture();
+        }
+
+        return snapshotFuture
+          // Step 2: Execute SRS operations FIRST (before instance update)
+          .compose(v -> {
+            LOGGER.debug("processInstanceUpdate:: Executing SRS operations for instance: {}, source: {}",
+              mappedInstance.getId(), instanceToUpdate.getSource());
+
             if (instanceToUpdate.getSource().equals(FOLIO.getValue())) {
-              LOGGER.debug("processInstanceUpdate:: processing FOLIO Instance with id: {}", instance.getId());
-              executeFieldsManipulation(instance, targetRecord);
-              return saveRecordInSrsAndHandleResponse(dataImportEventPayload, targetRecord, instance, instanceCollection,
-                tenantId, context.getUserId(), context.getRequestId());
-            }
-            if (instanceToUpdate.getSource().equals(MARC.getValue())) {
-              LOGGER.debug("processInstanceUpdate:: processing MARC Instance with id: {}", instance.getId());
-              setExternalIds(targetRecord, instance);
-              setSuppressFromDiscovery(targetRecord, instance.getDiscoverySuppress());
+              // FOLIO -> MARC: Create SRS record FIRST
+              LOGGER.debug("processInstanceUpdate:: FOLIO instance, creating SRS record first");
+              executeFieldsManipulation(mappedInstance, targetRecord);
+              return saveRecordInSrsOnly(dataImportEventPayload, targetRecord, tenantId, context.getUserId(), context.getRequestId());
+
+            } else if (instanceToUpdate.getSource().equals(MARC.getValue())) {
+              // MARC: Create/update SRS record FIRST
+              LOGGER.debug("processInstanceUpdate:: MARC instance, creating/updating SRS record first");
+              setExternalIds(targetRecord, mappedInstance);
+              setSuppressFromDiscovery(targetRecord, mappedInstance.getDiscoverySuppress());
+
               if (targetRecord.getMatchedId() == null) {
-                LOGGER.debug("processInstanceUpdate:: Instance with id: {} has no related marc bib. Creating new record in SRS", instance.getId());
+                LOGGER.debug("processInstanceUpdate:: MARC instance without SRS, creating new record");
                 String matchedId = UUID.randomUUID().toString();
-                return saveRecordInSrsAndHandleResponse(dataImportEventPayload, targetRecord.withId(matchedId).withMatchedId(matchedId),
-                  instance, instanceCollection, tenantId, context.getUserId(), context.getRequestId());
+                return saveRecordInSrsOnly(dataImportEventPayload, targetRecord.withId(matchedId).withMatchedId(matchedId),
+                  tenantId, context.getUserId(), context.getRequestId());
+              } else {
+                LOGGER.debug("processInstanceUpdate:: MARC instance with existing SRS: {}, updating record", targetRecord.getMatchedId());
+                return putRecordInSrsOnly(dataImportEventPayload, targetRecord, targetRecord.getMatchedId(),
+                  tenantId, context.getUserId(), context.getRequestId());
               }
-              LOGGER.debug("processInstanceUpdate:: Instance with id: {} has related marc bib with id: {}. Updating record in SRS", instance.getId(), targetRecord.getMatchedId());
-              return putRecordInSrsAndHandleResponse(dataImportEventPayload, targetRecord, instance,
-                targetRecord.getMatchedId(), tenantId, context.getUserId(), context.getRequestId());
+
+            } else {
+              // CONSORTIUM_FOLIO, CONSORTIUM_MARC or other sources: skip SRS operations
+              LOGGER.debug("processInstanceUpdate:: Source: {}, skipping SRS operations", instanceToUpdate.getSource());
+              return Future.succeededFuture();
             }
-            return Future.succeededFuture(instance);
-          }).compose(ar -> getPrecedingSucceedingTitlesHelper().createPrecedingSucceedingTitles(mappedInstance, context).map(ar))
+          })
+          // Step 3: Change source field AFTER successful SRS operation (for FOLIO->MARC conversion)
+          .map(v -> {
+            if (instanceToUpdate.getSource().equals(FOLIO.getValue())) {
+              // Now that SRS succeeded, we can safely change source to MARC
+              LOGGER.debug("processInstanceUpdate:: SRS succeeded, changing instance source from FOLIO to MARC");
+              JsonObject updatedInstanceJson = JsonObject.mapFrom(mappedInstance);
+              updatedInstanceJson.put(SOURCE_KEY, MARC_FORMAT);
+              return Instance.fromJson(updatedInstanceJson);
+            }
+            return mappedInstance;
+          })
+          // Step 4: Update Instance (only after SRS succeeds)
+          .compose(instanceToSave -> {
+            LOGGER.debug("processInstanceUpdate:: SRS operations completed successfully, now updating instance");
+            return updateInstanceAndRetryIfOlExists(instanceToSave, instanceCollection, dataImportEventPayload);
+          })
+          // Step 5: Get existing preceding/succeeding titles
+          .compose(updatedInstance -> getPrecedingSucceedingTitlesHelper()
+            .getExistingPrecedingSucceedingTitles(mappedInstance, context)
+            .map(titles -> titles.stream()
+              .map(titleJson -> titleJson.getString("id"))
+              .collect(Collectors.toSet()))
+            .map(titleIds -> new AbstractMap.SimpleEntry<>(updatedInstance, titleIds))
+          )
+          // Step 6: Delete old titles (errors are logged, not failed)
+          .compose(entry -> getPrecedingSucceedingTitlesHelper()
+            .deletePrecedingSucceedingTitles(entry.getValue(), context)
+            .map(entry.getKey())
+          )
+          // Step 7: Create new titles (if error - fail the whole operation)
+          .compose(updatedInstance -> getPrecedingSucceedingTitlesHelper()
+            .createPrecedingSucceedingTitles(mappedInstance, context)
+            .map(updatedInstance)
+          )
           .map(Json::encode);
       })
       .onComplete(ar -> {
@@ -364,10 +409,7 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
       .toList());
     instanceAsJson.put("id", instanceToUpdate.getId());
     instanceAsJson.put(HRID_KEY, instanceToUpdate.getHrid());
-    if (instanceToUpdate.getSource() != null && (!(instanceToUpdate.getSource().equals(CONSORTIUM_FOLIO.getValue())
-      || instanceToUpdate.getSource().equals(CONSORTIUM_MARC.getValue())) || instanceToUpdate.getSource().equals(FOLIO.getValue()))) {
-      instanceAsJson.put(SOURCE_KEY, MARC_FORMAT);
-    }
+    // Do NOT change source here - it will be changed AFTER successful SRS operations
     instanceAsJson.put(METADATA_KEY, instanceToUpdate.getMetadata());
     return instanceAsJson;
   }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
@@ -263,7 +263,7 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
         }
 
         markInstanceAndRecordAsDeletedIfNeeded(mappedInstance, targetRecord);
-        
+
         // Step 1: Copy snapshot to central tenant if needed (consortium scenario)
         Future<Void> snapshotFuture;
         if (dataImportEventPayload.getContext().containsKey(CENTRAL_TENANT_ID)) {
@@ -299,8 +299,8 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
                   tenantId, context.getUserId(), context.getRequestId());
               } else {
                 LOGGER.debug("processInstanceUpdate:: MARC instance with existing SRS: {}, updating record", targetRecord.getMatchedId());
-                return putRecordInSrsOnly(dataImportEventPayload, targetRecord, targetRecord.getMatchedId(),
-                  tenantId, context.getUserId(), context.getRequestId());
+                return putRecordInSrs(dataImportEventPayload, targetRecord, targetRecord.getMatchedId(),
+                  tenantId, context.getUserId(), context.getRequestId(), mappedInstance.getId());
               }
 
             } else {

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
@@ -975,6 +975,67 @@ public class ReplaceInstanceEventHandlerTest {
   }
 
   @Test
+  public void shouldNotUpdateInstanceWhenSrsUpdateFails() throws InterruptedException, ExecutionException, TimeoutException {
+    // Test that verifies SRS-first approach: if SRS update fails, instance should NOT be updated
+    Record incomingRecord = new Record()
+      .withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT))
+      .withMatchedId(UUID.randomUUID().toString())
+      .withSnapshotId(jobExecutionId);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(PAYLOAD_USER_ID, USER_ID);
+    context.put(OKAPI_REQUEST_ID, REQUEST_ID);
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
+    context.put(INSTANCE.value(), new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("hrid", UUID.randomUUID().toString())
+      .put("source", FOLIO.getValue()) // FOLIO instance being converted to MARC
+      .put("_version", INSTANCE_VERSION)
+      .encode());
+
+    Reader fakeReader = Mockito.mock(Reader.class);
+    String instanceTypeId = UUID.randomUUID().toString();
+    String title = "Test Title";
+
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(StringValue.of(instanceTypeId), StringValue.of(title));
+    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+
+    when(storage.getInstanceCollection(any())).thenReturn(instanceRecordCollection);
+
+    MappingManager.registerReaderFactory(fakeReaderFactory);
+    MappingManager.registerWriterFactory(new InstanceWriterFactory());
+
+    mockInstance(FOLIO.getValue());
+
+    // Mock SRS client to return FAILED response (simulating SRS failure)
+    Buffer errorBuffer = Buffer.buffer("SRS update failed");
+    HttpResponse<Buffer> failedResponse = buildHttpResponseWithBuffer(errorBuffer, HttpStatus.SC_BAD_REQUEST);
+    when(sourceStorageClient.postSourceStorageRecords(any()))
+      .thenReturn(Future.succeededFuture(failedResponse));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_INSTANCE_CREATED.value())
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst())
+      .withOkapiUrl(mockServer.baseUrl())
+      .withTenant(TENANT_ID)
+      .withToken(TOKEN)
+      .withContext(context)
+      .withJobExecutionId(UUID.randomUUID().toString());
+
+    CompletableFuture<DataImportEventPayload> future = replaceInstanceEventHandler.handle(dataImportEventPayload);
+
+    // Expect ExecutionException because SRS update failed
+    ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(20, TimeUnit.SECONDS));
+
+    // Verify the exception message contains expected error
+    assertTrue(exception.getMessage().contains("Failed to create MARC record in SRS"));
+
+    // MOST IMPORTANT: Verify that instance update was NOT called (0 times)
+    // because SRS operation failed before reaching instance update
+    verify(instanceRecordCollection, times(0)).update(any(Instance.class), any(Consumer.class), any(Consumer.class));
+  }
+
+  @Test
   public void shouldFailIfPayloadContainsCentralTenantIdAndSharedInstanceButHasNoPermissionForSharedInstanceUpdate() {
     Record incomingRecord = new Record().withSnapshotId(jobExecutionId)
       .withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT));

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
@@ -975,7 +975,7 @@ public class ReplaceInstanceEventHandlerTest {
   }
 
   @Test
-  public void shouldNotUpdateInstanceWhenSrsUpdateFails() throws InterruptedException, ExecutionException, TimeoutException {
+  public void shouldNotUpdateInstanceWhenSrsUpdateFails() {
     // Test that verifies SRS-first approach: if SRS update fails, instance should NOT be updated
     Record incomingRecord = new Record()
       .withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT))


### PR DESCRIPTION
## Purpose
When an error/exception occurs in saving a new SRS record for a record that was source=FOLIO, the instance’s source value should be reverted. 

## Approach
Approach used: record in record-storage first

## Learn
[MODINV-1373](https://folio-org.atlassian.net/browse/MODINV-1373)