### PR TITLE
MODINV-1391 - Data Import profiles will map invalid statistical codes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 22.1.0-SNAPSHOT 2026-mm-dd
+* Data Import profiles will map invalid statistical codes [MODINV-1391](https://folio-org.atlassian.net/browse/MODINV-1391)
+
 ## 22.0.0 2026-04-16
 * ECS: Improve logs in move holdings operation for [MODINV-1276](https://folio-org.atlassian.net/browse/MODINV-1276)
 * ECS: Moving holdings to another instance produces error if the instance does not already have an associated holdings with active affiliation [MODINV-1213](https://folio-org.atlassian.net/browse/MODINV-1213)

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
@@ -139,7 +139,7 @@ public class CreateHoldingEventHandler implements EventHandler {
                 throw new EventProcessingException("Mapped Holdings record(s) are invalid: %s".formatted(errors));
               }
 
-              LOGGER.trace(format("handle:: Mapped holdings: %s", validHoldingsList.encode()));
+              LOGGER.trace("handle:: Mapped holdings: {}", validHoldingsList.encode());
               dataImportEventPayload.getContext().put(HOLDINGS.value(), validHoldingsList.encode());
               return Map.entry(
                 List.of(Json.decodeValue(payloadContext.get(HOLDINGS.value()), HoldingsRecord[].class)),
@@ -262,7 +262,7 @@ public class CreateHoldingEventHandler implements EventHandler {
 
     HoldingsRecordCollection holdingsRecordCollection = storage.getHoldingsRecordCollection(context);
     holdingsList.forEach(holdings -> {
-      LOGGER.debug(format("addHoldings:: Trying to add holdings with id: %s", holdings.getId()));
+      LOGGER.debug("addHoldings:: Trying to add holdings with id: {}", holdings.getId());
       Promise<Void> createPromise = Promise.promise();
       createHoldingsRecordFutures.add(createPromise.future());
       holdingsRecordCollection.add(holdings,
@@ -276,7 +276,7 @@ public class CreateHoldingEventHandler implements EventHandler {
             LOGGER.info("addHoldings:: Duplicated event received by Holding id: {}. Ignoring...", holdings.getId());
             createPromise.fail(new DuplicateEventException(format("Duplicated event by Holding id: %s", holdings.getId())));
           } else {
-            LOGGER.warn(format("addHoldings:: Error posting Holdings cause %s, status code %s", failure.getReason(), failure.getStatusCode()));
+            LOGGER.warn("addHoldings:: Error posting Holdings cause {}, status code {}", failure.getReason(), failure.getStatusCode());
             createPromise.complete();
           }
         });

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
@@ -18,6 +18,7 @@ import org.folio.inventory.dataimport.entities.PartialError;
 import org.folio.inventory.dataimport.services.OrderHelperService;
 import org.folio.inventory.consortium.util.ConsortiumUtil;
 import org.folio.inventory.dataimport.util.ParsedRecordUtil;
+import org.folio.inventory.dataimport.util.ValidationUtil;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.domain.relationship.RecordToEntity;
 import org.folio.inventory.services.IdStorageService;
@@ -32,8 +33,10 @@ import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.Record;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -117,6 +120,8 @@ public class CreateHoldingEventHandler implements EventHandler {
               MappingManager.map(dataImportEventPayload, new MappingContext().withMappingParameters(mappingParameters));
               JsonArray holdingsList = new JsonArray(payloadContext.get(HOLDINGS.value()));
               String instanceId = getInstanceId(dataImportEventPayload);
+//              List<PartialError> validationErrors = new ArrayList<>();
+              JsonArray validHoldingsList = new JsonArray();
               for (int i = 0; i < holdingsList.size(); i++) {
                 JsonObject holdingAsJson = holdingsList.getJsonObject(i);
                 if (holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD) != null) {
@@ -128,20 +133,28 @@ public class CreateHoldingEventHandler implements EventHandler {
                 fillInstanceIdIfNeeded(instanceId, holdingAsJson);
               }
 
-              LOGGER.trace(format("handle:: Mapped holdings: %s", holdingsList.encode()));
-              dataImportEventPayload.getContext().put(HOLDINGS.value(), holdingsList.encode());
-              return List.of(Json.decodeValue(payloadContext.get(HOLDINGS.value()), HoldingsRecord[].class));
+              List<PartialError> validationErrors = validateHoldings(holdingsList, validHoldingsList);
+              if (validHoldingsList.isEmpty()) {
+                List<String> errors = validationErrors.stream().map(PartialError::getError).toList();
+                throw new EventProcessingException("Mapped Holdings record(s) are invalid: %s".formatted(errors));
+              }
+
+              LOGGER.trace(format("handle:: Mapped holdings: %s", validHoldingsList.encode()));
+              dataImportEventPayload.getContext().put(HOLDINGS.value(), validHoldingsList.encode());
+              return Map.entry(
+                List.of(Json.decodeValue(payloadContext.get(HOLDINGS.value()), HoldingsRecord[].class)),
+                validationErrors);
             })
-            .compose(holdingsToCreate -> consortiumService.getConsortiumConfiguration(context)
+            .compose(entry -> consortiumService.getConsortiumConfiguration(context)
               .compose(consortiumConfigurationOptional -> {
                 if (consortiumConfigurationOptional.isPresent()) {
                   return ConsortiumUtil.createShadowInstanceIfNeeded(consortiumService, storage.getInstanceCollection(context),
                       context, getInstanceId(dataImportEventPayload), consortiumConfigurationOptional.get())
-                    .map(holdingsToCreate);
+                    .map(entry);
                 }
-                return Future.succeededFuture(holdingsToCreate);
+                return Future.succeededFuture(entry);
               }))
-            .compose(holdingsToCreate -> addHoldings(holdingsToCreate, payloadContext, context))
+            .compose(entry -> addHoldings(entry.getKey(), entry.getValue(), payloadContext, context))
             .onSuccess(createdHoldings -> {
               LOGGER.info("handle:: Created Holdings records by jobExecutionId: '{}' and recordId: '{}' and chunkId: '{}'",
                 jobExecutionId, recordId, chunkId);
@@ -210,14 +223,39 @@ public class CreateHoldingEventHandler implements EventHandler {
   }
 
   private void fillInstanceId(JsonObject holdingAsJson, String instanceId) {
-    LOGGER.trace(format("fillInstanceId:: Adding instance id: %s, to holding with id: %s", instanceId, holdingAsJson.getString("id")));
+    LOGGER.trace("fillInstanceId:: Adding instance id: {}, to holding with id: {}",
+      instanceId, holdingAsJson.getString("id"));
     holdingAsJson.put(INSTANCE_ID_FIELD, instanceId);
   }
 
-  private Future<List<HoldingsRecord>> addHoldings(List<HoldingsRecord> holdingsList, HashMap<String, String> payloadContext, Context context) {
+  private List<PartialError> validateHoldings(JsonArray holdingsToValidate, JsonArray validHoldingsList) {
+    List<PartialError> validationErrors = new ArrayList<>();
+    for (int i = 0; i < holdingsToValidate.size(); i++) {
+      JsonObject holdingAsJson = holdingsToValidate.getJsonObject(i);
+      List<String> statCodeErrors = validateStatisticalCodeIds(holdingAsJson);
+
+      if (!statCodeErrors.isEmpty()) {
+        validationErrors.add(new PartialError(holdingAsJson.getString("id"), String.join(", ", statCodeErrors)));
+      } else {
+        validHoldingsList.add(holdingAsJson);
+      }
+    }
+    return validationErrors;
+  }
+
+  private List<String> validateStatisticalCodeIds(JsonObject holdingAsJson) {
+    JsonArray statCodeIdsArray = holdingAsJson.getJsonArray("statisticalCodeIds");
+    List<String> statCodeIds = statCodeIdsArray != null
+      ? statCodeIdsArray.stream().map(Object::toString).toList()
+      : Collections.emptyList();
+    return ValidationUtil.validateStatisticalCodeIds(statCodeIds);
+  }
+
+  private Future<List<HoldingsRecord>> addHoldings(List<HoldingsRecord> holdingsList, List<PartialError> initialErrors,
+                                                    HashMap<String, String> payloadContext, Context context) {
     Promise<List<HoldingsRecord>> holdingsPromise = Promise.promise();
     List<HoldingsRecord> createdHoldingsRecord = new ArrayList<>();
-    List<PartialError> errors = new ArrayList<>();
+    List<PartialError> errors = new ArrayList<>(initialErrors);
     List<Future<?>> createHoldingsRecordFutures = new ArrayList<>();
 
     HoldingsRecordCollection holdingsRecordCollection = storage.getHoldingsRecordCollection(context);

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
@@ -120,7 +120,6 @@ public class CreateHoldingEventHandler implements EventHandler {
               MappingManager.map(dataImportEventPayload, new MappingContext().withMappingParameters(mappingParameters));
               JsonArray holdingsList = new JsonArray(payloadContext.get(HOLDINGS.value()));
               String instanceId = getInstanceId(dataImportEventPayload);
-//              List<PartialError> validationErrors = new ArrayList<>();
               JsonArray validHoldingsList = new JsonArray();
               for (int i = 0; i < holdingsList.size(); i++) {
                 JsonObject holdingAsJson = holdingsList.getJsonObject(i);

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
@@ -120,7 +120,6 @@ public class CreateHoldingEventHandler implements EventHandler {
               MappingManager.map(dataImportEventPayload, new MappingContext().withMappingParameters(mappingParameters));
               JsonArray holdingsList = new JsonArray(payloadContext.get(HOLDINGS.value()));
               String instanceId = getInstanceId(dataImportEventPayload);
-              JsonArray validHoldingsList = new JsonArray();
               for (int i = 0; i < holdingsList.size(); i++) {
                 JsonObject holdingAsJson = holdingsList.getJsonObject(i);
                 if (holdingAsJson.getJsonObject(HOLDINGS_PATH_FIELD) != null) {
@@ -132,7 +131,9 @@ public class CreateHoldingEventHandler implements EventHandler {
                 fillInstanceIdIfNeeded(instanceId, holdingAsJson);
               }
 
-              List<PartialError> validationErrors = validateHoldings(holdingsList, validHoldingsList);
+              Map.Entry<JsonArray, List<PartialError>> validationResult = validateHoldings(holdingsList);
+              JsonArray validHoldingsList = validationResult.getKey();
+              List<PartialError> validationErrors = validationResult.getValue();
               if (validHoldingsList.isEmpty()) {
                 List<String> errors = validationErrors.stream().map(PartialError::getError).toList();
                 throw new EventProcessingException("Mapped Holdings record(s) are invalid: %s".formatted(errors));
@@ -227,8 +228,10 @@ public class CreateHoldingEventHandler implements EventHandler {
     holdingAsJson.put(INSTANCE_ID_FIELD, instanceId);
   }
 
-  private List<PartialError> validateHoldings(JsonArray holdingsToValidate, JsonArray validHoldingsList) {
+  private Map.Entry<JsonArray, List<PartialError>> validateHoldings(JsonArray holdingsToValidate) {
     List<PartialError> validationErrors = new ArrayList<>();
+    JsonArray validHoldingsList = new JsonArray();
+
     for (int i = 0; i < holdingsToValidate.size(); i++) {
       JsonObject holdingAsJson = holdingsToValidate.getJsonObject(i);
       List<String> statCodeErrors = validateStatisticalCodeIds(holdingAsJson);
@@ -239,7 +242,7 @@ public class CreateHoldingEventHandler implements EventHandler {
         validHoldingsList.add(holdingAsJson);
       }
     }
-    return validationErrors;
+    return Map.entry(validHoldingsList, validationErrors);
   }
 
   private List<String> validateStatisticalCodeIds(JsonObject holdingAsJson) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandler.java
@@ -33,7 +33,6 @@ import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.Record;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -131,7 +130,7 @@ public class CreateHoldingEventHandler implements EventHandler {
                 fillInstanceIdIfNeeded(instanceId, holdingAsJson);
               }
 
-              Map.Entry<JsonArray, List<PartialError>> validationResult = validateHoldings(holdingsList);
+              Map.Entry<JsonArray, List<PartialError>> validationResult = ValidationUtil.validateHoldings(holdingsList);
               JsonArray validHoldingsList = validationResult.getKey();
               List<PartialError> validationErrors = validationResult.getValue();
               if (validHoldingsList.isEmpty()) {
@@ -226,31 +225,6 @@ public class CreateHoldingEventHandler implements EventHandler {
     LOGGER.trace("fillInstanceId:: Adding instance id: {}, to holding with id: {}",
       instanceId, holdingAsJson.getString("id"));
     holdingAsJson.put(INSTANCE_ID_FIELD, instanceId);
-  }
-
-  private Map.Entry<JsonArray, List<PartialError>> validateHoldings(JsonArray holdingsToValidate) {
-    List<PartialError> validationErrors = new ArrayList<>();
-    JsonArray validHoldingsList = new JsonArray();
-
-    for (int i = 0; i < holdingsToValidate.size(); i++) {
-      JsonObject holdingAsJson = holdingsToValidate.getJsonObject(i);
-      List<String> statCodeErrors = validateStatisticalCodeIds(holdingAsJson);
-
-      if (!statCodeErrors.isEmpty()) {
-        validationErrors.add(new PartialError(holdingAsJson.getString("id"), String.join(", ", statCodeErrors)));
-      } else {
-        validHoldingsList.add(holdingAsJson);
-      }
-    }
-    return Map.entry(validHoldingsList, validationErrors);
-  }
-
-  private List<String> validateStatisticalCodeIds(JsonObject holdingAsJson) {
-    JsonArray statCodeIdsArray = holdingAsJson.getJsonArray("statisticalCodeIds");
-    List<String> statCodeIds = statCodeIdsArray != null
-      ? statCodeIdsArray.stream().map(Object::toString).toList()
-      : Collections.emptyList();
-    return ValidationUtil.validateStatisticalCodeIds(statCodeIds);
   }
 
   private Future<List<HoldingsRecord>> addHoldings(List<HoldingsRecord> holdingsList, List<PartialError> initialErrors,

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandler.java
@@ -236,7 +236,7 @@ public class CreateInstanceEventHandler extends AbstractInstanceEventHandler {
           LOGGER.info("Duplicated event received by InstanceId: {}. Ignoring...", instance.getId());
           promise.fail(new DuplicateEventException(format("Duplicated event by Instance id: %s", instance.getId())));
         } else {
-          LOGGER.error(format("Error posting Instance by instanceId:'%s' cause %s, status code %s", instance.getId(), failure.getReason(), failure.getStatusCode()));
+          LOGGER.error("Error posting Instance by instanceId:'{}' cause {}, status code {}", instance.getId(), failure.getReason(), failure.getStatusCode());
           promise.fail(failure.getReason());
         }
       });

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -47,7 +47,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
@@ -151,7 +150,7 @@ public class CreateItemEventHandler implements EventHandler {
             return processMappingResult(dataImportEventPayload, deduplicationItemId);
           })
           .compose(mappedItemList -> {
-            LOGGER.trace("handle:: Mapped items: {}", mappedItemList.encode());
+            LOGGER.trace("handle:: Mapped items: {}", mappedItemList::encode);
             Promise<List<Item>> createMultipleItemsPromise = Promise.promise();
             List<PartialError> multipleItemsCreateErrors = new ArrayList<>();
             List<Future<?>> createItemsFutures = new ArrayList<>();
@@ -227,7 +226,7 @@ public class CreateItemEventHandler implements EventHandler {
 
   private Future<Item> processSingleItem(String jobExecutionId, String recordId, String chunkId, ItemCollection itemCollection, JsonObject mappedItemJson) {
     List<String> errors = validateItem(mappedItemJson, requiredFields);
-    LOGGER.debug("processSingleItem:: Trying to create item with id: {}", mappedItemJson.getString("id"));
+    LOGGER.debug("processSingleItem:: Trying to create item with id: {}", () -> mappedItemJson.getString("id"));
     if (!errors.isEmpty()) {
       String msg = format("Mapped Item is invalid: %s, by jobExecutionId: '%s' and recordId: '%s' and chunkId: '%s' ", errors,
         jobExecutionId, recordId, chunkId);
@@ -394,7 +393,7 @@ public class CreateItemEventHandler implements EventHandler {
       .map(note -> note.withSource(null))
       .map(note -> note.withDate(dateTimeFormatter.format(ZonedDateTime.now())))
       .map(note -> note.withNoteType(validNotes.getOrDefault(note.getNoteType(), note.getNoteType())))
-      .collect(Collectors.toList());
+      .toList();
 
     if (LOGGER.isTraceEnabled()) {
       notes.forEach(note -> LOGGER.trace("addItem:: circulation note with id : {} added to item with itemId: {}", note.getId(), item.getId()));

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -26,6 +26,7 @@ import org.folio.inventory.storage.Storage;
 import org.folio.inventory.support.CqlHelper;
 import org.folio.inventory.support.ItemUtil;
 import org.folio.inventory.support.JsonHelper;
+import org.folio.inventory.dataimport.util.ValidationUtil;
 import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.processing.events.services.handler.EventHandler;
 import org.folio.processing.exceptions.EventProcessingException;
@@ -179,7 +180,7 @@ public class CreateItemEventHandler implements EventHandler {
               createItemsFutures.add(createItemPromise.future());
             });
 
-            Future.all(createItemsFutures).onComplete(ar -> {
+            Future.join(createItemsFutures).onComplete(ar -> {
               if (payloadContext.containsKey(ERRORS) || !multipleItemsCreateErrors.isEmpty()) {
                 payloadContext.put(ERRORS, Json.encode(multipleItemsCreateErrors));
               }
@@ -354,7 +355,16 @@ public class CreateItemEventHandler implements EventHandler {
   private List<String> validateItem(JsonObject itemAsJson, List<String> requiredFields) {
     List<String> errors = EventHandlingUtil.validateJsonByRequiredFields(itemAsJson, requiredFields);
     validateStatusName(itemAsJson, errors);
+    validateStatisticalCodes(itemAsJson, errors);
     return errors;
+  }
+
+  private void validateStatisticalCodes(JsonObject itemAsJson, List<String> errors) {
+    JsonArray statCodeIdsArray = itemAsJson.getJsonArray("statisticalCodeIds");
+    List<String> statCodeIds = statCodeIdsArray != null
+      ? statCodeIdsArray.stream().map(Object::toString).toList()
+      : List.of();
+    errors.addAll(ValidationUtil.validateStatisticalCodeIds(statCodeIds));
   }
 
   private Future<Boolean> isItemBarcodeUnique(String barcode, ItemCollection itemCollection) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandler.java
@@ -76,6 +76,7 @@ public class CreateItemEventHandler implements EventHandler {
   public static final String HOLDING_ID_FIELD = "id";
   public static final String ITEM_ID_FIELD = "id";
   public static final String PO_LINE_ID_FIELD = "id";
+  private static final String STATISTICAL_CODE_IDS_FIELD = "statisticalCodeIds";
   private static final String RECORD_ID_HEADER = "recordId";
   private static final String CHUNK_ID_HEADER = "chunkId";
   private static final String ERRORS = "ERRORS";
@@ -150,7 +151,7 @@ public class CreateItemEventHandler implements EventHandler {
             return processMappingResult(dataImportEventPayload, deduplicationItemId);
           })
           .compose(mappedItemList -> {
-            LOGGER.trace(format("handle:: Mapped items: %s", mappedItemList.encode()));
+            LOGGER.trace("handle:: Mapped items: {}", mappedItemList.encode());
             Promise<List<Item>> createMultipleItemsPromise = Promise.promise();
             List<PartialError> multipleItemsCreateErrors = new ArrayList<>();
             List<Future<?>> createItemsFutures = new ArrayList<>();
@@ -226,11 +227,11 @@ public class CreateItemEventHandler implements EventHandler {
 
   private Future<Item> processSingleItem(String jobExecutionId, String recordId, String chunkId, ItemCollection itemCollection, JsonObject mappedItemJson) {
     List<String> errors = validateItem(mappedItemJson, requiredFields);
-    LOGGER.debug(format("processSingleItem:: Trying to create item with id: %s", mappedItemJson.getString("id")));
+    LOGGER.debug("processSingleItem:: Trying to create item with id: {}", mappedItemJson.getString("id"));
     if (!errors.isEmpty()) {
       String msg = format("Mapped Item is invalid: %s, by jobExecutionId: '%s' and recordId: '%s' and chunkId: '%s' ", errors,
         jobExecutionId, recordId, chunkId);
-      LOGGER.warn("processSingleItem:: " + msg);
+      LOGGER.warn("processSingleItem:: {}", msg);
       return Future.failedFuture(msg);
     }
     Item mappedItem = ItemUtil.jsonToItem(mappedItemJson);
@@ -274,7 +275,7 @@ public class CreateItemEventHandler implements EventHandler {
     }).toList();
 
     if (materialTypes.stream().distinct().count() != 1) {
-      LOGGER.warn("validateItemsToContainSameMaterialType:: " + ITEMS_SHOULD_HAVE_SAME_MATERIAL_TYPE_MSG);
+      LOGGER.warn("validateItemsToContainSameMaterialType:: {}", ITEMS_SHOULD_HAVE_SAME_MATERIAL_TYPE_MSG);
       throw new EventProcessingException(ITEMS_SHOULD_HAVE_SAME_MATERIAL_TYPE_MSG);
     }
   }
@@ -360,7 +361,7 @@ public class CreateItemEventHandler implements EventHandler {
   }
 
   private void validateStatisticalCodes(JsonObject itemAsJson, List<String> errors) {
-    JsonArray statCodeIdsArray = itemAsJson.getJsonArray("statisticalCodeIds");
+    JsonArray statCodeIdsArray = itemAsJson.getJsonArray(STATISTICAL_CODE_IDS_FIELD);
     List<String> statCodeIds = statCodeIdsArray != null
       ? statCodeIdsArray.stream().map(Object::toString).toList()
       : List.of();
@@ -379,7 +380,7 @@ public class CreateItemEventHandler implements EventHandler {
         findResult -> promise.complete(findResult.getResult().records.isEmpty()),
         failure -> promise.fail(failure.getReason()));
     } catch (UnsupportedEncodingException e) {
-      LOGGER.warn(format("isItemBarcodeUnique:: Error to find items by barcode '%s'", barcode), e);
+      LOGGER.warn("isItemBarcodeUnique:: Error to find items by barcode '{}'", barcode, e);
       promise.fail(e);
     }
     return promise.future();
@@ -406,7 +407,7 @@ public class CreateItemEventHandler implements EventHandler {
           LOGGER.info("addItem:: Duplicated event received by ItemId: {}. Ignoring...", item.getId());
           promise.fail(new DuplicateEventException(format("Duplicated event by Item id: %s", item.getId())));
         } else {
-          LOGGER.warn(format("addItem:: Error posting Item cause %s, status code %s", failure.getReason(), failure.getStatusCode()));
+          LOGGER.warn("addItem:: Error posting Item cause {}, status code {}", failure.getReason(), failure.getStatusCode());
           promise.fail(failure.getReason());
         }
       });

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandler.java
@@ -561,8 +561,8 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
   protected Future<Record> getRecordByInstanceId(SourceStorageRecordsClient client, String instanceId) {
     return client.getSourceStorageRecordsFormattedById(instanceId, INSTANCE_ID_TYPE).compose(resp -> {
       if (resp.statusCode() != 200) {
-        LOGGER.warn(format("Failed to retrieve MARC record by instance id: '%s', status code: %s",
-          instanceId, resp.statusCode()));
+        LOGGER.warn("getRecordByInstanceId:: Failed to retrieve MARC record by instance id: '{}', status code: {}",
+          instanceId, resp.statusCode());
         return Future.succeededFuture(new Record().withParsedRecord(new ParsedRecord().withContent(new JsonObject())));
       }
       return Future.succeededFuture(resp.bodyAsJson(Record.class));
@@ -578,7 +578,7 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
           processOLError(instance, instanceCollection, eventPayload, promise, failure);
         } else {
           eventPayload.getContext().remove(CURRENT_RETRY_NUMBER);
-          LOGGER.error(format("Error updating Instance - %s, status code %s", failure.getReason(), failure.getStatusCode()));
+          LOGGER.error("updateInstanceAndRetryIfOlExists:: Error updating Instance - {}, status code {}", failure.getReason(), failure.getStatusCode());
           promise.fail(failure.getReason());
         }
       });
@@ -610,7 +610,6 @@ public class ReplaceInstanceEventHandler extends AbstractInstanceEventHandler { 
 
         handle(eventPayload).whenComplete((res, e) -> {
           if (e != null) {
-
             promise.fail(e.getMessage());
           } else {
             promise.complete();

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
@@ -144,7 +144,7 @@ public class UpdateHoldingEventHandler implements EventHandler {
           dataImportEventPayload.getContext().put(HOLDINGS.value(), validationResult.getKey().encode());
 
           List<HoldingsRecord> list = List.of(Json.decodeValue(dataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord[].class));
-          LOGGER.trace(format("handle:: Mapped holding: %s", Json.decodeValue(dataImportEventPayload.getContext().get(HOLDINGS.value()))));
+          LOGGER.trace("handle:: Mapped holding: {}", Json.decodeValue(dataImportEventPayload.getContext().get(HOLDINGS.value())));
           HoldingsRecordCollection holdingsRecordCollection = storage.getHoldingsRecordCollection(context);
           List<HoldingsRecord> expiredHoldings = new ArrayList<>();
           for (HoldingsRecord holding : list) {
@@ -153,7 +153,8 @@ public class UpdateHoldingEventHandler implements EventHandler {
             holdingsRecordCollection.update(holding,
               success -> {
                 try {
-                  LOGGER.info(format("handle:: Successfully updated holdings with id: %s", holding.getId()));
+                  LOGGER.info("handle:: Successfully updated holdings with id: {}, jobExecutionId: '{}' recordId: '{}' chunkId: '{}'",
+                    holding.getId(), jobExecutionId, recordId, chunkId);
                   updatedHoldingsRecord.add(holding);
                   constructDataImportEventPayload(updatePromise, dataImportEventPayload, list, context, errors);
                 } catch (Exception e) {
@@ -166,7 +167,8 @@ public class UpdateHoldingEventHandler implements EventHandler {
                   expiredHoldings.add(holding);
                 } else {
                   errors.add(new PartialError(holding.getId() != null ? holding.getId() : BLANK, failure.getReason()));
-                  LOGGER.warn("handle:: " + format(CANNOT_UPDATE_HOLDING_ERROR_MESSAGE, holding.getId(), jobExecutionId, recordId, chunkId, failure.getReason(), failure.getStatusCode()));
+                  LOGGER.warn("handle:: Error updating Holding by holdingId '{}' and jobExecution '{}' recordId '{}' chunkId '{}' - {}, status code {}",
+                    holding.getId(), jobExecutionId, recordId, chunkId, failure.getReason(), failure.getStatusCode());
                 }
                 updatePromise.complete();
               });
@@ -310,11 +312,11 @@ public class UpdateHoldingEventHandler implements EventHandler {
     int currentRetryNumber = dataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER) == null ? 0 : Integer.parseInt(dataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER));
     if (currentRetryNumber < MAX_RETRIES_COUNT) {
       dataImportEventPayload.getContext().put(CURRENT_RETRY_NUMBER, String.valueOf(currentRetryNumber + 1));
-      LOGGER.warn("processOLError:: Error updating Holdings. Expired Holdings: '{} '.Current retry number = '{}'. Retry UpdateHoldingEventHandler handler...", expiredHoldings, currentRetryNumber);
+       LOGGER.warn("processOLError:: Error updating Holdings. Expired Holdings: '{}'. Current retry number = '{}'. Retry UpdateHoldingEventHandler handler...", expiredHoldings, currentRetryNumber);
       getActualHoldingsList(expiredHoldings, holdingsRecords)
         .onSuccess(actualHoldingsList -> prepareDataAndReInvokeCurrentHandler(dataImportEventPayload, future, actualHoldingsList, errors, olAccumulativeResults))
         .onFailure(e -> {
-          String errMessage = format("Cannot get actual Holdings.Expired Holdings: '%s' for jobExecutionId '%s'. Error: %s ", expiredHoldings, dataImportEventPayload.getJobExecutionId(), e.getCause());
+           String errMessage = format("Cannot get actual Holdings.Expired Holdings: '%s' for jobExecutionId '%s'. Error: %s ", expiredHoldings, dataImportEventPayload.getJobExecutionId(), e.getCause());
           for (HoldingsRecord expiredHolding : expiredHoldings) {
             errors.add(new PartialError(expiredHolding.getId() != null ? expiredHolding.getId() : BLANK, errMessage));
           }
@@ -324,7 +326,7 @@ public class UpdateHoldingEventHandler implements EventHandler {
         });
     } else {
       String errMessage = format("Current retry number %s exceeded or equal given number %s for the Holding update for jobExecutionId '%s' ", MAX_RETRIES_COUNT, currentRetryNumber, dataImportEventPayload.getJobExecutionId());
-      LOGGER.warn("processOLError:: " + errMessage);
+       LOGGER.warn("processOLError:: {}", errMessage);
       for (HoldingsRecord expiredHolding : expiredHoldings) {
         errors.add(new PartialError(expiredHolding.getId() != null ? expiredHolding.getId() : BLANK, errMessage));
       }
@@ -340,7 +342,7 @@ public class UpdateHoldingEventHandler implements EventHandler {
     try {
       dataImportEventPayload.setCurrentNode(ObjectMapperTool.getMapper().readValue(dataImportEventPayload.getContext().get(CURRENT_NODE_PROPERTY), ProfileSnapshotWrapper.class));
     } catch (JsonProcessingException e) {
-      LOGGER.warn(format("prepareDataAndReInvokeCurrentHandler:: Cannot map from CURRENT_NODE value %s", e.getCause()));
+      LOGGER.warn("prepareDataAndReInvokeCurrentHandler:: Cannot map from CURRENT_NODE value, jobExecutionId: {}", dataImportEventPayload, e);
     }
     dataImportEventPayload.getContext().remove(CURRENT_EVENT_TYPE_PROPERTY);
     dataImportEventPayload.getContext().remove(CURRENT_NODE_PROPERTY);
@@ -377,7 +379,7 @@ public class UpdateHoldingEventHandler implements EventHandler {
         errors.add(new PartialError(itemId != null ? itemId : BLANK, failure.getReason()));
         EventProcessingException processingException =
           new EventProcessingException(format(CANNOT_GET_ACTUAL_ITEM_MESSAGE, itemId, failure.getReason(), failure.getStatusCode()));
-        LOGGER.warn("updateDataImportEventPayloadItem:: " + processingException);
+        LOGGER.warn("updateDataImportEventPayloadItem:: ", processingException);
         updateItemPromise.complete();
       });
     }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
@@ -33,7 +33,6 @@ import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,7 +74,6 @@ public class UpdateHoldingEventHandler implements EventHandler {
   private static final String CURRENT_EVENT_TYPE_PROPERTY = "CURRENT_EVENT_TYPE";
   private static final String CURRENT_HOLDING_PROPERTY = "CURRENT_HOLDING";
   private static final String CURRENT_NODE_PROPERTY = "CURRENT_NODE";
-  private static final String CANNOT_UPDATE_HOLDING_ERROR_MESSAGE = "Error updating Holding by holdingId '%s' and jobExecution '%s' recordId '%s' chunkId '%s' - %s, status code %s";
   private static final String CANNOT_GET_ACTUAL_ITEM_MESSAGE = "Cannot get actual Item after successfully updating holdings, by ITEM id: '%s' - '%s', status code '%s'";
   private static final String BLANK = "";
   private static final String ERRORS = "ERRORS";
@@ -139,7 +137,7 @@ public class UpdateHoldingEventHandler implements EventHandler {
           convertHoldings(dataImportEventPayload);
 
           JsonArray holdingsArray = new JsonArray(dataImportEventPayload.getContext().get(HOLDINGS.value()));
-          Map.Entry<JsonArray, List<PartialError>> validationResult = validateHoldings(holdingsArray);
+          Map.Entry<JsonArray, List<PartialError>> validationResult = ValidationUtil.validateHoldings(holdingsArray);
           errors.addAll(validationResult.getValue());
           dataImportEventPayload.getContext().put(HOLDINGS.value(), validationResult.getKey().encode());
 
@@ -226,30 +224,6 @@ public class UpdateHoldingEventHandler implements EventHandler {
     }
   }
 
-  private Map.Entry<JsonArray, List<PartialError>> validateHoldings(JsonArray holdingsToValidate) {
-    List<PartialError> validationErrors = new ArrayList<>();
-    JsonArray validHoldingsList = new JsonArray();
-
-    for (int i = 0; i < holdingsToValidate.size(); i++) {
-      JsonObject holdingAsJson = holdingsToValidate.getJsonObject(i);
-      List<String> statCodeErrors = validateStatisticalCodeIds(holdingAsJson);
-      if (!statCodeErrors.isEmpty()) {
-        validationErrors.add(new PartialError(holdingAsJson.getString("id"), String.join(", ", statCodeErrors)));
-      } else {
-        validHoldingsList.add(holdingAsJson);
-      }
-    }
-    return Map.entry(validHoldingsList, validationErrors);
-  }
-
-  private List<String> validateStatisticalCodeIds(JsonObject holdingAsJson) {
-    JsonArray statCodeIdsArray = holdingAsJson.getJsonArray("statisticalCodeIds");
-    List<String> statCodeIds = statCodeIdsArray != null
-      ? statCodeIdsArray.stream().map(Object::toString).toList()
-      : Collections.emptyList();
-    return ValidationUtil.validateStatisticalCodeIds(statCodeIds);
-  }
-
   private static void convertHoldings(DataImportEventPayload dataImportEventPayload) {
     JsonArray holdingsJsonArray = new JsonArray(dataImportEventPayload.getContext().get(HOLDINGS.value()));
     for (int i = 0; i < holdingsJsonArray.size(); i++) {
@@ -312,11 +286,11 @@ public class UpdateHoldingEventHandler implements EventHandler {
     int currentRetryNumber = dataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER) == null ? 0 : Integer.parseInt(dataImportEventPayload.getContext().get(CURRENT_RETRY_NUMBER));
     if (currentRetryNumber < MAX_RETRIES_COUNT) {
       dataImportEventPayload.getContext().put(CURRENT_RETRY_NUMBER, String.valueOf(currentRetryNumber + 1));
-       LOGGER.warn("processOLError:: Error updating Holdings. Expired Holdings: '{}'. Current retry number = '{}'. Retry UpdateHoldingEventHandler handler...", expiredHoldings, currentRetryNumber);
+      LOGGER.warn("processOLError:: Error updating Holdings. Expired Holdings: '{}'. Current retry number = '{}'. Retry UpdateHoldingEventHandler handler...", expiredHoldings, currentRetryNumber);
       getActualHoldingsList(expiredHoldings, holdingsRecords)
         .onSuccess(actualHoldingsList -> prepareDataAndReInvokeCurrentHandler(dataImportEventPayload, future, actualHoldingsList, errors, olAccumulativeResults))
         .onFailure(e -> {
-           String errMessage = format("Cannot get actual Holdings.Expired Holdings: '%s' for jobExecutionId '%s'. Error: %s ", expiredHoldings, dataImportEventPayload.getJobExecutionId(), e.getCause());
+          String errMessage = format("Cannot get actual Holdings.Expired Holdings: '%s' for jobExecutionId '%s'. Error: %s ", expiredHoldings, dataImportEventPayload.getJobExecutionId(), e.getCause());
           for (HoldingsRecord expiredHolding : expiredHoldings) {
             errors.add(new PartialError(expiredHolding.getId() != null ? expiredHolding.getId() : BLANK, errMessage));
           }
@@ -326,7 +300,7 @@ public class UpdateHoldingEventHandler implements EventHandler {
         });
     } else {
       String errMessage = format("Current retry number %s exceeded or equal given number %s for the Holding update for jobExecutionId '%s' ", MAX_RETRIES_COUNT, currentRetryNumber, dataImportEventPayload.getJobExecutionId());
-       LOGGER.warn("processOLError:: {}", errMessage);
+      LOGGER.warn("processOLError:: {}", errMessage);
       for (HoldingsRecord expiredHolding : expiredHoldings) {
         errors.add(new PartialError(expiredHolding.getId() != null ? expiredHolding.getId() : BLANK, errMessage));
       }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
@@ -38,9 +38,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.*;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.ActionProfile.Action.UPDATE;
 import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
@@ -381,7 +381,7 @@ public class UpdateHoldingEventHandler implements EventHandler {
   }
 
   private static String getQueryParamForMultipleHoldings(List<HoldingsRecord> holdings) {
-    return holdings.stream().map(HoldingsRecord::getId).collect(Collectors.joining(" OR "));
+    return holdings.stream().map(HoldingsRecord::getId).collect(joining(" OR "));
   }
 
   private void fillPayloadAndClearLists(DataImportEventPayload dataImportEventPayload, String errorsAsStringJson, CompletableFuture<DataImportEventPayload> future, OlHoldingsAccumulativeResults olAccumulativeResults) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandler.java
@@ -23,6 +23,7 @@ import org.folio.inventory.dataimport.entities.OlHoldingsAccumulativeResults;
 import org.folio.inventory.domain.items.ItemCollection;
 import org.folio.inventory.storage.Storage;
 import org.folio.inventory.support.ItemUtil;
+import org.folio.inventory.dataimport.util.ValidationUtil;
 import org.folio.processing.events.services.handler.EventHandler;
 import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
@@ -32,8 +33,10 @@ import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -134,6 +137,12 @@ public class UpdateHoldingEventHandler implements EventHandler {
           List<Future<?>> updatedHoldingsRecordFutures = new ArrayList<>();
           isPayloadConstructed = false;
           convertHoldings(dataImportEventPayload);
+
+          JsonArray holdingsArray = new JsonArray(dataImportEventPayload.getContext().get(HOLDINGS.value()));
+          Map.Entry<JsonArray, List<PartialError>> validationResult = validateHoldings(holdingsArray);
+          errors.addAll(validationResult.getValue());
+          dataImportEventPayload.getContext().put(HOLDINGS.value(), validationResult.getKey().encode());
+
           List<HoldingsRecord> list = List.of(Json.decodeValue(dataImportEventPayload.getContext().get(HOLDINGS.value()), HoldingsRecord[].class));
           LOGGER.trace(format("handle:: Mapped holding: %s", Json.decodeValue(dataImportEventPayload.getContext().get(HOLDINGS.value()))));
           HoldingsRecordCollection holdingsRecordCollection = storage.getHoldingsRecordCollection(context);
@@ -213,6 +222,30 @@ public class UpdateHoldingEventHandler implements EventHandler {
         future.completeExceptionally(new EventProcessingException(errorsAsStringJson));
       }
     }
+  }
+
+  private Map.Entry<JsonArray, List<PartialError>> validateHoldings(JsonArray holdingsToValidate) {
+    List<PartialError> validationErrors = new ArrayList<>();
+    JsonArray validHoldingsList = new JsonArray();
+
+    for (int i = 0; i < holdingsToValidate.size(); i++) {
+      JsonObject holdingAsJson = holdingsToValidate.getJsonObject(i);
+      List<String> statCodeErrors = validateStatisticalCodeIds(holdingAsJson);
+      if (!statCodeErrors.isEmpty()) {
+        validationErrors.add(new PartialError(holdingAsJson.getString("id"), String.join(", ", statCodeErrors)));
+      } else {
+        validHoldingsList.add(holdingAsJson);
+      }
+    }
+    return Map.entry(validHoldingsList, validationErrors);
+  }
+
+  private List<String> validateStatisticalCodeIds(JsonObject holdingAsJson) {
+    JsonArray statCodeIdsArray = holdingAsJson.getJsonArray("statisticalCodeIds");
+    List<String> statCodeIds = statCodeIdsArray != null
+      ? statCodeIdsArray.stream().map(Object::toString).toList()
+      : Collections.emptyList();
+    return ValidationUtil.validateStatisticalCodeIds(statCodeIds);
   }
 
   private static void convertHoldings(DataImportEventPayload dataImportEventPayload) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -27,6 +27,7 @@ import org.folio.inventory.storage.Storage;
 import org.folio.inventory.support.CqlHelper;
 import org.folio.inventory.support.ItemUtil;
 import org.folio.inventory.support.JsonHelper;
+import org.folio.inventory.dataimport.util.ValidationUtil;
 import org.folio.processing.events.services.handler.EventHandler;
 import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
@@ -338,6 +339,11 @@ public class UpdateItemEventHandler implements EventHandler {
   private List<String> validateItem(JsonObject itemAsJson, List<String> requiredFields) {
     List<String> errors = EventHandlingUtil.validateJsonByRequiredFields(itemAsJson, requiredFields);
     validateStatusName(itemAsJson, errors);
+    JsonArray statCodeIdsArray = itemAsJson.getJsonArray("statisticalCodeIds");
+    List<String> statCodeIds = statCodeIdsArray != null
+      ? statCodeIdsArray.stream().map(Object::toString).toList()
+      : List.of();
+    errors.addAll(ValidationUtil.validateStatisticalCodeIds(statCodeIds));
     return errors;
   }
 

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -103,6 +103,7 @@ public class UpdateItemEventHandler implements EventHandler {
   private static final String MULTIPLE_HOLDINGS_FIELD = "MULTIPLE_HOLDINGS_FIELD";
   private static final String TEMPORARY_MULTIPLE_HOLDINGS_FIELD = "TEMPORARY_MULTIPLE_HOLDINGS_FIELD";
   public static final String ID_PATH_FIELD = "id";
+  private static final String STATISTICAL_CODE_IDS_FIELD = "statisticalCodeIds";
   private final List<String> requiredFields = Arrays.asList("status.name", "materialType.id", "permanentLoanType.id", "holdingsRecordId");
   private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZone(ZoneOffset.UTC);
 
@@ -339,11 +340,7 @@ public class UpdateItemEventHandler implements EventHandler {
   private List<String> validateItem(JsonObject itemAsJson, List<String> requiredFields) {
     List<String> errors = EventHandlingUtil.validateJsonByRequiredFields(itemAsJson, requiredFields);
     validateStatusName(itemAsJson, errors);
-    JsonArray statCodeIdsArray = itemAsJson.getJsonArray("statisticalCodeIds");
-    List<String> statCodeIds = statCodeIdsArray != null
-      ? statCodeIdsArray.stream().map(Object::toString).toList()
-      : List.of();
-    errors.addAll(ValidationUtil.validateStatisticalCodeIds(statCodeIds));
+    validateStatisticalCodes(itemAsJson, errors);
     return errors;
   }
 
@@ -352,6 +349,14 @@ public class UpdateItemEventHandler implements EventHandler {
     if (StringUtils.isNotBlank(statusName) && !ItemStatusName.isStatusCorrect(statusName)) {
       errors.add(format("Invalid status specified '%s'", statusName));
     }
+  }
+
+  private void validateStatisticalCodes(JsonObject itemAsJson, List<String> errors) {
+    JsonArray statCodeIdsArray = itemAsJson.getJsonArray(STATISTICAL_CODE_IDS_FIELD);
+    List<String> statCodeIds = statCodeIdsArray != null
+      ? statCodeIdsArray.stream().map(Object::toString).toList()
+      : List.of();
+    errors.addAll(ValidationUtil.validateStatisticalCodeIds(statCodeIds));
   }
 
   private Future<Void> verifyItemBarcodeUniqueness(Item item, ItemCollection itemCollection, Promise<Void> updatePromise, List<PartialError> errors) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandler.java
@@ -158,13 +158,13 @@ public class UpdateItemEventHandler implements EventHandler {
           List<PartialError> errors = new ArrayList<>();
 
           JsonArray itemsJsonArray = new JsonArray(dataImportEventPayload.getContext().get(ITEM.value()));
-          LOGGER.trace(format("handle:: Mapped Items to update: %s", dataImportEventPayload.getContext().get(ITEM.value())));
+          LOGGER.trace("handle:: Mapped Items to update: {}", dataImportEventPayload.getContext().get(ITEM.value()));
           List<Item> expiredItems = new ArrayList<>();
           for (int i = 0; i < itemsJsonArray.size(); i++) {
             Promise<Void> updatePromise = Promise.promise();
             updatedItemsRecordFutures.add(updatePromise.future());
             JsonObject mappedItemAsJson = itemsJsonArray.getJsonObject(i).getJsonObject(ITEM_PATH_FIELD);
-            LOGGER.debug(format("handle:: Updating Item with id: %s", mappedItemAsJson.getString("id")));
+            LOGGER.debug("handle:: Updating Item with id: {}", mappedItemAsJson.getString("id"));
             List<String> validationErrors = validateItem(mappedItemAsJson, requiredFields);
             if (!validationErrors.isEmpty()) {
               String msg = format("Mapped Item is invalid: %s, by jobExecutionId: '%s' and recordId: '%s' and chunkId: '%s' ", validationErrors,

--- a/src/main/java/org/folio/inventory/dataimport/util/ValidationUtil.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/ValidationUtil.java
@@ -5,13 +5,14 @@ import org.folio.inventory.domain.instances.Instance;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Util for detailed validation different entities.
  */
 public class ValidationUtil {
 
-  public static final String INVALID_STATISTICAL_CODE_MSG = "Provided Statistical code is not a valid value.";
+  private static final String INVALID_STATISTICAL_CODE_MSG = "Provided Statistical code(s) are not a valid values: ";
 
   private ValidationUtil() {
   }
@@ -47,9 +48,16 @@ public class ValidationUtil {
   }
 
   private static void validateStatisticalCodeIds(List<String> errorMessages, List<String> ids) {
-    ids.stream()
+    List<String> invalidIds = ids.stream()
       .filter(id -> !isUUID(id))
-      .forEach(id -> errorMessages.add(INVALID_STATISTICAL_CODE_MSG));
+      .toList();
+
+    if (!invalidIds.isEmpty()) {
+      String values = invalidIds.stream()
+        .map(id -> "'" + id + "'")
+        .collect(Collectors.joining(", "));
+      errorMessages.add(INVALID_STATISTICAL_CODE_MSG + values + ".");
+    }
   }
 
   private static void validateField(List<String> errorMessages, List<String> values, String fieldName) {

--- a/src/main/java/org/folio/inventory/dataimport/util/ValidationUtil.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/ValidationUtil.java
@@ -1,9 +1,13 @@
 package org.folio.inventory.dataimport.util;
 
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.folio.inventory.dataimport.entities.PartialError;
 import org.folio.inventory.domain.instances.Instance;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -13,6 +17,7 @@ import java.util.stream.Collectors;
 public class ValidationUtil {
 
   private static final String INVALID_STATISTICAL_CODE_MSG = "Provided Statistical code(s) are not a valid values: ";
+  private static final String STATISTICAL_CODE_IDS_FIELD = "statisticalCodeIds";
 
   private ValidationUtil() {
   }
@@ -33,6 +38,29 @@ public class ValidationUtil {
     validateStatisticalCodeIds(errorMessages, instance.getStatisticalCodeIds());
 
     return errorMessages;
+  }
+
+  /**
+   * Validates holdings records specified in the JSON array.
+   * Invalid holdings are reported as {@link PartialError} entries.
+   *
+   * @param holdingsToValidate array of holding JSON objects to validate
+   * @return {@link Map.Entry} where the key is the array of valid holdings and the value is the list of validation errors
+   */
+  public static Map.Entry<JsonArray, List<PartialError>> validateHoldings(JsonArray holdingsToValidate) {
+    List<PartialError> validationErrors = new ArrayList<>();
+    JsonArray validHoldingsList = new JsonArray();
+
+    for (int i = 0; i < holdingsToValidate.size(); i++) {
+      JsonObject holdingAsJson = holdingsToValidate.getJsonObject(i);
+      List<String> statCodeErrors = validateHoldingStatisticalCodeIds(holdingAsJson);
+      if (!statCodeErrors.isEmpty()) {
+        validationErrors.add(new PartialError(holdingAsJson.getString("id"), String.join(", ", statCodeErrors)));
+      } else {
+        validHoldingsList.add(holdingAsJson);
+      }
+    }
+    return Map.entry(validHoldingsList, validationErrors);
   }
 
   /**
@@ -73,5 +101,13 @@ public class ValidationUtil {
     } catch (Exception ex) {
       return false;
     }
+  }
+
+  private static List<String> validateHoldingStatisticalCodeIds(JsonObject holdingAsJson) {
+    JsonArray statCodeIdsArray = holdingAsJson.getJsonArray(STATISTICAL_CODE_IDS_FIELD);
+    List<String> statCodeIds = statCodeIdsArray != null
+      ? statCodeIdsArray.stream().map(Object::toString).toList()
+      : List.of();
+    return validateStatisticalCodeIds(statCodeIds);
   }
 }

--- a/src/main/java/org/folio/inventory/dataimport/util/ValidationUtil.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/ValidationUtil.java
@@ -11,6 +11,8 @@ import java.util.UUID;
  */
 public class ValidationUtil {
 
+  public static final String INVALID_STATISTICAL_CODE_MSG = "Provided Statistical code is not a valid value.";
+
   private ValidationUtil() {
   }
 
@@ -27,8 +29,27 @@ public class ValidationUtil {
     //TODO: This will be extended for different fields and entities.That's why there are so many methods just for 1 field.
     // Branch for it extending validation: MODINV-1012-extended
     validateField(errorMessages, instance.getNatureOfContentTermIds(), "natureOfContentTermIds");
+    validateStatisticalCodeIds(errorMessages, instance.getStatisticalCodeIds());
 
     return errorMessages;
+  }
+
+  /**
+   * Validates that all provided statistical code IDs are valid UUIDs.
+   * Returns an error message for each invalid entry.
+   * @param ids list of statistical code IDs to validate
+   * @return list of error messages; empty if all IDs are valid UUIDs
+   */
+  public static List<String> validateStatisticalCodeIds(List<String> ids) {
+    ArrayList<String> errorMessages = new ArrayList<>();
+    validateStatisticalCodeIds(errorMessages, ids);
+    return errorMessages;
+  }
+
+  private static void validateStatisticalCodeIds(List<String> errorMessages, List<String> ids) {
+    ids.stream()
+      .filter(id -> !isUUID(id))
+      .forEach(id -> errorMessages.add(INVALID_STATISTICAL_CODE_MSG));
   }
 
   private static void validateField(List<String> errorMessages, List<String> values, String fieldName) {

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
@@ -8,6 +8,7 @@ import io.vertx.core.json.JsonObject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
+import org.folio.processing.value.ListValue;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.JobProfile;
 import org.folio.MappingProfile;
@@ -64,6 +65,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import static org.folio.ActionProfile.FolioRecord.HOLDINGS;
+import static org.folio.ActionProfile.FolioRecord.INSTANCE;
 import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_CREATED;
 import static org.folio.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
@@ -72,14 +74,22 @@ import static org.folio.inventory.dataimport.util.DataImportConstants.UNIQUE_ID_
 import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class CreateHoldingEventHandlerTest {
 
@@ -783,6 +793,150 @@ public class CreateHoldingEventHandlerTest {
 
     ExecutionException exception = Assert.assertThrows(ExecutionException.class, future::get);
     Assert.assertEquals(ACTION_HAS_NO_MAPPING_MSG, exception.getCause().getMessage());
+  }
+
+  @Test
+  public void shouldNotCreateSingleHoldingIfMappedStatisticalCodeIdIsInvalid() {
+    MappingProfile invalidStatCodeMappingProfile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(EntityType.HOLDINGS)
+      .withMappingDetails(new MappingDetail()
+        .withMappingFields(Lists.newArrayList(
+          new MappingRule().withName("permanentLocationId").withPath("permanentLocationId").withValue("KU/CC/DI/M").withEnabled("true"),
+          new MappingRule().withName("statisticalCodeId").withPath("statisticalCodeIds[]").withValue("990$a").withEnabled("true").withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING))));
+
+    ProfileSnapshotWrapper snapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(jobProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(jobProfile)
+      .withChildSnapshotWrappers(Collections.singletonList(
+        new ProfileSnapshotWrapper()
+          .withProfileId(actionProfile.getId())
+          .withContentType(ACTION_PROFILE)
+          .withContent(actionProfile)
+          .withChildSnapshotWrappers(Collections.singletonList(
+            new ProfileSnapshotWrapper()
+              .withProfileId(invalidStatCodeMappingProfile.getId())
+              .withContentType(MAPPING_PROFILE)
+              .withContent(JsonObject.mapFrom(invalidStatCodeMappingProfile).getMap())))));
+
+    // reader returns permanentLocationId, then invalid statistical code string
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(
+      StringValue.of(permanentLocationId),
+      ListValue.of(List.of("ebookss"))
+    );
+
+    String instanceId = String.valueOf(UUID.randomUUID());
+    Instance instance = new Instance(instanceId, 1, String.valueOf(UUID.randomUUID()),
+      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
+    Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(INSTANCE.value(), Json.encode(instance));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+      .withContext(context)
+      .withProfileSnapshot(snapshotWrapper)
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withCurrentNode(snapshotWrapper.getChildSnapshotWrappers().getFirst());
+
+    CompletableFuture<DataImportEventPayload> future = createHoldingEventHandler.handle(dataImportEventPayload);
+    ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
+    assertEquals(
+      "org.folio.processing.exceptions.EventProcessingException: Mapped Holdings record(s) are invalid: [Provided Statistical code is not a valid value.]",
+      exception.getMessage()
+    );
+  }
+
+  @Test
+  public void shouldCreateMultipleHoldingsAndReturnPartialErrorsForHoldingWithInvalidStatisticalCode()
+    throws ExecutionException, InterruptedException, TimeoutException {
+
+    MappingProfile invalidStatCodeMappingProfile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(EntityType.HOLDINGS)
+      .withMappingDetails(new MappingDetail()
+        .withMappingFields(Lists.newArrayList(
+          new MappingRule().withName("permanentLocationId").withPath("holdings.permanentLocationId").withValue("945$h").withEnabled("true"),
+          new MappingRule().withName("statisticalCodeId").withPath("holdings.statisticalCodeIds[]").withValue("990$a").withEnabled("true").withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING))));
+
+    ProfileSnapshotWrapper snapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(jobProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(jobProfile)
+      .withChildSnapshotWrappers(Collections.singletonList(
+        new ProfileSnapshotWrapper()
+          .withProfileId(actionProfile.getId())
+          .withContentType(ACTION_PROFILE)
+          .withContent(actionProfile)
+          .withChildSnapshotWrappers(Collections.singletonList(
+            new ProfileSnapshotWrapper()
+              .withProfileId(invalidStatCodeMappingProfile.getId())
+              .withContentType(MAPPING_PROFILE)
+              .withContent(JsonObject.mapFrom(invalidStatCodeMappingProfile).getMap())))));
+
+    String firstPermanentLocationId = UUID.randomUUID().toString();
+    String secondPermanentLocationId = UUID.randomUUID().toString();
+    String validStatisticalCodeUuid = UUID.randomUUID().toString();
+
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(
+      StringValue.of(firstPermanentLocationId),
+      ListValue.of(List.of(validStatisticalCodeUuid)),
+      StringValue.of(secondPermanentLocationId),
+      ListValue.of(List.of(validStatisticalCodeUuid)),
+      StringValue.of(UUID.randomUUID().toString()),
+      // reader returns invalid statistical code string
+      ListValue.of(List.of("ebookss"))
+    );
+
+    String instanceId = String.valueOf(UUID.randomUUID());
+    Instance instance = new Instance(instanceId, 1, String.valueOf(UUID.randomUUID()),
+      String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
+    Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(INSTANCE.value(), Json.encode(instance));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_HOLDING_CREATED.value())
+      .withContext(context)
+      .withProfileSnapshot(snapshotWrapper)
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withCurrentNode(snapshotWrapper.getChildSnapshotWrappers().getFirst());
+
+    CompletableFuture<DataImportEventPayload> future = createHoldingEventHandler.handle(dataImportEventPayload);
+
+    DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+    assertEquals(DI_INVENTORY_HOLDING_CREATED.value(), actualDataImportEventPayload.getEventType());
+    assertNotNull(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    JsonArray holdingsList = new JsonArray(actualDataImportEventPayload.getContext().get(HOLDINGS.value()));
+    assertEquals(2, holdingsList.size());
+    List<HoldingsRecord> holdings = holdingsList.stream()
+      .map(JsonObject.class::cast)
+      .map(j -> j.mapTo(HoldingsRecord.class))
+      .toList();
+    assertEquals(firstPermanentLocationId, (holdings.getFirst().getPermanentLocationId()));
+    assertEquals(secondPermanentLocationId, (holdings.getLast().getPermanentLocationId()));
+
+    for (HoldingsRecord holding : holdings) {
+      assertNotNull(holding.getId());
+      assertEquals(instanceId, holding.getInstanceId());
+      assertEquals(FOLIO_SOURCE_ID, holding.getSourceId());
+      assertTrue(holding.getStatisticalCodeIds().contains(validStatisticalCodeUuid));
+    }
+
+    JsonArray errors = new JsonArray(actualDataImportEventPayload.getContext().get(ERRORS));
+    assertEquals(1, errors.size());
+    PartialError partialError = errors.getJsonObject(0).mapTo(PartialError.class);
+    assertThat(
+      partialError.getError(),
+      containsString("Provided Statistical code is not a valid value.")
+    );
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
@@ -845,9 +845,9 @@ public class CreateHoldingEventHandlerTest {
 
     CompletableFuture<DataImportEventPayload> future = createHoldingEventHandler.handle(dataImportEventPayload);
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
-    assertEquals(
-      "org.folio.processing.exceptions.EventProcessingException: Mapped Holdings record(s) are invalid: [Provided Statistical code is not a valid value.]",
-      exception.getMessage()
+    assertThat(
+      exception.getMessage(),
+      containsString("Provided Statistical code(s) are not a valid values: 'ebookss'.")
     );
   }
 
@@ -935,7 +935,7 @@ public class CreateHoldingEventHandlerTest {
     PartialError partialError = errors.getJsonObject(0).mapTo(PartialError.class);
     assertThat(
       partialError.getError(),
-      containsString("Provided Statistical code is not a valid value.")
+      containsString("Provided Statistical code(s) are not a valid values: 'ebookss'.")
     );
   }
 

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateHoldingEventHandlerTest.java
@@ -206,7 +206,7 @@ public class CreateHoldingEventHandlerTest {
       String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(INSTANCE.value(), new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
     context.put(ERRORS, Json.encode(new PartialError(null, "testError")));
 
@@ -239,7 +239,7 @@ public class CreateHoldingEventHandlerTest {
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> payloadContext = new HashMap<>();
 
-    payloadContext.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    payloadContext.put(INSTANCE.value(), new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
     payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
     payloadContext.put(ERRORS, Json.encode(new PartialError(null, "testError")));
 
@@ -303,7 +303,7 @@ public class CreateHoldingEventHandlerTest {
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> payloadContext = new HashMap<>();
 
-    payloadContext.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    payloadContext.put(INSTANCE.value(), new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
     payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
     payloadContext.put(ERRORS, Json.encode(new PartialError(null, "testError")));
 
@@ -367,7 +367,7 @@ public class CreateHoldingEventHandlerTest {
       String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(INSTANCE.value(), new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
@@ -400,7 +400,7 @@ public class CreateHoldingEventHandlerTest {
       String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(INSTANCE.value(), new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
@@ -446,7 +446,7 @@ public class CreateHoldingEventHandlerTest {
       String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(INSTANCE.value(), new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
@@ -493,7 +493,7 @@ public class CreateHoldingEventHandlerTest {
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
 
     HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", instanceAsJson.encode());
+    context.put(INSTANCE.value(), instanceAsJson.encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
@@ -549,7 +549,7 @@ public class CreateHoldingEventHandlerTest {
       String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(INSTANCE.value(), new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
@@ -585,7 +585,7 @@ public class CreateHoldingEventHandlerTest {
       String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(INSTANCE.value(), new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
@@ -612,7 +612,7 @@ public class CreateHoldingEventHandlerTest {
       String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(INSTANCE.value(), new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
@@ -631,7 +631,7 @@ public class CreateHoldingEventHandlerTest {
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITHOUT_INSTANCE_ID));
 
     HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", new JsonObject().encode());
+    context.put(INSTANCE.value(), new JsonObject().encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
@@ -651,7 +651,7 @@ public class CreateHoldingEventHandlerTest {
     Record record = new Record().withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId));
 
     HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", new JsonObject().encode());
+    context.put(INSTANCE.value(), new JsonObject().encode());
     context.put("InvalidField", JsonObject.mapFrom(record).encode());
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
@@ -742,7 +742,7 @@ public class CreateHoldingEventHandlerTest {
       String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()), String.valueOf(UUID.randomUUID()));
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
-    context.put("INSTANCE", new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
+    context.put(INSTANCE.value(), new JsonObject(new ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(instance)).encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
@@ -74,6 +74,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -103,6 +104,7 @@ import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -273,6 +275,44 @@ public class CreateInstanceEventHandlerTest {
             .withProfileId(mappingProfileWithNatureOfContentTerm.getId())
             .withContentType(MAPPING_PROFILE)
             .withContent(JsonObject.mapFrom(mappingProfileWithNatureOfContentTerm).getMap())))));
+
+  private JobProfile jobProfileWithInvalidStatisticalCode = new JobProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Create MARC Bibs with invalid statistical code")
+    .withDataType(JobProfile.DataType.MARC);
+
+  private ActionProfile actionProfileWithInvalidStatisticalCode = new ActionProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Create Instance with invalid statistical code")
+    .withAction(ActionProfile.Action.CREATE)
+    .withFolioRecord(INSTANCE);
+
+  private MappingProfile mappingProfileWithInvalidStatisticalCode = new MappingProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Mapping profile with invalid statistical code")
+    .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+    .withExistingRecordType(EntityType.INSTANCE)
+    .withMappingDetails(new MappingDetail()
+      .withMappingFields(Lists.newArrayList(
+        new MappingRule().withPath("instance.instanceTypeId").withValue("\"instanceTypeIdExpression\"").withEnabled("true"),
+        new MappingRule().withPath("instance.title").withValue("\"titleExpression\"").withEnabled("true"),
+        new MappingRule().withPath("instance.statisticalCodeIds[]").withName("statisticalCodeId").withValue("\"ebookss\"").withEnabled("true").withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING))));
+
+  private ProfileSnapshotWrapper profileSnapshotWrapperWithInvalidStatisticalCode = new ProfileSnapshotWrapper()
+    .withId(UUID.randomUUID().toString())
+    .withProfileId(jobProfileWithInvalidStatisticalCode.getId())
+    .withContentType(JOB_PROFILE)
+    .withContent(jobProfileWithInvalidStatisticalCode)
+    .withChildSnapshotWrappers(Collections.singletonList(
+      new ProfileSnapshotWrapper()
+        .withProfileId(actionProfileWithInvalidStatisticalCode.getId())
+        .withContentType(ACTION_PROFILE)
+        .withContent(actionProfileWithInvalidStatisticalCode)
+        .withChildSnapshotWrappers(Collections.singletonList(
+          new ProfileSnapshotWrapper()
+            .withProfileId(mappingProfileWithInvalidStatisticalCode.getId())
+            .withContentType(MAPPING_PROFILE)
+            .withContent(JsonObject.mapFrom(mappingProfileWithInvalidStatisticalCode).getMap())))));
 
   private MappingProfile mappingProfileWithSuppressFalse = new MappingProfile()
     .withId(UUID.randomUUID().toString())
@@ -1002,6 +1042,46 @@ public class CreateInstanceEventHandlerTest {
 
     CompletableFuture<DataImportEventPayload> future = createInstanceEventHandler.handle(dataImportEventPayload);
     future.get(10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void shouldNotCreateInstanceIfStatisticalCodeIdIsInvalid() {
+    String instanceTypeId = "fe19bae4-da28-472b-be90-d442e2428ead";
+    String recordId = "567859ad-505a-400d-a699-0028a1fdbf84";
+    String instanceId = "4d4545df-b5ba-4031-a031-70b1c1b2fc5d";
+    String title = "titleValue";
+    RecordToEntity recordToInstance = RecordToEntity.builder().recordId(recordId).entityId(instanceId).build();
+
+    Reader fakeReader = Mockito.mock(Reader.class);
+    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+    when(storage.getInstanceCollection(any())).thenReturn(instanceRecordCollection);
+    when(instanceIdStorageService.store(any(), any(), any())).thenReturn(Future.succeededFuture(recordToInstance));
+
+    // reader returns invalid statisticalCodeIds field value
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(
+      StringValue.of(instanceTypeId),
+      StringValue.of(title),
+      ListValue.of(List.of("ebookss"))
+    );
+
+    MappingManager.registerReaderFactory(fakeReaderFactory);
+    MappingManager.registerWriterFactory(new InstanceWriterFactory());
+
+    HashMap<String, String> context = new HashMap<>();
+    Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withEventType(DI_INVENTORY_INSTANCE_CREATED.value())
+      .withTenant(TENANT_ID)
+      .withOkapiUrl(mockServer.baseUrl())
+      .withContext(context)
+      .withCurrentNode(profileSnapshotWrapperWithInvalidStatisticalCode.getChildSnapshotWrappers().getFirst());
+
+    CompletableFuture<DataImportEventPayload> future = createInstanceEventHandler.handle(dataImportEventPayload);
+    ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
+    assertThat(exception.getMessage(), containsString("Mapped Instance is invalid: [Provided Statistical code is not a valid value.]"));
   }
 
   @Test(expected = Exception.class)

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
@@ -1081,7 +1081,7 @@ public class CreateInstanceEventHandlerTest {
 
     CompletableFuture<DataImportEventPayload> future = createInstanceEventHandler.handle(dataImportEventPayload);
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
-    assertThat(exception.getMessage(), containsString("Mapped Instance is invalid: [Provided Statistical code is not a valid value.]"));
+    assertThat(exception.getMessage(), containsString("Provided Statistical code(s) are not a valid values: 'ebookss'."));
   }
 
   @Test(expected = Exception.class)

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateInstanceEventHandlerTest.java
@@ -276,18 +276,7 @@ public class CreateInstanceEventHandlerTest {
             .withContentType(MAPPING_PROFILE)
             .withContent(JsonObject.mapFrom(mappingProfileWithNatureOfContentTerm).getMap())))));
 
-  private JobProfile jobProfileWithInvalidStatisticalCode = new JobProfile()
-    .withId(UUID.randomUUID().toString())
-    .withName("Create MARC Bibs with invalid statistical code")
-    .withDataType(JobProfile.DataType.MARC);
-
-  private ActionProfile actionProfileWithInvalidStatisticalCode = new ActionProfile()
-    .withId(UUID.randomUUID().toString())
-    .withName("Create Instance with invalid statistical code")
-    .withAction(ActionProfile.Action.CREATE)
-    .withFolioRecord(INSTANCE);
-
-  private MappingProfile mappingProfileWithInvalidStatisticalCode = new MappingProfile()
+  private MappingProfile mappingProfileWithStatisticalCode = new MappingProfile()
     .withId(UUID.randomUUID().toString())
     .withName("Mapping profile with invalid statistical code")
     .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
@@ -298,21 +287,21 @@ public class CreateInstanceEventHandlerTest {
         new MappingRule().withPath("instance.title").withValue("\"titleExpression\"").withEnabled("true"),
         new MappingRule().withPath("instance.statisticalCodeIds[]").withName("statisticalCodeId").withValue("\"ebookss\"").withEnabled("true").withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING))));
 
-  private ProfileSnapshotWrapper profileSnapshotWrapperWithInvalidStatisticalCode = new ProfileSnapshotWrapper()
+  private ProfileSnapshotWrapper profileSnapshotWrapperWithStatisticalCode = new ProfileSnapshotWrapper()
     .withId(UUID.randomUUID().toString())
-    .withProfileId(jobProfileWithInvalidStatisticalCode.getId())
+    .withProfileId(jobProfile.getId())
     .withContentType(JOB_PROFILE)
-    .withContent(jobProfileWithInvalidStatisticalCode)
-    .withChildSnapshotWrappers(Collections.singletonList(
+    .withContent(jobProfile)
+    .withChildSnapshotWrappers(List.of(
       new ProfileSnapshotWrapper()
-        .withProfileId(actionProfileWithInvalidStatisticalCode.getId())
+        .withProfileId(actionProfile.getId())
         .withContentType(ACTION_PROFILE)
-        .withContent(actionProfileWithInvalidStatisticalCode)
-        .withChildSnapshotWrappers(Collections.singletonList(
+        .withContent(actionProfile)
+        .withChildSnapshotWrappers(List.of(
           new ProfileSnapshotWrapper()
-            .withProfileId(mappingProfileWithInvalidStatisticalCode.getId())
+            .withProfileId(mappingProfileWithStatisticalCode.getId())
             .withContentType(MAPPING_PROFILE)
-            .withContent(JsonObject.mapFrom(mappingProfileWithInvalidStatisticalCode).getMap())))));
+            .withContent(JsonObject.mapFrom(mappingProfileWithStatisticalCode).getMap())))));
 
   private MappingProfile mappingProfileWithSuppressFalse = new MappingProfile()
     .withId(UUID.randomUUID().toString())
@@ -1077,7 +1066,7 @@ public class CreateInstanceEventHandlerTest {
       .withTenant(TENANT_ID)
       .withOkapiUrl(mockServer.baseUrl())
       .withContext(context)
-      .withCurrentNode(profileSnapshotWrapperWithInvalidStatisticalCode.getChildSnapshotWrappers().getFirst());
+      .withCurrentNode(profileSnapshotWrapperWithStatisticalCode.getChildSnapshotWrappers().getFirst());
 
     CompletableFuture<DataImportEventPayload> future = createInstanceEventHandler.handle(dataImportEventPayload);
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
@@ -38,7 +38,6 @@ import org.folio.rest.jaxrs.model.MappingRule;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1423,7 +1422,10 @@ public class CreateItemEventHandlerTest {
     JsonArray errors = new JsonArray(dataImportEventPayload.getContext().get(ERRORS));
     assertEquals(1, errors.size());
     PartialError partialError = errors.getJsonObject(0).mapTo(PartialError.class);
-    assertThat(partialError.getError(), containsString("Mapped Item is invalid: [Provided Statistical code is not a valid value.]"));
+    assertThat(
+      partialError.getError(),
+      containsString("Provided Statistical code(s) are not a valid values: 'ebookss'.")
+    );
   }
 
   @Test()
@@ -1519,8 +1521,11 @@ public class CreateItemEventHandlerTest {
     JsonArray errors = new JsonArray(dataImportEventPayload.getContext().get(ERRORS));
     assertEquals(1, errors.size());
     PartialError partialError = errors.getJsonObject(0).mapTo(PartialError.class);
-    MatcherAssert.assertThat(partialError.getError(), containsString("Provided Statistical code is not a valid value."));
     assertEquals(expectedHoldingId2, partialError.getHoldingId());
+    assertThat(
+      partialError.getError(),
+      containsString("Provided Statistical code(s) are not a valid values: 'ebookss'.")
+    );
   }
 
 }

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
@@ -29,6 +29,7 @@ import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.processing.mapping.mapper.reader.Reader;
 import org.folio.processing.mapping.mapper.reader.record.marc.MarcBibReaderFactory;
+import org.folio.processing.value.ListValue;
 import org.folio.processing.value.StringValue;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.MappingDetail;
@@ -37,6 +38,7 @@ import org.folio.rest.jaxrs.model.MappingRule;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -71,6 +73,12 @@ import static org.folio.rest.jaxrs.model.EntityType.ITEM;
 import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -1357,4 +1365,162 @@ public class CreateItemEventHandlerTest {
       Assert.assertEquals(holdingsAsJson.getJsonObject(i).getString("id"), createdItem.getString("holdingId"));
     }
   }
+
+  @Test()
+  public void shouldNotCreateItemIfStatisticalCodeIdIsInvalid() {
+    MappingProfile invalidStatCodeMappingProfile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(ITEM)
+      .withMappingDetails(new MappingDetail()
+        .withMappingFields(Arrays.asList(
+          new MappingRule().withPath("item.status.name").withValue("\"statusExpression\"").withEnabled("true"),
+          new MappingRule().withPath("item.permanentLoanType.id").withValue("\"permanentLoanTypeExpression\"").withEnabled("true"),
+          new MappingRule().withPath("item.materialType.id").withValue("\"materialTypeExpression\"").withEnabled("true"),
+          new MappingRule().withName("statisticalCodeId").withPath("item.statisticalCodeIds[]").withValue("invalidStatCodeValue").withEnabled("true").withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
+        )));
+
+    ProfileSnapshotWrapper snapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(jobProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(JsonObject.mapFrom(jobProfile).getMap())
+      .withChildSnapshotWrappers(Collections.singletonList(
+        new ProfileSnapshotWrapper()
+          .withProfileId(actionProfile.getId())
+          .withContentType(ACTION_PROFILE)
+          .withContent(JsonObject.mapFrom(actionProfile).getMap())
+          .withChildSnapshotWrappers(Collections.singletonList(
+            new ProfileSnapshotWrapper()
+              .withProfileId(invalidStatCodeMappingProfile.getId())
+              .withContentType(MAPPING_PROFILE)
+              .withContent(JsonObject.mapFrom(invalidStatCodeMappingProfile).getMap())))));
+
+    // reader returns: status, permanentLoanType, materialType, then invalid statistical code ID
+    Mockito.when(fakeReader.read(any(MappingRule.class))).thenReturn(
+      StringValue.of(AVAILABLE.value()),
+      StringValue.of(UUID.randomUUID().toString()),
+      StringValue.of(UUID.randomUUID().toString()),
+      ListValue.of(List.of("ebookss")));
+
+    JsonArray holdingsAsJson = new JsonArray(List.of(
+      new JsonObject().put("id", UUID.randomUUID().toString()).put("permanentLocationId", PERMANENT_LOCATION_ID)));
+
+    HashMap<String, String> payloadContext = new HashMap<>();
+    Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITHOUT_HOLDING_ID));
+    payloadContext.put(EntityType.MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
+    payloadContext.put(EntityType.HOLDINGS.value(), holdingsAsJson.encode());
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(payloadContext)
+      .withCurrentNode(snapshotWrapper.getChildSnapshotWrappers().getFirst());
+
+    CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
+
+    assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
+    JsonArray errors = new JsonArray(dataImportEventPayload.getContext().get(ERRORS));
+    assertEquals(1, errors.size());
+    PartialError partialError = errors.getJsonObject(0).mapTo(PartialError.class);
+    assertThat(partialError.getError(), containsString("Mapped Item is invalid: [Provided Statistical code is not a valid value.]"));
+  }
+
+  @Test()
+  public void shouldCreateMultipleItemsAndReturnPartialErrorsForItemWithInvalidStatisticalCode()
+    throws ExecutionException, InterruptedException, TimeoutException {
+    MappingProfile invalidStatCodeMappingProfile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(ITEM)
+      .withMappingDetails(new MappingDetail()
+        .withMappingFields(Arrays.asList(
+          new MappingRule().withPath("item.status.name").withValue("\"statusExpression\"").withEnabled("true"),
+          new MappingRule().withPath("item.permanentLoanType.id").withValue("\"permanentLoanTypeExpression\"").withEnabled("true"),
+          new MappingRule().withPath("item.materialType.id").withValue("\"materialTypeExpression\"").withEnabled("true"),
+          new MappingRule().withName("statisticalCodeId").withPath("item.statisticalCodeIds[]").withValue("invalidStatCodeValue").withEnabled("true").withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
+        )));
+
+    ProfileSnapshotWrapper snapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(jobProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(JsonObject.mapFrom(jobProfile).getMap())
+      .withChildSnapshotWrappers(Collections.singletonList(
+        new ProfileSnapshotWrapper()
+          .withProfileId(actionProfile.getId())
+          .withContentType(ACTION_PROFILE)
+          .withContent(JsonObject.mapFrom(actionProfile).getMap())
+          .withChildSnapshotWrappers(Collections.singletonList(
+            new ProfileSnapshotWrapper()
+              .withProfileId(invalidStatCodeMappingProfile.getId())
+              .withContentType(MAPPING_PROFILE)
+              .withContent(JsonObject.mapFrom(invalidStatCodeMappingProfile).getMap())))));
+
+    String validStatisticalCodeUuid = UUID.randomUUID().toString();
+
+    Mockito.when(fakeReader.read(any(MappingRule.class))).thenReturn(
+      StringValue.of(AVAILABLE.value()),
+      StringValue.of(UUID.randomUUID().toString()),
+      StringValue.of(UUID.randomUUID().toString()),
+      ListValue.of(List.of(validStatisticalCodeUuid)),
+      StringValue.of(AVAILABLE.value()),
+      StringValue.of(UUID.randomUUID().toString()),
+      StringValue.of(UUID.randomUUID().toString()),
+    // reader returns the invalid statistical code
+      ListValue.of(List.of("ebookss"))
+    );
+
+    Mockito.doAnswer(invocationOnMock -> {
+      Item item = invocationOnMock.getArgument(0);
+      Consumer<Success<Item>> successHandler = invocationOnMock.getArgument(1);
+      successHandler.accept(new Success<>(item));
+      return null;
+    }).when(mockedItemCollection).add(any(), any(Consumer.class), any(Consumer.class));
+
+    String expectedHoldingId1 = UUID.randomUUID().toString();
+    String expectedHoldingId2 = UUID.randomUUID().toString();
+    String permanentLocationId2 = UUID.randomUUID().toString();
+
+    JsonArray holdingsAsJson = new JsonArray(List.of(
+      new JsonObject()
+        .put("id", expectedHoldingId1)
+        .put("permanentLocationId", PERMANENT_LOCATION_ID),
+      new JsonObject()
+        .put("id", expectedHoldingId2)
+        .put("permanentLocationId", permanentLocationId2)));
+
+    HashMap<String, String> payloadContext = new HashMap<>();
+    Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_HOLDING_ID));
+    payloadContext.put(EntityType.MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
+    payloadContext.put(EntityType.HOLDINGS.value(), holdingsAsJson.encode());
+    payloadContext.put(MULTIPLE_HOLDINGS_FIELD, "945");
+    payloadContext.put(HOLDINGS_IDENTIFIERS, Json.encode(List.of(PERMANENT_LOCATION_ID, permanentLocationId2)));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(payloadContext)
+      .withCurrentNode(snapshotWrapper.getChildSnapshotWrappers().getFirst());
+
+    CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
+
+    DataImportEventPayload eventPayload = future.get(5, TimeUnit.SECONDS);
+    assertNotNull(eventPayload.getContext().get(ITEM.value()));
+    JsonArray createdItems = new JsonArray(eventPayload.getContext().get(ITEM.value()));
+    assertEquals(1, createdItems.size());
+    JsonObject createdItem = createdItems.getJsonObject(0);
+    assertNotNull(createdItem.getJsonObject("status").getString("name"));
+    assertNotNull(createdItem.getString("permanentLoanTypeId"));
+    assertNotNull(createdItem.getString("materialTypeId"));
+    assertEquals(holdingsAsJson.getJsonObject(0).getString("id"), createdItem.getString("holdingId"));
+    assertTrue(createdItem.getJsonArray("statisticalCodeIds").contains(validStatisticalCodeUuid));
+
+    JsonArray errors = new JsonArray(dataImportEventPayload.getContext().get(ERRORS));
+    assertEquals(1, errors.size());
+    PartialError partialError = errors.getJsonObject(0).mapTo(PartialError.class);
+    MatcherAssert.assertThat(partialError.getError(), containsString("Provided Statistical code is not a valid value."));
+    assertEquals(expectedHoldingId2, partialError.getHoldingId());
+  }
+
 }

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/CreateItemEventHandlerTest.java
@@ -219,7 +219,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -287,7 +287,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -366,7 +366,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -445,7 +445,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -514,7 +514,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -564,7 +564,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -611,7 +611,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -681,7 +681,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -738,7 +738,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -793,7 +793,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -857,7 +857,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -911,7 +911,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -974,7 +974,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -1044,6 +1044,7 @@ public class CreateItemEventHandlerTest {
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
     DataImportEventPayload eventPayload = future.get(5, TimeUnit.SECONDS);
+
     // then
     verify(mockedItemCollection, Mockito.times(0))
       .findByCql(anyString(), any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
@@ -1059,7 +1060,7 @@ public class CreateItemEventHandlerTest {
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withContext(new HashMap<>())
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -1083,7 +1084,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -1119,7 +1120,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -1147,13 +1148,13 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
 
     // then
-    DataImportEventPayload eventPayload = future.get(5, TimeUnit.SECONDS);
+    future.get(5, TimeUnit.SECONDS);
   }
 
   @Rule
@@ -1187,7 +1188,7 @@ public class CreateItemEventHandlerTest {
     // given
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     boolean isEligible = createItemHandler.isEligible(dataImportEventPayload);
@@ -1237,7 +1238,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -1289,7 +1290,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);
@@ -1342,7 +1343,7 @@ public class CreateItemEventHandlerTest {
       .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = createItemHandler.handle(dataImportEventPayload);

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
@@ -309,18 +309,7 @@ public class ReplaceInstanceEventHandlerTest {
             .withContentType(MAPPING_PROFILE)
             .withContent(JsonObject.mapFrom(mappingProfileWithNatureOfContentTerm).getMap())))));
 
-  private JobProfile jobProfileWithInvalidStatisticalCode = new JobProfile()
-    .withId(UUID.randomUUID().toString())
-    .withName("Create MARC Bibs with invalid StatisticalCode")
-    .withDataType(JobProfile.DataType.MARC);
-
-  private ActionProfile actionProfileWithInvalidStatisticalCode = new ActionProfile()
-    .withId(UUID.randomUUID().toString())
-    .withName("Replace preliminary Item with invalid StatisticalCode")
-    .withAction(ActionProfile.Action.UPDATE)
-    .withFolioRecord(INSTANCE);
-
-  private MappingProfile mappingProfileWithInvalidStatisticalCode = new MappingProfile()
+  private MappingProfile mappingProfileWithStatisticalCode = new MappingProfile()
     .withId(UUID.randomUUID().toString())
     .withName("Prelim item from MARC with invalid StatisticalCode")
     .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
@@ -332,21 +321,21 @@ public class ReplaceInstanceEventHandlerTest {
         new MappingRule().withPath("instance.statisticalCodeIds[]").withValue("\"ebookss\"").withEnabled("true")
           .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING))));
 
-  private ProfileSnapshotWrapper profileSnapshotWrapperWithInvalidStatisticalCode = new ProfileSnapshotWrapper()
+  private ProfileSnapshotWrapper profileSnapshotWrapperWithStatisticalCode = new ProfileSnapshotWrapper()
     .withId(UUID.randomUUID().toString())
-    .withProfileId(jobProfileWithInvalidStatisticalCode.getId())
+    .withProfileId(jobProfile.getId())
     .withContentType(JOB_PROFILE)
-    .withContent(jobProfileWithInvalidStatisticalCode)
+    .withContent(jobProfile)
     .withChildSnapshotWrappers(Collections.singletonList(
       new ProfileSnapshotWrapper()
-        .withProfileId(actionProfileWithInvalidStatisticalCode.getId())
+        .withProfileId(actionProfile.getId())
         .withContentType(ACTION_PROFILE)
-        .withContent(actionProfileWithInvalidStatisticalCode)
+        .withContent(actionProfile)
         .withChildSnapshotWrappers(Collections.singletonList(
           new ProfileSnapshotWrapper()
-            .withProfileId(mappingProfileWithInvalidStatisticalCode.getId())
+            .withProfileId(mappingProfileWithStatisticalCode.getId())
             .withContentType(MAPPING_PROFILE)
-            .withContent(JsonObject.mapFrom(mappingProfileWithInvalidStatisticalCode).getMap())))));
+            .withContent(JsonObject.mapFrom(mappingProfileWithStatisticalCode).getMap())))));
 
   private ReplaceInstanceEventHandler replaceInstanceEventHandler;
   private PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper;
@@ -1368,7 +1357,7 @@ public class ReplaceInstanceEventHandlerTest {
       .withOkapiUrl(mockServer.baseUrl())
       .withToken(TOKEN)
       .withContext(context)
-      .withCurrentNode(profileSnapshotWrapperWithInvalidStatisticalCode.getChildSnapshotWrappers().getFirst());
+      .withCurrentNode(profileSnapshotWrapperWithStatisticalCode.getChildSnapshotWrappers().getFirst());
 
     CompletableFuture<DataImportEventPayload> future = replaceInstanceEventHandler.handle(dataImportEventPayload);
 

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
@@ -1373,7 +1373,7 @@ public class ReplaceInstanceEventHandlerTest {
     CompletableFuture<DataImportEventPayload> future = replaceInstanceEventHandler.handle(dataImportEventPayload);
 
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
-    assertThat(exception.getMessage(), containsString("Mapped Instance is invalid: [Provided Statistical code is not a valid value.]"));
+    assertThat(exception.getMessage(), containsString("Provided Statistical code(s) are not a valid values: 'ebookss'."));
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/ReplaceInstanceEventHandlerTest.java
@@ -309,6 +309,45 @@ public class ReplaceInstanceEventHandlerTest {
             .withContentType(MAPPING_PROFILE)
             .withContent(JsonObject.mapFrom(mappingProfileWithNatureOfContentTerm).getMap())))));
 
+  private JobProfile jobProfileWithInvalidStatisticalCode = new JobProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Create MARC Bibs with invalid StatisticalCode")
+    .withDataType(JobProfile.DataType.MARC);
+
+  private ActionProfile actionProfileWithInvalidStatisticalCode = new ActionProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Replace preliminary Item with invalid StatisticalCode")
+    .withAction(ActionProfile.Action.UPDATE)
+    .withFolioRecord(INSTANCE);
+
+  private MappingProfile mappingProfileWithInvalidStatisticalCode = new MappingProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Prelim item from MARC with invalid StatisticalCode")
+    .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+    .withExistingRecordType(EntityType.INSTANCE)
+    .withMappingDetails(new MappingDetail()
+      .withMappingFields(Lists.newArrayList(
+        new MappingRule().withPath("instance.instanceTypeId").withValue("\"instanceTypeIdExpression\"").withEnabled("true"),
+        new MappingRule().withPath("instance.title").withValue("\"titleExpression\"").withEnabled("true"),
+        new MappingRule().withPath("instance.statisticalCodeIds[]").withValue("\"ebookss\"").withEnabled("true")
+          .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING))));
+
+  private ProfileSnapshotWrapper profileSnapshotWrapperWithInvalidStatisticalCode = new ProfileSnapshotWrapper()
+    .withId(UUID.randomUUID().toString())
+    .withProfileId(jobProfileWithInvalidStatisticalCode.getId())
+    .withContentType(JOB_PROFILE)
+    .withContent(jobProfileWithInvalidStatisticalCode)
+    .withChildSnapshotWrappers(Collections.singletonList(
+      new ProfileSnapshotWrapper()
+        .withProfileId(actionProfileWithInvalidStatisticalCode.getId())
+        .withContentType(ACTION_PROFILE)
+        .withContent(actionProfileWithInvalidStatisticalCode)
+        .withChildSnapshotWrappers(Collections.singletonList(
+          new ProfileSnapshotWrapper()
+            .withProfileId(mappingProfileWithInvalidStatisticalCode.getId())
+            .withContentType(MAPPING_PROFILE)
+            .withContent(JsonObject.mapFrom(mappingProfileWithInvalidStatisticalCode).getMap())))));
+
   private ReplaceInstanceEventHandler replaceInstanceEventHandler;
   private PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper;
 
@@ -1293,6 +1332,49 @@ public class ReplaceInstanceEventHandlerTest {
     future.get(10, TimeUnit.SECONDS);
   }
 
+  @Test()
+  public void shouldNotUpdatedInstanceIfStatisticalCodeIdIsInvalid() {
+    String instanceTypeId = UUID.randomUUID().toString();
+    String title = "titleValue";
+    Reader fakeReader = Mockito.mock(Reader.class);
+    mockInstance(MARC_INSTANCE_SOURCE);
+
+    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+    when(storage.getInstanceCollection(any())).thenReturn(instanceRecordCollection);
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(
+      StringValue.of(instanceTypeId),
+      StringValue.of(title),
+      ListValue.of(Lists.newArrayList("ebookss"))
+    );
+
+    MappingManager.registerReaderFactory(fakeReaderFactory);
+    MappingManager.registerWriterFactory(new InstanceWriterFactory());
+
+    HashMap<String, String> context = new HashMap<>();
+    Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
+    context.put(INSTANCE.value(), new JsonObject()
+      .put("id", instanceId)
+      .put("hrid", UUID.randomUUID().toString())
+      .put("source", MARC_INSTANCE_SOURCE)
+      .put("_version", INSTANCE_VERSION)
+      .put("discoverySuppress", false)
+      .encode());
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_INSTANCE_CREATED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withTenant(TENANT_ID)
+      .withOkapiUrl(mockServer.baseUrl())
+      .withToken(TOKEN)
+      .withContext(context)
+      .withCurrentNode(profileSnapshotWrapperWithInvalidStatisticalCode.getChildSnapshotWrappers().getFirst());
+
+    CompletableFuture<DataImportEventPayload> future = replaceInstanceEventHandler.handle(dataImportEventPayload);
+
+    ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
+    assertThat(exception.getMessage(), containsString("Mapped Instance is invalid: [Provided Statistical code is not a valid value.]"));
+  }
 
   @Test
   public void shouldReturnFailedFutureIfCurrentActionProfileHasNoMappingProfile() {

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -1233,7 +1233,6 @@ public class UpdateHoldingEventHandlerTest {
     MappingManager.registerWriterFactory(new HoldingWriterFactory());
     MappingManager.registerMapperFactory(new HoldingsMapperFactory());
 
-    String instanceId = UUID.randomUUID().toString();
     String firstId = UUID.randomUUID().toString();
     String secondId = UUID.randomUUID().toString();
     String firstHrid = UUID.randomUUID().toString();
@@ -1478,7 +1477,6 @@ public class UpdateHoldingEventHandlerTest {
     // given
     MappingProfile invalidStatCodeMappingProfile = new MappingProfile()
       .withId(UUID.randomUUID().toString())
-      .withName("Mapping with invalid statistical code")
       .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
       .withExistingRecordType(EntityType.HOLDINGS)
       .withMappingDetails(new MappingDetail()

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -1527,10 +1527,11 @@ public class UpdateHoldingEventHandlerTest {
     JsonArray holdingsList = new JsonArray();
     holdingsList.add(new JsonObject().put("holdings", JsonObject.mapFrom(holdingsRecord)));
 
-    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    Record incomingRecord = new Record()
+      .withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
     HashMap<String, String> context = new HashMap<>();
     context.put(HOLDINGS.value(), Json.encode(holdingsList));
-    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_MARC_FOR_UPDATE_RECEIVED.value())
@@ -1544,7 +1545,10 @@ public class UpdateHoldingEventHandlerTest {
 
     // then
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
-    assertThat(exception.getMessage(), containsString("Provided Statistical code is not a valid value."));
+    assertThat(
+      exception.getMessage(),
+      containsString("Provided Statistical code(s) are not a valid values: 'ebookss'.")
+    );
   }
 
   @Test
@@ -1638,10 +1642,10 @@ public class UpdateHoldingEventHandlerTest {
 
     JsonArray errors = new JsonArray(actualEventPayload.getContext().get(ERRORS));
     assertEquals(1, errors.size());
-    JsonObject partialError = errors.getJsonObject(0);
+    PartialError partialError = errors.getJsonObject(0).mapTo(PartialError.class);
     assertThat(
-      partialError.getString("error"),
-      containsString("Provided Statistical code is not a valid value.")
+      partialError.getError(),
+      containsString("Provided Statistical code(s) are not a valid values: 'ebookss'.")
     );
   }
 

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateHoldingEventHandlerTest.java
@@ -7,6 +7,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
+import org.folio.processing.value.ListValue;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.JobProfile;
 import org.folio.MappingMetadataDto;
@@ -64,19 +65,23 @@ import static org.folio.ActionProfile.FolioRecord.ITEM;
 import static org.folio.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_MATCHED;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_HOLDING_UPDATED;
+import static org.folio.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.folio.inventory.dataimport.handlers.actions.UpdateHoldingEventHandler.ACTION_HAS_NO_MAPPING_MSG;
 import static org.folio.inventory.dataimport.handlers.actions.UpdateHoldingEventHandler.CURRENT_RETRY_NUMBER;
 import static org.folio.inventory.domain.items.ItemStatusName.AVAILABLE;
 import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -1466,6 +1471,178 @@ public class UpdateHoldingEventHandlerTest {
       .withContext(new HashMap<>())
       .withCurrentNode(profileSnapshotWrapper);
     assertFalse(updateHoldingEventHandler.isEligible(dataImportEventPayload));
+  }
+
+  @Test()
+  public void shouldNotUpdateHoldingIfStatisticalCodeIdIsInvalid() {
+    // given
+    MappingProfile invalidStatCodeMappingProfile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Mapping with invalid statistical code")
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(EntityType.HOLDINGS)
+      .withMappingDetails(new MappingDetail()
+        .withMappingFields(Lists.newArrayList(
+          new MappingRule().withName("permanentLocationId").withPath("holdings.permanentLocationId").withValue("KU/CC/DI/M").withEnabled("true"),
+          new MappingRule().withName("statisticalCodeId").withPath("holdings.statisticalCodeIds[]").withValue("990$a").withEnabled("true")
+            .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING))));
+
+    ProfileSnapshotWrapper snapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(jobProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(jobProfile)
+      .withChildSnapshotWrappers(Collections.singletonList(
+        new ProfileSnapshotWrapper()
+          .withProfileId(actionProfile.getId())
+          .withContentType(ACTION_PROFILE)
+          .withContent(actionProfile)
+          .withChildSnapshotWrappers(Collections.singletonList(
+            new ProfileSnapshotWrapper()
+              .withProfileId(invalidStatCodeMappingProfile.getId())
+              .withContentType(MAPPING_PROFILE)
+              .withContent(JsonObject.mapFrom(invalidStatCodeMappingProfile).getMap())))));
+
+    Reader fakeReader = Mockito.mock(Reader.class);
+    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    // reader returns: invalid statistical code string
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(
+      StringValue.of(permanentLocationId),
+      ListValue.of(List.of("ebookss"))
+    );
+
+    MappingManager.registerReaderFactory(fakeReaderFactory);
+    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
+
+    String instanceId = UUID.randomUUID().toString();
+    String holdingId = UUID.randomUUID().toString();
+    HoldingsRecord holdingsRecord = new HoldingsRecord()
+      .withId(holdingId)
+      .withHrid("ho001")
+      .withInstanceId(instanceId)
+      .withPermanentLocationId(permanentLocationId);
+
+    JsonArray holdingsList = new JsonArray();
+    holdingsList.add(new JsonObject().put("holdings", JsonObject.mapFrom(holdingsRecord)));
+
+    Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), Json.encode(holdingsList));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_MARC_FOR_UPDATE_RECEIVED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(context)
+      .withProfileSnapshot(snapshotWrapper)
+      .withCurrentNode(snapshotWrapper.getChildSnapshotWrappers().getFirst());
+
+    // when
+    CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
+
+    // then
+    ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
+    assertThat(exception.getMessage(), containsString("Provided Statistical code is not a valid value."));
+  }
+
+  @Test
+  public void shouldUpdateMultipleHoldingsWithPartialErrorIfOneHoldingHasInvalidStatisticalCode() throws InterruptedException, ExecutionException, TimeoutException {
+    MappingProfile invalidStatCodeMappingProfile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(EntityType.HOLDINGS)
+      .withMappingDetails(new MappingDetail()
+        .withMappingFields(Lists.newArrayList(
+          new MappingRule().withName("permanentLocationId").withPath("holdings.permanentLocationId").withValue("945$h").withEnabled("true"),
+          new MappingRule().withName("statisticalCodeId").withPath("holdings.statisticalCodeIds[]").withValue("990$a").withEnabled("true")
+            .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING))));
+
+    ProfileSnapshotWrapper snapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(jobProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(jobProfile)
+      .withChildSnapshotWrappers(Collections.singletonList(
+        new ProfileSnapshotWrapper()
+          .withProfileId(actionProfile.getId())
+          .withContentType(ACTION_PROFILE)
+          .withContent(actionProfile)
+          .withChildSnapshotWrappers(Collections.singletonList(
+            new ProfileSnapshotWrapper()
+              .withProfileId(invalidStatCodeMappingProfile.getId())
+              .withContentType(MAPPING_PROFILE)
+              .withContent(JsonObject.mapFrom(invalidStatCodeMappingProfile).getMap())))));
+
+    String firstPermanentLocationId = UUID.randomUUID().toString();
+    String secondPermanentLocationId = UUID.randomUUID().toString();
+    String validStatisticalCodeUuid = UUID.randomUUID().toString();
+
+    Reader fakeReader = Mockito.mock(Reader.class);
+    when(fakeReader.read(any(MappingRule.class))).thenReturn(
+      StringValue.of(firstPermanentLocationId),
+      ListValue.of(List.of(validStatisticalCodeUuid)),
+      StringValue.of(secondPermanentLocationId),
+      ListValue.of(List.of("ebookss"))
+    );
+
+    when(fakeReaderFactory.createReader()).thenReturn(fakeReader);
+    when(storage.getHoldingsRecordCollection(any())).thenReturn(holdingsRecordsCollection);
+    when(storage.getItemCollection(any())).thenReturn(itemCollection);
+
+    MappingManager.registerReaderFactory(fakeReaderFactory);
+    MappingManager.registerWriterFactory(new HoldingWriterFactory());
+    MappingManager.registerMapperFactory(new HoldingsMapperFactory());
+
+    String instanceId = UUID.randomUUID().toString();
+    HoldingsRecord firstHoldingsRecord = new HoldingsRecord()
+      .withId(UUID.randomUUID().toString())
+      .withInstanceId(instanceId)
+      .withHrid("ho001")
+      .withPermanentLocationId(permanentLocationId);
+
+    HoldingsRecord secondHoldingsRecord = new HoldingsRecord()
+      .withId(UUID.randomUUID().toString())
+      .withInstanceId(instanceId)
+      .withHrid("ho002")
+      .withPermanentLocationId(permanentLocationId);
+
+    JsonArray holdingsList = new JsonArray();
+    holdingsList.add(new JsonObject().put("holdings", firstHoldingsRecord));
+    holdingsList.add(new JsonObject().put("holdings", secondHoldingsRecord));
+
+    Record incomingRecord = new Record()
+      .withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_INSTANCE_ID_AND_MULTIPLE_HOLDINGS));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), Json.encode(holdingsList));
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_MARC_FOR_UPDATE_RECEIVED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(context)
+      .withProfileSnapshot(snapshotWrapper)
+      .withCurrentNode(snapshotWrapper.getChildSnapshotWrappers().getFirst());
+
+    CompletableFuture<DataImportEventPayload> future = updateHoldingEventHandler.handle(dataImportEventPayload);
+
+    DataImportEventPayload actualEventPayload = future.get(5, TimeUnit.MILLISECONDS);
+    assertNotNull(actualEventPayload.getContext().get(HOLDINGS.value()));
+    JsonArray resultedHoldingsList = new JsonArray(actualEventPayload.getContext().get(HOLDINGS.value()));
+    assertEquals(1, resultedHoldingsList.size());
+    HoldingsRecord firstResultedHolding = resultedHoldingsList.getJsonObject(0).mapTo(HoldingsRecord.class);
+    assertEquals(firstHoldingsRecord.getId(), firstResultedHolding.getId());
+    assertTrue(firstResultedHolding.getStatisticalCodeIds().contains(validStatisticalCodeUuid));
+    assertEquals(firstPermanentLocationId, firstResultedHolding.getPermanentLocationId());
+
+    JsonArray errors = new JsonArray(actualEventPayload.getContext().get(ERRORS));
+    assertEquals(1, errors.size());
+    JsonObject partialError = errors.getJsonObject(0);
+    assertThat(
+      partialError.getString("error"),
+      containsString("Provided Statistical code is not a valid value.")
+    );
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandlerTest.java
@@ -1410,7 +1410,10 @@ public class UpdateItemEventHandlerTest {
 
     // then
     ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
-    assertThat(exception.getMessage(), containsString("Mapped Item is invalid: [Provided Statistical code is not a valid value.]"));
+    assertThat(
+      exception.getMessage(),
+      containsString("Provided Statistical code(s) are not a valid values: 'ebookss'.")
+    );
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandlerTest.java
@@ -264,7 +264,7 @@ public class UpdateItemEventHandlerTest {
       .withEventType(DI_INVENTORY_ITEM_MATCHED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = updateItemHandler.handle(dataImportEventPayload);
@@ -338,7 +338,7 @@ public class UpdateItemEventHandlerTest {
       .withEventType(DI_INVENTORY_ITEM_MATCHED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = updateItemHandler.handle(dataImportEventPayload);
@@ -414,7 +414,7 @@ public class UpdateItemEventHandlerTest {
       .withEventType(DI_INVENTORY_ITEM_MATCHED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = updateItemHandler.handle(dataImportEventPayload);
@@ -551,7 +551,7 @@ public class UpdateItemEventHandlerTest {
     // Provide behavior for the items
     doAnswer(invocationOnMock -> {
       Consumer<Failure> failureHandler = invocationOnMock.getArgument(2);
-      failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemIds.get(0)), 409));
+      failureHandler.accept(new Failure(format("Cannot update record %s it has been changed (optimistic locking): Stored _version is 2, _version of request is 1", itemIds.getFirst()), 409));
       return null;
     }).doAnswer(invocationOnMock -> {
         Item itemRecord = invocationOnMock.getArgument(0);
@@ -653,7 +653,7 @@ public class UpdateItemEventHandlerTest {
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(context)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     CompletableFuture<DataImportEventPayload> future = updateItemHandler.handle(dataImportEventPayload);
     DataImportEventPayload actualDataImportEventPayload = future.get(5, TimeUnit.MILLISECONDS);
@@ -703,7 +703,7 @@ public class UpdateItemEventHandlerTest {
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(contextSecondRun)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
 
     doAnswer(invocationOnMock -> {
@@ -1003,7 +1003,7 @@ public class UpdateItemEventHandlerTest {
       .withEventType(DI_INVENTORY_ITEM_MATCHED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = updateItemHandler.handle(dataImportEventPayload);
@@ -1076,7 +1076,7 @@ public class UpdateItemEventHandlerTest {
       .withEventType(DI_INVENTORY_ITEM_MATCHED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = updateItemHandler.handle(dataImportEventPayload);
@@ -1199,7 +1199,7 @@ public class UpdateItemEventHandlerTest {
       .withEventType(DI_INVENTORY_ITEM_MATCHED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = updateItemHandler.handle(dataImportEventPayload);
@@ -1219,7 +1219,7 @@ public class UpdateItemEventHandlerTest {
       .withEventType(DI_INVENTORY_ITEM_MATCHED.value())
       .withContext(payloadContext)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = updateItemHandler.handle(dataImportEventPayload);
@@ -1291,7 +1291,7 @@ public class UpdateItemEventHandlerTest {
       .withEventType(DI_INVENTORY_ITEM_MATCHED.value())
       .withJobExecutionId(UUID.randomUUID().toString())
       .withContext(payloadContext)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = updateItemHandler.handle(dataImportEventPayload);
@@ -1356,7 +1356,7 @@ public class UpdateItemEventHandlerTest {
   @Test
   public void shouldReturnFailedFutureAndNotUpdateItemIfStatisticalCodeIdIsInvalid() {
     // given
-    MappingProfile invalidStatCodeMappingProfile = new MappingProfile()
+    MappingProfile statCodeMappingProfile = new MappingProfile()
       .withId(UUID.randomUUID().toString())
       .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
       .withExistingRecordType(ITEM)
@@ -1377,9 +1377,9 @@ public class UpdateItemEventHandlerTest {
           .withContent(JsonObject.mapFrom(actionProfile).getMap())
           .withChildSnapshotWrappers(Collections.singletonList(
             new ProfileSnapshotWrapper()
-              .withProfileId(invalidStatCodeMappingProfile.getId())
+              .withProfileId(statCodeMappingProfile.getId())
               .withContentType(MAPPING_PROFILE)
-              .withContent(JsonObject.mapFrom(invalidStatCodeMappingProfile).getMap())))));
+              .withContent(JsonObject.mapFrom(statCodeMappingProfile).getMap())))));
 
     // reader returns invalid statistical code ID value
     when(fakeReader.read(any(MappingRule.class)))
@@ -1421,7 +1421,7 @@ public class UpdateItemEventHandlerTest {
     // given
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_INVENTORY_ITEM_MATCHED.value())
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     boolean isEligible = updateItemHandler.isEligible(dataImportEventPayload);

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/UpdateItemEventHandlerTest.java
@@ -9,6 +9,7 @@ import junitparams.Parameters;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
 import org.folio.DataImportEventTypes;
+import org.folio.processing.value.ListValue;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.JobProfile;
 import org.folio.MappingMetadataDto;
@@ -71,7 +72,6 @@ import static org.folio.DataImportEventTypes.DI_INVENTORY_ITEM_MATCHED;
 import static org.folio.DataImportEventTypes.DI_INVENTORY_ITEM_UPDATED;
 import static org.folio.DataImportEventTypes.DI_INCOMING_MARC_BIB_RECORD_PARSED;
 import static org.folio.inventory.dataimport.handlers.actions.UpdateItemEventHandler.ACTION_HAS_NO_MAPPING_MSG;
-import static org.folio.inventory.dataimport.handlers.actions.UpdateItemEventHandler.CURRENT_RETRY_NUMBER;
 import static org.folio.inventory.domain.items.Item.HRID_KEY;
 import static org.folio.inventory.domain.items.Item.STATUS_KEY;
 import static org.folio.inventory.domain.items.ItemStatusName.AVAILABLE;
@@ -83,7 +83,10 @@ import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -1348,6 +1351,66 @@ public class UpdateItemEventHandlerTest {
     // then
     ExecutionException exception = Assert.assertThrows(ExecutionException.class, future::get);
     Assert.assertEquals(ACTION_HAS_NO_MAPPING_MSG, exception.getCause().getMessage());
+  }
+
+  @Test
+  public void shouldReturnFailedFutureAndNotUpdateItemIfStatisticalCodeIdIsInvalid() {
+    // given
+    MappingProfile invalidStatCodeMappingProfile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(ITEM)
+      .withMappingDetails(new MappingDetail()
+        .withMappingFields(Collections.singletonList(
+          new MappingRule().withName("statisticalCodeId").withPath("item.statisticalCodeIds[]").withValue("990$a").withEnabled("true")
+            .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING))));
+
+    ProfileSnapshotWrapper snapshotWrapper = new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withProfileId(jobProfile.getId())
+      .withContentType(JOB_PROFILE)
+      .withContent(JsonObject.mapFrom(jobProfile).getMap())
+      .withChildSnapshotWrappers(Collections.singletonList(
+        new ProfileSnapshotWrapper()
+          .withProfileId(actionProfile.getId())
+          .withContentType(ACTION_PROFILE)
+          .withContent(JsonObject.mapFrom(actionProfile).getMap())
+          .withChildSnapshotWrappers(Collections.singletonList(
+            new ProfileSnapshotWrapper()
+              .withProfileId(invalidStatCodeMappingProfile.getId())
+              .withContentType(MAPPING_PROFILE)
+              .withContent(JsonObject.mapFrom(invalidStatCodeMappingProfile).getMap())))));
+
+    // reader returns invalid statistical code ID value
+    when(fakeReader.read(any(MappingRule.class)))
+      .thenReturn(ListValue.of(List.of("ebookss")));
+
+    JsonObject itemJson = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("status", new JsonObject().put("name", AVAILABLE.value()))
+      .put("materialType", new JsonObject().put("id", UUID.randomUUID().toString()))
+      .put("permanentLoanType", new JsonObject().put("id", UUID.randomUUID().toString()))
+      .put("holdingsRecordId", UUID.randomUUID().toString());
+
+    JsonArray itemsList = new JsonArray();
+    itemsList.add(new JsonObject().put("item", itemJson));
+
+    HashMap<String, String> payloadContext = new HashMap<>();
+    payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_WITH_HOLDING_ID))));
+    payloadContext.put(ITEM.value(), itemsList.encode());
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INVENTORY_ITEM_MATCHED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(payloadContext)
+      .withCurrentNode(snapshotWrapper.getChildSnapshotWrappers().getFirst());
+
+    // when
+    CompletableFuture<DataImportEventPayload> future = updateItemHandler.handle(dataImportEventPayload);
+
+    // then
+    ExecutionException exception = assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
+    assertThat(exception.getMessage(), containsString("Mapped Item is invalid: [Provided Statistical code is not a valid value.]"));
   }
 
   @Test

--- a/src/test/java/org/folio/inventory/dataimport/util/ValidationUtilTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/util/ValidationUtilTest.java
@@ -7,11 +7,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 @RunWith(BlockJUnit4ClassRunner.class)
 public class ValidationUtilTest {
+
+  private static final String INVALID_STATISTICAL_CODE_MSG = "Provided Statistical code(s) are not a valid values: ";
 
   @Test
   public void shouldHaveNoErrorIfNatureAreAsUUID() {
@@ -30,5 +33,47 @@ public class ValidationUtilTest {
     Assert.assertEquals("Value 'not uuid value' is not a UUID for natureOfContentTermIds field", errors.get(0));
     Assert.assertEquals("Value 'second not UUID value' is not a UUID for natureOfContentTermIds field", errors.get(1));
 
+  }
+
+  @Test
+  public void shouldHaveNoErrorIfStatisticalCodeIdsAreAllUUIDs() {
+    Instance instance = new Instance(UUID.randomUUID().toString(), 1, "in001", "MARC", "Title", UUID.randomUUID().toString());
+    instance.setStatisticalCodeIds(List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+    List<String> errors = ValidationUtil.validateUUIDs(instance);
+    Assert.assertEquals(0, errors.size());
+  }
+
+  @Test
+  public void shouldHaveErrorIfAllStatisticalCodeIdsInInstanceAreNotUUIDs() {
+    Instance instance = new Instance(UUID.randomUUID().toString(), 1, "in001", "MARC", "Title", UUID.randomUUID().toString());
+    instance.setStatisticalCodeIds(Arrays.asList("ebookss", UUID.randomUUID().toString(), "another-invalid"));
+    List<String> errors = ValidationUtil.validateUUIDs(instance);
+    Assert.assertEquals(1, errors.size());
+    Assert.assertTrue(errors.getFirst().startsWith(INVALID_STATISTICAL_CODE_MSG));
+    Assert.assertTrue(errors.getFirst().contains("'ebookss'"));
+    Assert.assertTrue(errors.getFirst().contains("'another-invalid'"));
+  }
+
+  @Test
+  public void shouldHaveNoErrorIfStatisticalCodeIdsAreEmpty() {
+    List<String> errors = ValidationUtil.validateStatisticalCodeIds(Collections.emptyList());
+    Assert.assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  public void shouldReturnOneErrorForAllInvalidStatisticalCodeIds() {
+    List<String> errors = ValidationUtil.validateStatisticalCodeIds(
+      Arrays.asList("invalid-code1", UUID.randomUUID().toString(), "invalid-code2"));
+    Assert.assertEquals(1, errors.size());
+    Assert.assertTrue(errors.getFirst().startsWith(INVALID_STATISTICAL_CODE_MSG));
+    Assert.assertTrue(errors.getFirst().contains("'invalid-code1'"));
+    Assert.assertTrue(errors.getFirst().contains("'invalid-code2'"));
+  }
+
+  @Test
+  public void shouldReturnNoErrorWhenAllStatisticalCodeIdsAreValidUUIDs() {
+    List<String> errors =
+      ValidationUtil.validateStatisticalCodeIds(List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+    Assert.assertTrue(errors.isEmpty());
   }
 }


### PR DESCRIPTION
## Purpose
when the mapping for the statisticalCodesIds field is set to map based on a value from a MARC field, and if the value from the MARC field does not match any existing statistical codes, then the statistical code property is added to the entity (instance, holdings, or item) with the incoming invalid value and is displayed as empty on the UI.

## Approach
* apply statistical codes IDs field validation during processing records import for instance, holdings, items creation/update
* add tests


## Learning
[MODINV-1391](https://issues.folio.org/browse/MODINV-1391)