### PR TITLE
MODINV-1389: Populate location code in MARC Holdings during update ow…

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtil.java
+++ b/src/main/java/org/folio/inventory/dataimport/util/AdditionalFieldsUtil.java
@@ -371,6 +371,36 @@ public final class AdditionalFieldsUtil {
       .flatMap(df -> df.getSubfields(subfield).stream().findFirst().map(Subfield::getData));
   }
 
+  /**
+   * Reads the value of a subfield from the first matching data field in a
+   * MARC record, identified by {@code tag} only, disregarding indicator values.
+   *
+   * @param srcRecord record containing the parsed MARC content to retrieve data
+   * @param tag       three-character MARC tag of the data field (must not be
+   *                  a control field tag, i.e. must not start with "00")
+   * @param subfield  subfield code whose data value should be returned
+   * @return {@link Optional} containing the data of the first matching
+   *         subfield in any data field with the given tag, or an empty
+   *         {@link Optional} if no matching field or subfield is found
+   * @throws IllegalArgumentException if {@code tag} identifies a control
+   *                                  instead of a data field
+   */
+  public static Optional<String> getValueFromDataField(Record srcRecord, String tag, char subfield) {
+    if (Verifier.isControlField(tag)) {
+      String msg = INVALID_DATA_FIELD_MSG.formatted(tag);
+      LOGGER.warn("getValueFromDataField:: {}", msg);
+      throw new IllegalArgumentException(msg);
+    }
+
+    return Optional.ofNullable(computeMarcRecord(srcRecord))
+      .stream()
+      .flatMap(marcRecord -> marcRecord.getDataFields().stream())
+      .filter(df -> df.getTag().equals(tag))
+      .flatMap(df -> df.getSubfields(subfield).stream())
+      .findFirst()
+      .map(Subfield::getData);
+  }
+
   private static MarcReader buildMarcReader(Record srcRecord) {
     String content = normalizeContent(srcRecord.getParsedRecord());
     return new MarcJsonReader(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));

--- a/src/main/java/org/folio/inventory/resources/InventoryClientFactory.java
+++ b/src/main/java/org/folio/inventory/resources/InventoryClientFactory.java
@@ -5,6 +5,7 @@ import io.vertx.ext.web.RoutingContext;
 import org.folio.inventory.client.wrappers.SourceStorageRecordsClientWrapper;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.WebContext;
+import org.folio.inventory.storage.external.CollectionResourceClient;
 import org.folio.inventory.storage.external.MultipleRecordsFetchClient;
 
 /**
@@ -31,5 +32,14 @@ public interface InventoryClientFactory {
    * @return A configured SourceStorageRecordsClientWrapper.
    */
   SourceStorageRecordsClientWrapper createSourceStorageRecordsClient(Context context, HttpClient client);
+
+  /**
+   * Creates a client for fetching locations by ID from the target tenant.
+   *
+   * @param context The context containing tenant, token, and user information for the target tenant.
+   * @param client  The shared HttpClient instance.
+   * @return A configured CollectionResourceClient for the locations API.
+   */
+  CollectionResourceClient createLocationClient(Context context, HttpClient client);
 
 }

--- a/src/main/java/org/folio/inventory/resources/InventoryClientFactoryImpl.java
+++ b/src/main/java/org/folio/inventory/resources/InventoryClientFactoryImpl.java
@@ -2,6 +2,8 @@ package org.folio.inventory.resources;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.ext.web.RoutingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.inventory.client.wrappers.SourceStorageRecordsClientWrapper;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.WebContext;
@@ -15,6 +17,8 @@ import java.net.MalformedURLException;
  * Default implementation of the InventoryClientFactory.
  */
 public class InventoryClientFactoryImpl implements InventoryClientFactory {
+
+  private static final Logger LOGGER = LogManager.getLogger(InventoryClientFactoryImpl.class);
 
   @Override
   public MultipleRecordsFetchClient createHoldingsRecordsFetchClient(RoutingContext routingContext, WebContext context, HttpClient client) {
@@ -31,5 +35,17 @@ public class InventoryClientFactoryImpl implements InventoryClientFactory {
   public SourceStorageRecordsClientWrapper createSourceStorageRecordsClient(Context context, HttpClient client) {
     return new SourceStorageRecordsClientWrapper(
       context.getOkapiLocation(), context.getTenantId(), context.getToken(), context.getUserId(), context.getRequestId(), client);
+  }
+
+  @Override
+  public CollectionResourceClient createLocationClient(Context context, HttpClient client) {
+    try {
+      return MoveApiUtil.createLocationStorageClient(
+        MoveApiUtil.createHttpClient(client, context,
+          throwable -> LOGGER.warn("createLocationClient:: Failed to contact location storage", throwable)),
+        context);
+    } catch (MalformedURLException e) {
+      throw new RuntimeException("Failed to create location client due to malformed URL", e);
+    }
   }
 }

--- a/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
+++ b/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import java.lang.invoke.MethodHandles;
-import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -429,7 +428,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
                 LOGGER.info("processHoldingsOwnershipUpdate:: Created {} holdings in target tenant: {}",
                   createdHoldings.size(), updateContext.targetTenantContext.getTenantId());
 
-                return moveSrsRecordsForMarcHoldings(holdingsRecords, createdHoldings, updateContext.sourceContext, updateContext.targetTenantContext, notUpdatedEntities, holdingMarcSources)
+                return moveSrsRecordsForMarcHoldings(holdingsRecords, createdHoldings, updateContext.sourceContext, updateContext.targetTenantContext, notUpdatedEntities, holdingMarcSources, updateContext.targetLocationClient)
                   .thenCompose(v -> transferAttachedItems(createdHoldings, notUpdatedEntities, updateContext.routingContext, updateContext.sourceContext, updateContext.targetTenantContext))
                   .thenCompose(itemIds -> {
                     // Calculate holdings to delete after SRS migration to account for any SRS errors
@@ -501,7 +500,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
    */
   private CompletableFuture<Void> moveSrsRecordsForMarcHoldings(List<HoldingsRecord> sourceHoldings, List<HoldingsRecord> targetHoldings,
                                                                 WebContext sourceContext, Context targetTenantContext, List<NotUpdatedEntity> notUpdatedEntities,
-                                                                Map<String, Record> holdingMarcSources) {
+                                                                Map<String, Record> holdingMarcSources, CollectionResourceClient locationClient) {
 
     LOGGER.info("moveSrsRecordsForMarcHoldings:: Starting SRS record migration for {} source holdings", sourceHoldings.size());
 
@@ -537,7 +536,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
         List<CompletableFuture<Void>> futures = marcHoldingsToProcess.stream()
           .map(sourceHolding -> prepareAndExecuteHoldingsSrsMove(
             sourceHolding, targetHoldings, holdingMarcSources, createdSnapshot,
-            sourceContext, targetTenantContext, notUpdatedEntities))
+            sourceContext, targetTenantContext, notUpdatedEntities, locationClient))
           .toList();
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
       })
@@ -560,7 +559,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
   private CompletableFuture<Void> prepareAndExecuteHoldingsSrsMove(HoldingsRecord sourceHolding, List<HoldingsRecord> targetHoldings,
                                                                    Map<String, Record> holdingMarcSources, Snapshot createdSnapshot,
                                                                    WebContext sourceContext, Context targetTenantContext,
-                                                                   List<NotUpdatedEntity> notUpdatedEntities) {
+                                                                   List<NotUpdatedEntity> notUpdatedEntities, CollectionResourceClient locationClient) {
     try {
       LOGGER.info("moveSrsRecordsForMarcHoldings:: Processing MARC holdings: {}", sourceHolding.getId());
 
@@ -577,7 +576,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
         sourceHolding.getId(), targetHolding.getId());
 
       return fetchLocationCodeAndMoveSrsRecord(sourceHolding, sourceHoldingRecord, targetHolding,
-        sourceContext, targetTenantContext, notUpdatedEntities, createdSnapshot);
+        sourceContext, targetTenantContext, notUpdatedEntities, createdSnapshot, locationClient);
 
     } catch (Exception ex) {
       String errorMessage = String.format("Unexpected error processing holdings record %s: %s", sourceHolding.getId(), ex.getMessage());
@@ -589,10 +588,11 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
 
   private CompletableFuture<Void> fetchLocationCodeAndMoveSrsRecord(HoldingsRecord sourceHolding, Record sourceHoldingRecord, HoldingsRecord targetHolding,
                                                                     WebContext sourceContext, Context targetTenantContext,
-                                                                    List<NotUpdatedEntity> notUpdatedEntities, Snapshot snapshot) {
+                                                                    List<NotUpdatedEntity> notUpdatedEntities, Snapshot snapshot,
+                                                                    CollectionResourceClient locationClient) {
     LOGGER.info("fetchLocationCodeAndMoveSrsRecord:: Fetching location code for holdings: {}", targetHolding.getId());
 
-    return fetchLocationCode(targetHolding.getPermanentLocationId(), targetTenantContext)
+    return fetchLocationCode(targetHolding.getPermanentLocationId(), locationClient)
       .thenCompose(locationCode -> {
         LOGGER.debug("fetchLocationCodeAndMoveSrsRecord:: Retrieved location code: {} for location ID: {}",
           locationCode, targetHolding.getPermanentLocationId());
@@ -607,44 +607,34 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
       });
   }
 
-  private CompletableFuture<String> fetchLocationCode(String locationId, Context targetTenantContext) {
-    LOGGER.debug("fetchLocationCode:: Fetching location by ID: {} for tenant: {}", locationId, targetTenantContext.getTenantId());
+  private CompletableFuture<String> fetchLocationCode(String locationId, CollectionResourceClient locationClient) {
+    LOGGER.debug("fetchLocationCode:: Fetching location by ID: {}", locationId);
 
     if (locationId == null || locationId.isBlank()) {
       LOGGER.warn("fetchLocationCode:: locationId is empty, cannot fetch location code");
       return CompletableFuture.completedFuture("");
     }
 
-    try {
-      CollectionResourceClient locationsClient = MoveApiUtil.createLocationStorageClient(
-        MoveApiUtil.createHttpClient(client, targetTenantContext,
-          throwable -> LOGGER.warn("fetchLocationCode:: Failed to contact location storage", throwable)),
-        targetTenantContext);
-
-      CompletableFuture<String> future = new CompletableFuture<>();
-      locationsClient.get(locationId, response -> {
-        try {
-          if (response.getStatusCode() == HttpStatus.HTTP_OK.toInt() && response.hasBody()) {
-            String locationCode = response.getJson().getString(LOCATION_CODE_FIELD);
-            if (locationCode != null && !locationCode.isBlank()) {
-              future.complete(locationCode);
-              return;
-            }
-            LOGGER.warn("fetchLocationCode:: Location {} does not contain code field, fallback to locationId", locationId);
-          } else {
-            LOGGER.warn("fetchLocationCode:: Failed to fetch location {}, status: {}", locationId, response.getStatusCode());
+    CompletableFuture<String> future = new CompletableFuture<>();
+    locationClient.get(locationId, response -> {
+      try {
+        if (response.getStatusCode() == HttpStatus.HTTP_OK.toInt() && response.hasBody()) {
+          String locationCode = response.getJson().getString(LOCATION_CODE_FIELD);
+          if (locationCode != null && !locationCode.isBlank()) {
+            future.complete(locationCode);
+            return;
           }
-          future.complete(locationId);
-        } catch (Exception e) {
-          LOGGER.warn("fetchLocationCode:: Unexpected response parse error for location {}", locationId, e);
-          future.complete(locationId);
+          LOGGER.warn("fetchLocationCode:: Location {} does not contain code field, fallback to locationId", locationId);
+        } else {
+          LOGGER.warn("fetchLocationCode:: Failed to fetch location {}, status: {}", locationId, response.getStatusCode());
         }
-      });
-      return future;
-    } catch (MalformedURLException e) {
-      LOGGER.warn("fetchLocationCode:: Invalid location URL for tenant {}", targetTenantContext.getTenantId(), e);
-      return CompletableFuture.completedFuture(locationId);
-    }
+        future.complete(locationId);
+      } catch (Exception e) {
+        LOGGER.warn("fetchLocationCode:: Unexpected response parse error for location {}", locationId, e);
+        future.complete(locationId);
+      }
+    });
+    return future;
   }
 
   private CompletableFuture<Void> moveSingleMarcHoldingsSrsRecord(HoldingsRecord sourceHolding, Record marcSrsRecord, HoldingsRecord targetHolding,
@@ -656,8 +646,10 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
     CompletableFuture<Void> result = new CompletableFuture<>();
 
     try {
-      String jsonTargetHolding = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(targetHolding);
-      LOGGER.trace("moveSingleMarcHoldingsSrsRecord:: targetHolding: \n{}", jsonTargetHolding);
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace("moveSingleMarcHoldingsSrsRecord:: targetHolding: \n{}",
+          objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(targetHolding));
+      }
       LOGGER.debug("moveSingleMarcHoldingsSrsRecord:: Preparing to move SRS record for holdings: {}, hrId: {}",
         targetHolding.getId(), targetHolding.getHrid());
 
@@ -1221,6 +1213,7 @@ private CompletableFuture<List<HoldingsRecord>> getHoldingsByInstanceId(Holdings
 
     MultipleRecordsFetchClient holdingsRecordFetchClient = clientFactory.createHoldingsRecordsFetchClient(routingContext, context, client);
     SourceStorageRecordsClientWrapper sourceSrsClient = clientFactory.createSourceStorageRecordsClient(context, client);
+    CollectionResourceClient targetLocationClient = clientFactory.createLocationClient(targetTenantContext, client);
 
     HoldingsRecordCollection sourceTenantHoldingsRecordCollection = storage.getHoldingsRecordCollection(context);
     HoldingsRecordCollection targetTenantHoldingsRecordCollection = storage.getHoldingsRecordCollection(targetTenantContext);
@@ -1228,7 +1221,7 @@ private CompletableFuture<List<HoldingsRecord>> getHoldingsByInstanceId(Holdings
     LOGGER.debug("initializeUpdateContext:: Update context initialized successfully");
 
     return new HoldingsOwnershipUpdateContext(holdingsRecordFetchClient, sourceSrsClient,
-      sourceTenantHoldingsRecordCollection, targetTenantHoldingsRecordCollection,
+      targetLocationClient, sourceTenantHoldingsRecordCollection, targetTenantHoldingsRecordCollection,
       context, targetTenantContext, routingContext);
 
   }
@@ -1239,6 +1232,7 @@ private CompletableFuture<List<HoldingsRecord>> getHoldingsByInstanceId(Holdings
   record HoldingsOwnershipUpdateContext(
     MultipleRecordsFetchClient holdingsRecordFetchClient,
     SourceStorageRecordsClientWrapper sourceSrsClient,
+    CollectionResourceClient targetLocationClient,
     HoldingsRecordCollection sourceTenantHoldingsRecordCollection,
     HoldingsRecordCollection targetTenantHoldingsRecordCollection,
     WebContext sourceContext, Context targetTenantContext,

--- a/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
+++ b/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
@@ -715,17 +715,15 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
       AdditionalFieldsUtil::replaceOrAddControlledFieldInMarcRecord);
     LOGGER.info("buildTargetSrsRecord:: Updated field 001 with new HRID: {}", targetHolding.getHrid());
 
-    // Replace existing 852$b values and set target holding permanent location code.
+    // Replace existing 852$b values (regardless of indicators) and set target holding permanent location code.
     if (locationCode != null && !locationCode.isEmpty()) {
-      Optional<String> existing852b = AdditionalFieldsUtil.getValueFromDataField(sourceSrsRecord,
-        MARC_TAG_852, INDICATOR_BLANK, INDICATOR_BLANK, SUBFIELD_B);
+      Optional<String> existing852b = AdditionalFieldsUtil.getValueFromDataField(sourceSrsRecord, MARC_TAG_852, SUBFIELD_B);
       while (existing852b.isPresent()) {
         boolean removed = AdditionalFieldsUtil.removeField(sourceSrsRecord, MARC_TAG_852, SUBFIELD_B, existing852b.get());
         if (!removed) {
           break;
         }
-        existing852b = AdditionalFieldsUtil.getValueFromDataField(sourceSrsRecord,
-          MARC_TAG_852, INDICATOR_BLANK, INDICATOR_BLANK, SUBFIELD_B);
+        existing852b = AdditionalFieldsUtil.getValueFromDataField(sourceSrsRecord, MARC_TAG_852, SUBFIELD_B);
       }
       AdditionalFieldsUtil.addDataFieldToMarcRecord(sourceSrsRecord, MARC_TAG_852,
         INDICATOR_BLANK, INDICATOR_BLANK, SUBFIELD_B, locationCode);

--- a/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
+++ b/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
@@ -646,10 +646,8 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
     CompletableFuture<Void> result = new CompletableFuture<>();
 
     try {
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("moveSingleMarcHoldingsSrsRecord:: targetHolding: \n{}",
+      LOGGER.trace("moveSingleMarcHoldingsSrsRecord:: targetHolding: \n{}",
           objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(targetHolding));
-      }
       LOGGER.debug("moveSingleMarcHoldingsSrsRecord:: Preparing to move SRS record for holdings: {}, hrId: {}",
         targetHolding.getId(), targetHolding.getHrid());
 

--- a/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
+++ b/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
@@ -646,8 +646,8 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
     CompletableFuture<Void> result = new CompletableFuture<>();
 
     try {
-      LOGGER.trace("moveSingleMarcHoldingsSrsRecord:: targetHolding: \n{}",
-          objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(targetHolding));
+      String jsonTargetHolding = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(targetHolding);
+      LOGGER.trace("moveSingleMarcHoldingsSrsRecord:: targetHolding: \n{}", jsonTargetHolding);
       LOGGER.debug("moveSingleMarcHoldingsSrsRecord:: Preparing to move SRS record for holdings: {}, hrId: {}",
         targetHolding.getId(), targetHolding.getHrid());
 

--- a/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
+++ b/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
@@ -22,10 +22,8 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.client.WebClient;
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,7 +64,6 @@ import org.folio.inventory.storage.external.CollectionResourceClient;
 import org.folio.inventory.storage.external.MultipleRecordsFetchClient;
 import org.folio.inventory.support.ItemUtil;
 import org.folio.inventory.support.MoveApiUtil;
-import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.rest.jaxrs.model.ExternalIdsHolder;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.Snapshot;
@@ -91,7 +88,6 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
   private static final String HOLDINGS_RECORD_ID = "holdingsRecordId";
   private static final String ITEM_ID = "itemId";
   private static final String INSTANCE_ID = "instanceId";
-  private static final String LOCATION_STORAGE_PATH = "/locations";
   private static final String LOCATION_CODE_FIELD = "code";
   private static final String MARC_TAG_852 = "852";
   private static final char INDICATOR_BLANK = ' ';
@@ -620,12 +616,10 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
     }
 
     try {
-      OkapiHttpClient okapiClient = new OkapiHttpClient(WebClient.wrap(client), URI.create(targetTenantContext.getOkapiLocation()).toURL(),
-        targetTenantContext.getTenantId(), targetTenantContext.getToken(), targetTenantContext.getUserId(),
-        targetTenantContext.getRequestId(), throwable -> LOGGER.warn("fetchLocationCode:: Failed to contact location storage", throwable));
-
-      CollectionResourceClient locationsClient = new CollectionResourceClient(okapiClient,
-        URI.create(targetTenantContext.getOkapiLocation() + LOCATION_STORAGE_PATH).toURL());
+      CollectionResourceClient locationsClient = MoveApiUtil.createLocationStorageClient(
+        MoveApiUtil.createHttpClient(client, targetTenantContext,
+          throwable -> LOGGER.warn("fetchLocationCode:: Failed to contact location storage", throwable)),
+        targetTenantContext);
 
       CompletableFuture<String> future = new CompletableFuture<>();
       locationsClient.get(locationId, response -> {

--- a/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
+++ b/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
@@ -2,7 +2,6 @@ package org.folio.inventory.resources;
 
 import static java.lang.String.format;
 import static org.folio.inventory.dataimport.handlers.matching.util.EventHandlingUtil.constructContext;
-import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.FIELDS;
 import static org.folio.inventory.dataimport.util.AdditionalFieldsUtil.TAG_001;
 import static org.folio.inventory.domain.instances.InstanceSource.CONSORTIUM_FOLIO;
 import static org.folio.inventory.domain.instances.InstanceSource.CONSORTIUM_MARC;
@@ -17,21 +16,23 @@ import static org.folio.inventory.support.MoveApiUtil.respond;
 import static org.folio.inventory.support.http.server.JsonResponse.unprocessableEntity;
 import static org.folio.inventory.validation.UpdateOwnershipValidator.updateOwnershipHasRequiredFields;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.client.WebClient;
 import java.lang.invoke.MethodHandles;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -53,6 +54,7 @@ import org.folio.inventory.common.api.request.PagingParameters;
 import org.folio.inventory.common.domain.MultipleRecords;
 import org.folio.inventory.consortium.services.ConsortiumService;
 import org.folio.inventory.dataimport.services.SnapshotService;
+import org.folio.inventory.dataimport.util.AdditionalFieldsUtil;
 import org.folio.inventory.domain.HoldingsRecordCollection;
 import org.folio.inventory.domain.instances.Instance;
 import org.folio.inventory.domain.items.Item;
@@ -64,8 +66,8 @@ import org.folio.inventory.storage.external.CollectionResourceClient;
 import org.folio.inventory.storage.external.MultipleRecordsFetchClient;
 import org.folio.inventory.support.ItemUtil;
 import org.folio.inventory.support.MoveApiUtil;
+import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.rest.jaxrs.model.ExternalIdsHolder;
-import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.Snapshot;
 
@@ -89,6 +91,11 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
   private static final String HOLDINGS_RECORD_ID = "holdingsRecordId";
   private static final String ITEM_ID = "itemId";
   private static final String INSTANCE_ID = "instanceId";
+  private static final String LOCATION_STORAGE_PATH = "/locations";
+  private static final String LOCATION_CODE_FIELD = "code";
+  private static final String MARC_TAG_852 = "852";
+  private static final char INDICATOR_BLANK = ' ';
+  private static final char SUBFIELD_B = 'b';
   private static final int HOLDINGS_PAGE_SIZE = 100;
 
   private final ConsortiumService consortiumService;
@@ -573,7 +580,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
       LOGGER.debug("moveSrsRecordsForMarcHoldings:: Moving SRS record for source holdings: {} to target holdings: {}",
         sourceHolding.getId(), targetHolding.getId());
 
-      return moveSingleMarcHoldingsSrsRecord(sourceHolding, sourceHoldingRecord, targetHolding,
+      return fetchLocationCodeAndMoveSrsRecord(sourceHolding, sourceHoldingRecord, targetHolding,
         sourceContext, targetTenantContext, notUpdatedEntities, createdSnapshot);
 
     } catch (Exception ex) {
@@ -584,8 +591,70 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
     }
   }
 
+  private CompletableFuture<Void> fetchLocationCodeAndMoveSrsRecord(HoldingsRecord sourceHolding, Record sourceHoldingRecord, HoldingsRecord targetHolding,
+                                                                    WebContext sourceContext, Context targetTenantContext,
+                                                                    List<NotUpdatedEntity> notUpdatedEntities, Snapshot snapshot) {
+    LOGGER.info("fetchLocationCodeAndMoveSrsRecord:: Fetching location code for holdings: {}", targetHolding.getId());
+
+    return fetchLocationCode(targetHolding.getPermanentLocationId(), targetTenantContext)
+      .thenCompose(locationCode -> {
+        LOGGER.debug("fetchLocationCodeAndMoveSrsRecord:: Retrieved location code: {} for location ID: {}",
+          locationCode, targetHolding.getPermanentLocationId());
+        return moveSingleMarcHoldingsSrsRecord(sourceHolding, sourceHoldingRecord, targetHolding,
+          sourceContext, targetTenantContext, notUpdatedEntities, snapshot, locationCode);
+      })
+      .exceptionally(throwable -> {
+        String errorMessage = String.format("Failed to fetch location code for holdings: %s", sourceHolding.getId());
+        LOGGER.error("fetchLocationCodeAndMoveSrsRecord:: {}", errorMessage, throwable);
+        notUpdatedEntities.add(new NotUpdatedEntity().withEntityId(sourceHolding.getId()).withErrorMessage(errorMessage));
+        return null;
+      });
+  }
+
+  private CompletableFuture<String> fetchLocationCode(String locationId, Context targetTenantContext) {
+    LOGGER.debug("fetchLocationCode:: Fetching location by ID: {} for tenant: {}", locationId, targetTenantContext.getTenantId());
+
+    if (locationId == null || locationId.isBlank()) {
+      LOGGER.warn("fetchLocationCode:: locationId is empty, cannot fetch location code");
+      return CompletableFuture.completedFuture("");
+    }
+
+    try {
+      OkapiHttpClient okapiClient = new OkapiHttpClient(WebClient.wrap(client), URI.create(targetTenantContext.getOkapiLocation()).toURL(),
+        targetTenantContext.getTenantId(), targetTenantContext.getToken(), targetTenantContext.getUserId(),
+        targetTenantContext.getRequestId(), throwable -> LOGGER.warn("fetchLocationCode:: Failed to contact location storage", throwable));
+
+      CollectionResourceClient locationsClient = new CollectionResourceClient(okapiClient,
+        URI.create(targetTenantContext.getOkapiLocation() + LOCATION_STORAGE_PATH).toURL());
+
+      CompletableFuture<String> future = new CompletableFuture<>();
+      locationsClient.get(locationId, response -> {
+        try {
+          if (response.getStatusCode() == HttpStatus.HTTP_OK.toInt() && response.hasBody()) {
+            String locationCode = response.getJson().getString(LOCATION_CODE_FIELD);
+            if (locationCode != null && !locationCode.isBlank()) {
+              future.complete(locationCode);
+              return;
+            }
+            LOGGER.warn("fetchLocationCode:: Location {} does not contain code field, fallback to locationId", locationId);
+          } else {
+            LOGGER.warn("fetchLocationCode:: Failed to fetch location {}, status: {}", locationId, response.getStatusCode());
+          }
+          future.complete(locationId);
+        } catch (Exception e) {
+          LOGGER.warn("fetchLocationCode:: Unexpected response parse error for location {}", locationId, e);
+          future.complete(locationId);
+        }
+      });
+      return future;
+    } catch (MalformedURLException e) {
+      LOGGER.warn("fetchLocationCode:: Invalid location URL for tenant {}", targetTenantContext.getTenantId(), e);
+      return CompletableFuture.completedFuture(locationId);
+    }
+  }
+
   private CompletableFuture<Void> moveSingleMarcHoldingsSrsRecord(HoldingsRecord sourceHolding, Record marcSrsRecord, HoldingsRecord targetHolding,
-                                                                  WebContext sourceContext, Context targetTenantContext, List<NotUpdatedEntity> notUpdatedEntities, Snapshot snapshot) {
+                                                                  WebContext sourceContext, Context targetTenantContext, List<NotUpdatedEntity> notUpdatedEntities, Snapshot snapshot, String locationCode) {
 
     LOGGER.info("moveSingleMarcHoldingsSrsRecord:: Starting SRS record migration for holdings: {} -> {}",
       sourceHolding.getId(), targetHolding.getId());
@@ -601,7 +670,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
       SourceStorageRecordsClientWrapper sourceSrsClient = clientFactory.createSourceStorageRecordsClient(sourceContext, client);
       SourceStorageRecordsClientWrapper targetSrsClient = clientFactory.createSourceStorageRecordsClient(targetTenantContext, client);
 
-      Record newRecordForTarget = buildTargetSrsRecord(marcSrsRecord, targetHolding, snapshot);
+      Record newRecordForTarget = buildTargetSrsRecord(marcSrsRecord, targetHolding, snapshot, locationCode);
       targetSrsClient.postSourceStorageRecords(newRecordForTarget).onComplete(postAr -> {
         if (postAr.failed() || postAr.result().statusCode() != HttpStatus.HTTP_CREATED.toInt()) {
           String msg = String.format("Failed to post SRS record to target tenant=%s: %s",
@@ -643,47 +712,50 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
 
   /**
    * Creates a new SRS Record for the target tenant by copying data from the source record
-   * and updating key fields like HRID in externalIdsHolder and the 001 field in parsedRecord.
+   * and updating key fields like HRID in externalIdsHolder, the 001 field in parsedRecord,
+   * and the 852 field subfield 'b' with the location code.
    *
    * @param sourceSrsRecord The original SRS record from the source tenant.
    * @param targetHolding   The newly created holdings record in the target tenant, containing the new HRID.
    * @param snapshot        The snapshot under which the new SRS record will be created.
+   * @param locationCode    The location code to populate in field 852 subfield 'b'.
    * @return A new, ready-to-post {@link Record} object.
-   * @throws JsonProcessingException if serialization of parsedRecord content fails.
    */
-  private Record buildTargetSrsRecord(Record sourceSrsRecord, HoldingsRecord targetHolding, Snapshot snapshot) throws JsonProcessingException {
+  private Record buildTargetSrsRecord(Record sourceSrsRecord, HoldingsRecord targetHolding, Snapshot snapshot, String locationCode) {
 
-    LOGGER.info("buildTargetSrsRecord:: Building target SRS record for holdings: {}, hrId: {}",
-      targetHolding.getId(), targetHolding.getHrid());
+    LOGGER.info("buildTargetSrsRecord:: Building target SRS record for holdings: {}, hrId: {}, location code: {}",
+      targetHolding.getId(), targetHolding.getHrid(), locationCode);
 
     ExternalIdsHolder newExternalIds = sourceSrsRecord.getExternalIdsHolder();
     newExternalIds.setHoldingsHrid(targetHolding.getHrid());
 
-    ParsedRecord sourceParsedRecord = sourceSrsRecord.getParsedRecord();
-    String contentAsJsonString = objectMapper.writeValueAsString(sourceParsedRecord.getContent());
-    JsonObject parsedContentCopy = new JsonObject(contentAsJsonString);
-    JsonArray fields = parsedContentCopy.getJsonArray(FIELDS);
-    if (fields != null) {
-      for (int i = 0; i < fields.size(); i++) {
-        if (fields.getValue(i) instanceof JsonObject field && field.containsKey(TAG_001)) {
-          field.put(TAG_001, targetHolding.getHrid());
-          LOGGER.info("buildTargetSrsRecord:: Updated field 001 with new HRID: {}", targetHolding.getHrid());
+    AdditionalFieldsUtil.addControlledFieldToMarcRecord(sourceSrsRecord, TAG_001, targetHolding.getHrid(),
+      AdditionalFieldsUtil::replaceOrAddControlledFieldInMarcRecord);
+    LOGGER.info("buildTargetSrsRecord:: Updated field 001 with new HRID: {}", targetHolding.getHrid());
+
+    // Replace existing 852$b values and set target holding permanent location code.
+    if (locationCode != null && !locationCode.isEmpty()) {
+      Optional<String> existing852b = AdditionalFieldsUtil.getValueFromDataField(sourceSrsRecord,
+        MARC_TAG_852, INDICATOR_BLANK, INDICATOR_BLANK, SUBFIELD_B);
+      while (existing852b.isPresent()) {
+        boolean removed = AdditionalFieldsUtil.removeField(sourceSrsRecord, MARC_TAG_852, SUBFIELD_B, existing852b.get());
+        if (!removed) {
           break;
         }
+        existing852b = AdditionalFieldsUtil.getValueFromDataField(sourceSrsRecord,
+          MARC_TAG_852, INDICATOR_BLANK, INDICATOR_BLANK, SUBFIELD_B);
       }
+      AdditionalFieldsUtil.addDataFieldToMarcRecord(sourceSrsRecord, MARC_TAG_852,
+        INDICATOR_BLANK, INDICATOR_BLANK, SUBFIELD_B, locationCode);
+      LOGGER.info("buildTargetSrsRecord:: Updated field 852 subfield 'b' with location code: {}", locationCode);
     }
-
-    Map<String, Object> contentAsMap = parsedContentCopy.getMap();
-    ParsedRecord newParsedRecord = new ParsedRecord()
-      .withId(sourceParsedRecord.getId())
-      .withContent(contentAsMap);
 
     return new Record()
       .withSnapshotId(snapshot.getJobExecutionId())
       .withMatchedId(sourceSrsRecord.getMatchedId())
       .withRecordType(sourceSrsRecord.getRecordType())
       .withExternalIdsHolder(newExternalIds)
-      .withParsedRecord(newParsedRecord)
+      .withParsedRecord(sourceSrsRecord.getParsedRecord())
       .withRawRecord(sourceSrsRecord.getRawRecord())
       .withAdditionalInfo(sourceSrsRecord.getAdditionalInfo())
       .withState(sourceSrsRecord.getState())

--- a/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
+++ b/src/main/java/org/folio/inventory/resources/UpdateOwnershipApi.java
@@ -428,7 +428,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
                 LOGGER.info("processHoldingsOwnershipUpdate:: Created {} holdings in target tenant: {}",
                   createdHoldings.size(), updateContext.targetTenantContext.getTenantId());
 
-                return moveSrsRecordsForMarcHoldings(holdingsRecords, createdHoldings, updateContext.sourceContext, updateContext.targetTenantContext, notUpdatedEntities, holdingMarcSources, updateContext.targetLocationClient)
+                return moveSrsRecordsForMarcHoldings(holdingsRecords, createdHoldings, notUpdatedEntities, holdingMarcSources, updateContext)
                   .thenCompose(v -> transferAttachedItems(createdHoldings, notUpdatedEntities, updateContext.routingContext, updateContext.sourceContext, updateContext.targetTenantContext))
                   .thenCompose(itemIds -> {
                     // Calculate holdings to delete after SRS migration to account for any SRS errors
@@ -492,15 +492,14 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
    *
    * @param sourceHoldings     The original list of holdings records from the source tenant.
    * @param targetHoldings     The list of newly created holdings records in the target tenant.
-   * @param sourceContext      The context for the source tenant.
-   * @param targetTenantContext The context for the target tenant.
    * @param notUpdatedEntities A list to which any entities that fail during processing will be added.
    * @param holdingMarcSources A map of source holdings ID to its fetched MARC Record.
+   * @param updateContext      The context holding source/target tenant contexts and the target location client.
    * @return A CompletableFuture that completes when all SRS records have been processed.
    */
   private CompletableFuture<Void> moveSrsRecordsForMarcHoldings(List<HoldingsRecord> sourceHoldings, List<HoldingsRecord> targetHoldings,
-                                                                WebContext sourceContext, Context targetTenantContext, List<NotUpdatedEntity> notUpdatedEntities,
-                                                                Map<String, Record> holdingMarcSources, CollectionResourceClient locationClient) {
+                                                                List<NotUpdatedEntity> notUpdatedEntities, Map<String, Record> holdingMarcSources,
+                                                                HoldingsOwnershipUpdateContext updateContext) {
 
     LOGGER.info("moveSrsRecordsForMarcHoldings:: Starting SRS record migration for {} source holdings", sourceHoldings.size());
 
@@ -527,7 +526,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
       .withStatus(Snapshot.Status.PARSING_IN_PROGRESS);
 
     //Create a snapshot. An error at this stage is fatal for the full batch.
-    return snapshotService.postSnapshotInSrsAndHandleResponse(targetTenantContext, snapshot)
+    return snapshotService.postSnapshotInSrsAndHandleResponse(updateContext.targetTenantContext, snapshot)
       .toCompletionStage().toCompletableFuture()
       .thenCompose(createdSnapshot -> {
         LOGGER.info("moveSrsRecordsForMarcHoldings:: Created a single snapshot {} for the entire operation", createdSnapshot.getJobExecutionId());
@@ -536,7 +535,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
         List<CompletableFuture<Void>> futures = marcHoldingsToProcess.stream()
           .map(sourceHolding -> prepareAndExecuteHoldingsSrsMove(
             sourceHolding, targetHoldings, holdingMarcSources, createdSnapshot,
-            sourceContext, targetTenantContext, notUpdatedEntities, locationClient))
+            notUpdatedEntities, updateContext))
           .toList();
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
       })
@@ -558,8 +557,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
 
   private CompletableFuture<Void> prepareAndExecuteHoldingsSrsMove(HoldingsRecord sourceHolding, List<HoldingsRecord> targetHoldings,
                                                                    Map<String, Record> holdingMarcSources, Snapshot createdSnapshot,
-                                                                   WebContext sourceContext, Context targetTenantContext,
-                                                                   List<NotUpdatedEntity> notUpdatedEntities, CollectionResourceClient locationClient) {
+                                                                   List<NotUpdatedEntity> notUpdatedEntities, HoldingsOwnershipUpdateContext updateContext) {
     try {
       LOGGER.info("moveSrsRecordsForMarcHoldings:: Processing MARC holdings: {}", sourceHolding.getId());
 
@@ -576,7 +574,7 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
         sourceHolding.getId(), targetHolding.getId());
 
       return fetchLocationCodeAndMoveSrsRecord(sourceHolding, sourceHoldingRecord, targetHolding,
-        sourceContext, targetTenantContext, notUpdatedEntities, createdSnapshot, locationClient);
+        notUpdatedEntities, createdSnapshot, updateContext);
 
     } catch (Exception ex) {
       String errorMessage = String.format("Unexpected error processing holdings record %s: %s", sourceHolding.getId(), ex.getMessage());
@@ -587,17 +585,16 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
   }
 
   private CompletableFuture<Void> fetchLocationCodeAndMoveSrsRecord(HoldingsRecord sourceHolding, Record sourceHoldingRecord, HoldingsRecord targetHolding,
-                                                                    WebContext sourceContext, Context targetTenantContext,
                                                                     List<NotUpdatedEntity> notUpdatedEntities, Snapshot snapshot,
-                                                                    CollectionResourceClient locationClient) {
+                                                                    HoldingsOwnershipUpdateContext updateContext) {
     LOGGER.info("fetchLocationCodeAndMoveSrsRecord:: Fetching location code for holdings: {}", targetHolding.getId());
 
-    return fetchLocationCode(targetHolding.getPermanentLocationId(), locationClient)
+    return fetchLocationCode(targetHolding.getPermanentLocationId(), updateContext.targetLocationClient)
       .thenCompose(locationCode -> {
         LOGGER.debug("fetchLocationCodeAndMoveSrsRecord:: Retrieved location code: {} for location ID: {}",
           locationCode, targetHolding.getPermanentLocationId());
         return moveSingleMarcHoldingsSrsRecord(sourceHolding, sourceHoldingRecord, targetHolding,
-          sourceContext, targetTenantContext, notUpdatedEntities, snapshot, locationCode);
+          notUpdatedEntities, snapshot, locationCode, updateContext);
       })
       .exceptionally(throwable -> {
         String errorMessage = String.format("Failed to fetch location code for holdings: %s", sourceHolding.getId());
@@ -638,7 +635,8 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
   }
 
   private CompletableFuture<Void> moveSingleMarcHoldingsSrsRecord(HoldingsRecord sourceHolding, Record marcSrsRecord, HoldingsRecord targetHolding,
-                                                                  WebContext sourceContext, Context targetTenantContext, List<NotUpdatedEntity> notUpdatedEntities, Snapshot snapshot, String locationCode) {
+                                                                  List<NotUpdatedEntity> notUpdatedEntities, Snapshot snapshot, String locationCode,
+                                                                  HoldingsOwnershipUpdateContext updateContext) {
 
     LOGGER.info("moveSingleMarcHoldingsSrsRecord:: Starting SRS record migration for holdings: {} -> {}",
       sourceHolding.getId(), targetHolding.getId());
@@ -651,14 +649,14 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
       LOGGER.debug("moveSingleMarcHoldingsSrsRecord:: Preparing to move SRS record for holdings: {}, hrId: {}",
         targetHolding.getId(), targetHolding.getHrid());
 
-      SourceStorageRecordsClientWrapper sourceSrsClient = clientFactory.createSourceStorageRecordsClient(sourceContext, client);
-      SourceStorageRecordsClientWrapper targetSrsClient = clientFactory.createSourceStorageRecordsClient(targetTenantContext, client);
+      SourceStorageRecordsClientWrapper sourceSrsClient = clientFactory.createSourceStorageRecordsClient(updateContext.sourceContext, client);
+      SourceStorageRecordsClientWrapper targetSrsClient = clientFactory.createSourceStorageRecordsClient(updateContext.targetTenantContext, client);
 
       Record newRecordForTarget = buildTargetSrsRecord(marcSrsRecord, targetHolding, snapshot, locationCode);
       targetSrsClient.postSourceStorageRecords(newRecordForTarget).onComplete(postAr -> {
         if (postAr.failed() || postAr.result().statusCode() != HttpStatus.HTTP_CREATED.toInt()) {
           String msg = String.format("Failed to post SRS record to target tenant=%s: %s",
-            targetTenantContext.getTenantId(), postAr.cause() != null ? postAr.cause().getMessage() : postAr.result().bodyAsString());
+            updateContext.targetTenantContext.getTenantId(), postAr.cause() != null ? postAr.cause().getMessage() : postAr.result().bodyAsString());
           LOGGER.warn("moveSingleMarcHoldingsSrsRecord:: {}", msg);
           notUpdatedEntities.add(new NotUpdatedEntity().withEntityId(sourceHolding.getId()).withErrorMessage(msg));
           result.complete(null);
@@ -666,13 +664,13 @@ public class UpdateOwnershipApi extends AbstractInventoryResource {
         }
 
         LOGGER.trace("moveSingleMarcHoldingsSrsRecord:: Posted SRS record to target tenant={}, response: \n{}",
-          targetTenantContext.getTenantId(), postAr.result().bodyAsString());
+          updateContext.targetTenantContext.getTenantId(), postAr.result().bodyAsString());
 
         LOGGER.debug("moveSingleMarcHoldingsSrsRecord:: Deleting source SRS record with id: {}", marcSrsRecord.getId());
         sourceSrsClient.deleteSourceStorageRecordsById(marcSrsRecord.getId(), "SRS_RECORD").onComplete(deleteAr -> {
           if (deleteAr.failed() || deleteAr.result().statusCode() != HttpStatus.HTTP_NO_CONTENT.toInt()) {
             String msg = String.format("Failed to delete source SRS record in source tenant=%s: %s",
-              sourceContext.getTenantId(), deleteAr.cause() != null ? deleteAr.cause().getMessage() : deleteAr.result().bodyAsString());
+              updateContext.sourceContext.getTenantId(), deleteAr.cause() != null ? deleteAr.cause().getMessage() : deleteAr.result().bodyAsString());
             LOGGER.warn("moveSingleMarcHoldingsSrsRecord:: {}", msg);
             notUpdatedEntities.add(new NotUpdatedEntity().withEntityId(sourceHolding.getId()).withErrorMessage(msg));
             result.complete(null);

--- a/src/main/java/org/folio/inventory/support/MoveApiUtil.java
+++ b/src/main/java/org/folio/inventory/support/MoveApiUtil.java
@@ -9,6 +9,7 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.NotUpdatedEntity;
 import org.folio.UpdateOwnershipResponse;
+import org.folio.inventory.common.Context;
 import org.folio.inventory.common.WebContext;
 import org.folio.inventory.storage.external.CollectionResourceClient;
 import org.folio.inventory.storage.external.CqlQuery;
@@ -17,9 +18,11 @@ import org.folio.inventory.support.http.client.OkapiHttpClient;
 import org.folio.inventory.support.http.server.ServerErrorResponse;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.folio.inventory.support.http.server.JsonResponse.badRequest;
 import static org.folio.inventory.support.http.server.JsonResponse.success;
@@ -31,6 +34,7 @@ public final class MoveApiUtil {
   public static final String BOUND_WITH_PARTS_RECORDS_PROPERTY = "boundWithParts";
   public static final String TARGET_TENANT_ID = "targetTenantId";
   public static final String ITEM_STORAGE = "/item-storage/items";
+  public static final String LOCATION_STORAGE = "/locations";
   public static final String ITEMS_PROPERTY = "items";
   private static final String HOLDINGS_ITEMS_PROPERTY = "holdingsItems";
   private static final String BARE_HOLDINGS_ITEMS_PROPERTY = "bareHoldingsItems";
@@ -43,6 +47,12 @@ public final class MoveApiUtil {
         String.format("Failed to contact storage module: %s", exception.toString())));
   }
 
+  public static OkapiHttpClient createHttpClient(HttpClient client, Context context,
+                                                 Consumer<Throwable> exceptionHandler) throws MalformedURLException {
+    return new OkapiHttpClient(WebClient.wrap(client), URI.create(context.getOkapiLocation()).toURL(),
+      context.getTenantId(), context.getToken(), context.getUserId(), context.getRequestId(), exceptionHandler);
+  }
+
 
   private static MultipleRecordsFetchClient createFetchClient(CollectionResourceClient client, String propertyName) {
     return MultipleRecordsFetchClient.builder()
@@ -52,10 +62,10 @@ public final class MoveApiUtil {
       .build();
   }
 
-  public static CollectionResourceClient createStorageClient(OkapiHttpClient client, WebContext context, String storageUrl)
+  public static CollectionResourceClient createStorageClient(OkapiHttpClient client, Context context, String storageUrl)
     throws MalformedURLException {
 
-    return new CollectionResourceClient(client, new URL(context.getOkapiLocation() + storageUrl));
+    return new CollectionResourceClient(client, URI.create(context.getOkapiLocation() + storageUrl).toURL());
   }
 
   public static CollectionResourceClient createHoldingsStorageClient(OkapiHttpClient client, WebContext context)
@@ -71,6 +81,11 @@ public final class MoveApiUtil {
   public static CollectionResourceClient createItemStorageClient(OkapiHttpClient client, WebContext context)
     throws MalformedURLException {
     return createStorageClient(client, context, ITEM_STORAGE);
+  }
+
+  public static CollectionResourceClient createLocationStorageClient(OkapiHttpClient client, Context context)
+    throws MalformedURLException {
+    return createStorageClient(client, context, LOCATION_STORAGE);
   }
 
   public static MultipleRecordsFetchClient createHoldingsRecordsFetchClient(CollectionResourceClient client) {

--- a/src/main/java/org/folio/inventory/support/MoveApiUtil.java
+++ b/src/main/java/org/folio/inventory/support/MoveApiUtil.java
@@ -19,7 +19,6 @@ import org.folio.inventory.support.http.server.ServerErrorResponse;
 
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;

--- a/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
+++ b/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
@@ -1339,6 +1339,58 @@ public class HoldingsUpdateOwnershipApiTest extends ApiTests {
     assertThat(field852bValues.getFirst(), is(targetLocationId));
   }
 
+  @Test
+  public void shouldFallbackToLocationIdWhenLocationResponseIsNotValidJson() throws Exception {
+    UUID instanceId = UUID.randomUUID();
+    JsonObject instance = smallAngryPlanet(instanceId);
+    InstanceApiClient.createInstance(okapiClient, instance.copy().put("source", CONSORTIUM_FOLIO.getValue()));
+    InstanceApiClient.createInstance(consortiumOkapiClient, instance.copy().put("source", FOLIO.getValue()));
+
+    final UUID marcHoldingsId = holdingsStorageClient.create(
+        new HoldingRequestBuilder()
+          .forInstance(instanceId)
+          .withMarcSource()
+      )
+      .getId();
+
+    final JsonObject srsRecordToCreate = buildMarcSourceRecord(marcHoldingsId);
+    final String sourceSrsId = srsRecordToCreate.getString("id");
+    sourceRecordStorageClient.create(srsRecordToCreate);
+
+    String targetLocationId = UUID.randomUUID().toString();
+
+    ResourceClient collegeLocationsClient = ResourceClient.forLocations(collegeOkapiClient);
+    collegeLocationsClient.emulateFailure(
+      new EndpointFailureDescriptor()
+        .setFailureExpireDate(DateTime.now().plusSeconds(5).toDate())
+        .setStatusCode(200)
+        .setContentType("application/json")
+        .setBody("not-a-valid-json-body")
+        .setMethod(HttpMethod.GET.name())
+        .setUrlPattern("/locations/" + targetLocationId)
+    );
+
+    JsonObject requestBody = new HoldingsRecordUpdateOwnershipRequestBuilder(instanceId,
+      new JsonArray(List.of(marcHoldingsId.toString())), UUID.fromString(targetLocationId), ApiTestSuite.COLLEGE_TENANT_ID).create();
+
+    Response response = updateHoldingsRecordsOwnership(requestBody);
+    collegeLocationsClient.disableFailureEmulation();
+
+    assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+    assertThat(response.getJson().getJsonArray("notUpdatedEntities").size(), is(0));
+
+    List<JsonObject> targetSrsRecords = collegeSourceRecordStorageClient.getMany("matchedId==" + sourceSrsId, 1);
+    assertThat(targetSrsRecords.size(), is(1));
+
+    JsonObject parsedRecord = targetSrsRecords.getFirst().getJsonObject("parsedRecord");
+    JsonObject parsedContent = getParsedContent(parsedRecord);
+    List<String> field852bValues = getField852bValues(parsedContent);
+
+    // Operation should complete and use locationId as fallback when the location response body cannot be parsed.
+    assertThat(field852bValues.size(), is(1));
+    assertThat(field852bValues.getFirst(), is(targetLocationId));
+  }
+
   private JsonObject buildMarcSourceRecord(UUID holdingsId) {
     final var srsId = UUID.randomUUID();
     return new JsonObject()

--- a/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
+++ b/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
@@ -7,6 +7,7 @@ import api.support.InstanceApiClient;
 import api.support.builders.HoldingRequestBuilder;
 import api.support.builders.HoldingsRecordUpdateOwnershipRequestBuilder;
 import api.support.builders.ItemRequestBuilder;
+import api.support.http.ResourceClient;
 import api.support.http.StorageInterfaceUrls;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
@@ -1178,6 +1179,112 @@ public class HoldingsUpdateOwnershipApiTest extends ApiTests {
     List<String> targetHoldingIds = targetHoldings.stream().map(h -> h.getString("id")).toList();
     assertTrue("MARC holding should be in target tenant", targetHoldingIds.contains(marcHoldingsId.toString()));
     assertTrue("FOLIO holding should be in target tenant", targetHoldingIds.contains(folioHoldingsId.toString()));
+  }
+
+  @Test
+  public void shouldFallbackToLocationIdWhenFetchingTargetLocationFailsForMarcHolding() throws Exception {
+    UUID instanceId = UUID.randomUUID();
+    JsonObject instance = smallAngryPlanet(instanceId);
+    InstanceApiClient.createInstance(okapiClient, instance.copy().put("source", CONSORTIUM_FOLIO.getValue()));
+    InstanceApiClient.createInstance(consortiumOkapiClient, instance.copy().put("source", FOLIO.getValue()));
+
+    final UUID marcHoldingsId = holdingsStorageClient.create(
+        new HoldingRequestBuilder()
+          .forInstance(instanceId)
+          .withMarcSource()
+      )
+      .getId();
+
+    final JsonObject srsRecordToCreate = buildMarcSourceRecord(marcHoldingsId);
+    final String sourceSrsId = srsRecordToCreate.getString("id");
+    sourceRecordStorageClient.create(srsRecordToCreate);
+
+    String targetLocationId = getMainLibraryLocation();
+    ensureCollegeTenantLocationExists(targetLocationId);
+
+    ResourceClient collegeLocationsClient = ResourceClient.forLocations(collegeOkapiClient);
+    collegeLocationsClient.emulateFailure(
+      new EndpointFailureDescriptor()
+        .setFailureExpireDate(DateTime.now().plusSeconds(5).toDate())
+        .setStatusCode(500)
+        .setContentType("application/json")
+        .setBody(new JsonObject().put("message", "Location service unavailable").toString())
+        .setMethod(HttpMethod.GET.name())
+        .setUrlPattern("/locations/.*")
+    );
+
+    JsonObject requestBody = new HoldingsRecordUpdateOwnershipRequestBuilder(instanceId,
+      new JsonArray(List.of(marcHoldingsId.toString())), UUID.fromString(targetLocationId), ApiTestSuite.COLLEGE_TENANT_ID).create();
+
+    Response response = updateHoldingsRecordsOwnership(requestBody);
+    collegeLocationsClient.disableFailureEmulation();
+
+    assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+    assertThat(response.getJson().getJsonArray("notUpdatedEntities").size(), is(0));
+
+    // Operation should complete and use locationId as fallback when GET /locations fails.
+    assertThat(holdingsStorageClient.getById(marcHoldingsId).getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
+
+    List<JsonObject> targetSrsRecords = collegeSourceRecordStorageClient.getMany("matchedId==" + sourceSrsId, 1);
+    assertThat(targetSrsRecords.size(), is(1));
+
+    JsonObject parsedRecord = targetSrsRecords.getFirst().getJsonObject("parsedRecord");
+    JsonObject parsedContent = getParsedContent(parsedRecord);
+    List<String> field852bValues = getField852bValues(parsedContent);
+
+    assertThat(field852bValues.size(), is(1));
+    assertThat(field852bValues.getFirst(), is(targetLocationId));
+  }
+
+  @Test
+  public void shouldFallbackToLocationIdWhenFetchedLocationCodeIsEmpty() throws Exception {
+    UUID instanceId = UUID.randomUUID();
+    JsonObject instance = smallAngryPlanet(instanceId);
+    InstanceApiClient.createInstance(okapiClient, instance.copy().put("source", CONSORTIUM_FOLIO.getValue()));
+    InstanceApiClient.createInstance(consortiumOkapiClient, instance.copy().put("source", FOLIO.getValue()));
+
+    final UUID marcHoldingsId = holdingsStorageClient.create(
+        new HoldingRequestBuilder()
+          .forInstance(instanceId)
+          .withMarcSource()
+      )
+      .getId();
+
+    final JsonObject srsRecordToCreate = buildMarcSourceRecord(marcHoldingsId);
+    final String sourceSrsId = srsRecordToCreate.getString("id");
+    sourceRecordStorageClient.create(srsRecordToCreate);
+
+    String targetLocationId = UUID.randomUUID().toString();
+
+    ResourceClient collegeLocationsClient = ResourceClient.forLocations(collegeOkapiClient);
+    collegeLocationsClient.emulateFailure(
+      new EndpointFailureDescriptor()
+        .setFailureExpireDate(DateTime.now().plusSeconds(5).toDate())
+        .setStatusCode(200)
+        .setContentType("application/json")
+        .setBody(new JsonObject().put("id", targetLocationId).put("code", "").toString())
+        .setMethod(HttpMethod.GET.name())
+        .setUrlPattern("/locations/" + targetLocationId)
+    );
+
+    JsonObject requestBody = new HoldingsRecordUpdateOwnershipRequestBuilder(instanceId,
+      new JsonArray(List.of(marcHoldingsId.toString())), UUID.fromString(targetLocationId), ApiTestSuite.COLLEGE_TENANT_ID).create();
+
+    Response response = updateHoldingsRecordsOwnership(requestBody);
+    collegeLocationsClient.disableFailureEmulation();
+
+    assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+    assertThat(response.getJson().getJsonArray("notUpdatedEntities").size(), is(0));
+
+    List<JsonObject> targetSrsRecords = collegeSourceRecordStorageClient.getMany("matchedId==" + sourceSrsId, 1);
+    assertThat(targetSrsRecords.size(), is(1));
+
+    JsonObject parsedRecord = targetSrsRecords.getFirst().getJsonObject("parsedRecord");
+    JsonObject parsedContent = getParsedContent(parsedRecord);
+    List<String> field852bValues = getField852bValues(parsedContent);
+
+    assertThat(field852bValues.size(), is(1));
+    assertThat(field852bValues.getFirst(), is(targetLocationId));
   }
 
   private JsonObject buildMarcSourceRecord(UUID holdingsId) {

--- a/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
+++ b/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
@@ -1039,6 +1039,58 @@ public class HoldingsUpdateOwnershipApiTest extends ApiTests {
   }
 
   @Test
+  public void shouldReturn400WhenMarcSrsRecordCreationFailsInTargetTenant() throws Exception {
+    UUID instanceId = UUID.randomUUID();
+    JsonObject instance = smallAngryPlanet(instanceId);
+    InstanceApiClient.createInstance(okapiClient, instance.copy().put("source", CONSORTIUM_FOLIO.getValue()));
+    InstanceApiClient.createInstance(consortiumOkapiClient, instance.copy().put("source", FOLIO.getValue()));
+
+    final UUID marcHoldingsId = holdingsStorageClient.create(
+      new HoldingRequestBuilder()
+        .forInstance(instanceId)
+        .withMarcSource())
+      .getId();
+
+    final JsonObject sourceSrsRecord = buildMarcSourceRecord(marcHoldingsId);
+    final String sourceSrsId = sourceSrsRecord.getString("id");
+    sourceRecordStorageClient.create(sourceSrsRecord);
+
+    ensureCollegeTenantLocationExists(getMainLibraryLocation());
+
+    collegeSourceRecordStorageClient.emulateFailure(
+      new EndpointFailureDescriptor()
+        .setFailureExpireDate(DateTime.now().plusSeconds(5).toDate())
+        .setStatusCode(500)
+        .setContentType("application/json")
+        .setBody(new JsonObject().put("message", "target MARC SRS create failed").toString())
+        .setMethod(HttpMethod.POST.name())
+        .setBodyContains(marcHoldingsId.toString())
+    );
+
+    JsonObject requestBody = new HoldingsRecordUpdateOwnershipRequestBuilder(instanceId,
+      new JsonArray(List.of(marcHoldingsId.toString())),
+      UUID.fromString(getMainLibraryLocation()), ApiTestSuite.COLLEGE_TENANT_ID).create();
+
+    Response response = updateHoldingsRecordsOwnership(requestBody);
+    collegeSourceRecordStorageClient.disableFailureEmulation();
+
+    assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
+
+    JsonArray notUpdatedEntities = response.getJson().getJsonArray("notUpdatedEntities");
+    assertThat(notUpdatedEntities.size(), is(1));
+    JsonObject failedEntity = notUpdatedEntities.getJsonObject(0);
+    assertThat(failedEntity.getString("entityId"), is(marcHoldingsId.toString()));
+    assertThat(failedEntity.getString("errorMessage"), containsString("Failed to post SRS record to target tenant=college"));
+
+    // Holdings stays in source tenant when MARC SRS move cannot be completed.
+    assertThat(holdingsStorageClient.getById(marcHoldingsId).getStatusCode(), is(HttpStatus.SC_OK));
+
+    // Source SRS still exists and target SRS is not created.
+    assertThat(sourceRecordStorageClient.getById(UUID.fromString(sourceSrsId)).getStatusCode(), is(HttpStatus.SC_OK));
+    assertThat(collegeSourceRecordStorageClient.getMany("matchedId==" + sourceSrsId, 1).size(), is(0));
+  }
+
+  @Test
   public void shouldDoNothingAndReportAllAsNotUpdatedWhenNoValidHoldingsRemainAfterValidation() throws Exception {
     UUID instanceId = UUID.randomUUID();
     JsonObject instance = smallAngryPlanet(instanceId);

--- a/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
+++ b/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
@@ -835,6 +835,48 @@ public class HoldingsUpdateOwnershipApiTest extends ApiTests {
   }
 
   @Test
+  public void shouldRemoveExisting852bValueRegardlessOfIndicatorsWhenPopulatingLocationCode() throws Exception {
+    UUID instanceId = UUID.randomUUID();
+    JsonObject instance = smallAngryPlanet(instanceId);
+    InstanceApiClient.createInstance(okapiClient, instance.put("source", CONSORTIUM_FOLIO.getValue()));
+    InstanceApiClient.createInstance(consortiumOkapiClient, instance.put("source", FOLIO.getValue()));
+
+    final UUID holdingsId = holdingsStorageClient.create(
+        new HoldingRequestBuilder()
+          .forInstance(instanceId)
+          .withMarcSource()
+      )
+      .getId();
+
+    // Source 852 field carries subfield 'b' under non-blank indicators (e.g. a different cataloging convention).
+    final JsonObject srsRecordToCreate = buildMarcSourceRecord(holdingsId, "4", "0");
+    final String sourceSrsId = srsRecordToCreate.getString("id");
+    sourceRecordStorageClient.create(srsRecordToCreate);
+
+    ensureCollegeTenantLocationExists(getMainLibraryLocation());
+
+    JsonObject requestBody = new HoldingsRecordUpdateOwnershipRequestBuilder(instanceId,
+      new JsonArray(List.of(holdingsId.toString())), UUID.fromString(getMainLibraryLocation()), ApiTestSuite.COLLEGE_TENANT_ID).create();
+
+    Response response = updateHoldingsRecordsOwnership(requestBody);
+
+    assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+    assertThat(response.getJson().getJsonArray("notUpdatedEntities").size(), is(0));
+
+    List<JsonObject> targetSrsRecords = collegeSourceRecordStorageClient.getMany("matchedId==" + sourceSrsId, 1);
+    assertThat(targetSrsRecords.size(), is(1));
+
+    JsonObject parsedRecord = targetSrsRecords.getFirst().getJsonObject("parsedRecord");
+    JsonObject parsedContent = getParsedContent(parsedRecord);
+    List<String> field852bValues = getField852bValues(parsedContent);
+
+    // The stale 852$b under non-blank indicators should be removed, leaving only the freshly populated one.
+    assertEquals(1, field852bValues.size());
+    assertEquals(MAIN_LIBRARY_LOCATION_CODE, field852bValues.getFirst());
+    assertNotEquals("OLD_LOCATION_CODE", field852bValues.getFirst());
+  }
+
+  @Test
   public void shouldFailMarcHoldingsAndMoveFolioHoldingWhenSnapshotCreationFails() throws Exception {
     UUID instanceId = UUID.randomUUID();
     JsonObject instance = smallAngryPlanet(instanceId);
@@ -1548,6 +1590,10 @@ public class HoldingsUpdateOwnershipApiTest extends ApiTests {
   }
 
   private JsonObject buildMarcSourceRecord(UUID holdingsId) {
+    return buildMarcSourceRecord(holdingsId, " ", " ");
+  }
+
+  private JsonObject buildMarcSourceRecord(UUID holdingsId, String ind1, String ind2) {
     final var srsId = UUID.randomUUID();
     return new JsonObject()
       .put("id", srsId.toString())
@@ -1565,8 +1611,8 @@ public class HoldingsUpdateOwnershipApiTest extends ApiTests {
               .put("subfields", new JsonArray()
                 .add(new JsonObject().put("b", "OLD_LOCATION_CODE"))
                 .add(new JsonObject().put("h", "Some call number")))
-              .put("ind1", " ")
-              .put("ind2", " "))))
+              .put("ind1", ind1)
+              .put("ind2", ind2))))
         )
       );
   }

--- a/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
+++ b/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
@@ -1180,7 +1180,7 @@ public class HoldingsUpdateOwnershipApiTest extends ApiTests {
     assertTrue("FOLIO holding should be in target tenant", targetHoldingIds.contains(folioHoldingsId.toString()));
   }
 
-   private JsonObject buildMarcSourceRecord(UUID holdingsId) {
+  private JsonObject buildMarcSourceRecord(UUID holdingsId) {
     final var srsId = UUID.randomUUID();
     return new JsonObject()
       .put("id", srsId.toString())

--- a/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
+++ b/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
@@ -7,6 +7,7 @@ import api.support.InstanceApiClient;
 import api.support.builders.HoldingRequestBuilder;
 import api.support.builders.HoldingsRecordUpdateOwnershipRequestBuilder;
 import api.support.builders.ItemRequestBuilder;
+import api.support.http.StorageInterfaceUrls;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -57,6 +58,7 @@ import static support.matchers.ResponseMatchers.hasValidationError;
 public class HoldingsUpdateOwnershipApiTest extends ApiTests {
   private static final String INSTANCE_ID = "instanceId";
   private static final String ID = "id";
+  private static final String MAIN_LIBRARY_LOCATION_CODE = "NU/JC/DL/ML";
 
   @Before
   public void initConsortia() throws Exception {
@@ -790,6 +792,8 @@ public class HoldingsUpdateOwnershipApiTest extends ApiTests {
     final String sourceSrsId = srsRecordToCreate.getString("id");
     sourceRecordStorageClient.create(srsRecordToCreate);
 
+    ensureCollegeTenantLocationExists(getMainLibraryLocation());
+
     JsonObject requestBody = new HoldingsRecordUpdateOwnershipRequestBuilder(instanceId,
       new JsonArray(List.of(holdingsId.toString())), UUID.fromString(getMainLibraryLocation()), ApiTestSuite.COLLEGE_TENANT_ID).create();
 
@@ -819,6 +823,14 @@ public class HoldingsUpdateOwnershipApiTest extends ApiTests {
     assertNotEquals(sourceSrsId, targetSrsRecord.getString("id"));
     assertEquals(sourceSrsId, targetSrsRecord.getString("matchedId"));
     assertEquals("MARC_HOLDING", targetSrsRecord.getString("recordType"));
+
+    JsonObject parsedRecord = targetSrsRecord.getJsonObject("parsedRecord");
+    JsonObject parsedContent = getParsedContent(parsedRecord);
+
+    List<String> field852bValues = getField852bValues(parsedContent);
+    assertEquals(1, field852bValues.size());
+    assertEquals(MAIN_LIBRARY_LOCATION_CODE, field852bValues.getFirst());
+    assertNotEquals("OLD_LOCATION_CODE", field852bValues.getFirst());
   }
 
   @Test
@@ -1181,12 +1193,69 @@ public class HoldingsUpdateOwnershipApiTest extends ApiTests {
         .put("content", new JsonObject()
           .put("leader", "00000nu  a2200000   4500")
           .put("fields", new JsonArray()
+            .add(new JsonObject().put("001", holdingsId.toString()))
             .add(new JsonObject().put("852", new JsonObject()
-              .put("subfields", new JsonArray().add(new JsonObject().put("h", "Some call number")))
+              .put("subfields", new JsonArray()
+                .add(new JsonObject().put("b", "OLD_LOCATION_CODE"))
+                .add(new JsonObject().put("h", "Some call number")))
               .put("ind1", " ")
               .put("ind2", " "))))
         )
       );
+  }
+
+
+  private List<String> getField852bValues(JsonObject parsedContent) {
+    List<String> values = new java.util.ArrayList<>();
+    JsonArray fields = parsedContent.getJsonArray("fields", new JsonArray());
+    for (int i = 0; i < fields.size(); i++) {
+      JsonObject field = fields.getJsonObject(i);
+      if (field == null || !field.containsKey("852")) {
+        continue;
+      }
+
+      JsonObject dataField = field.getJsonObject("852");
+      JsonArray subfields = dataField.getJsonArray("subfields", new JsonArray());
+      for (int j = 0; j < subfields.size(); j++) {
+        JsonObject subfield = subfields.getJsonObject(j);
+        if (subfield != null && subfield.containsKey("b")) {
+          values.add(subfield.getString("b"));
+        }
+      }
+    }
+    return values;
+  }
+
+  private JsonObject getParsedContent(JsonObject parsedRecord) {
+    Object content = parsedRecord.getValue("content");
+    if (content instanceof JsonObject contentJson) {
+      return contentJson;
+    }
+    if (content instanceof String contentString) {
+      return new JsonObject(contentString);
+    }
+    throw new IllegalStateException("Unexpected parsedRecord.content type: " + (content == null ? "null" : content.getClass().getName()));
+  }
+
+  private void ensureCollegeTenantLocationExists(String locationId)
+    throws ExecutionException, InterruptedException, TimeoutException {
+    JsonObject locationBody = new JsonObject()
+      .put("id", locationId)
+      .put("name", "Main Library (college test fixture)")
+      .put("code", MAIN_LIBRARY_LOCATION_CODE)
+      .put("institutionId", UUID.randomUUID().toString())
+      .put("campusId", UUID.randomUUID().toString())
+      .put("libraryId", UUID.randomUUID().toString())
+      .put("primaryServicePoint", UUID.randomUUID().toString());
+
+    Response createLocationResponse = collegeOkapiClient
+      .post(StorageInterfaceUrls.locationsStorageUrl(""), locationBody)
+      .toCompletableFuture()
+      .get(30, TimeUnit.SECONDS);
+
+    // 201 means created; 422 means already exists in this test environment.
+    assertTrue(createLocationResponse.getStatusCode() == HttpStatus.SC_CREATED
+      || createLocationResponse.getStatusCode() == HttpStatus.SC_UNPROCESSABLE_ENTITY);
   }
 
   private Response updateHoldingsRecordsOwnership(JsonObject holdingsRecordUpdateOwnershipRequestBody) throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {

--- a/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
+++ b/src/test/java/api/holdings/HoldingsUpdateOwnershipApiTest.java
@@ -1391,6 +1391,162 @@ public class HoldingsUpdateOwnershipApiTest extends ApiTests {
     assertThat(field852bValues.getFirst(), is(targetLocationId));
   }
 
+  @Test
+  public void shouldFallbackToLocationIdWhenLocationResponseHasEmptyBody() throws Exception {
+    UUID instanceId = UUID.randomUUID();
+    JsonObject instance = smallAngryPlanet(instanceId);
+    InstanceApiClient.createInstance(okapiClient, instance.copy().put("source", CONSORTIUM_FOLIO.getValue()));
+    InstanceApiClient.createInstance(consortiumOkapiClient, instance.copy().put("source", FOLIO.getValue()));
+
+    final UUID marcHoldingsId = holdingsStorageClient.create(
+        new HoldingRequestBuilder()
+          .forInstance(instanceId)
+          .withMarcSource()
+      )
+      .getId();
+
+    final JsonObject srsRecordToCreate = buildMarcSourceRecord(marcHoldingsId);
+    final String sourceSrsId = srsRecordToCreate.getString("id");
+    sourceRecordStorageClient.create(srsRecordToCreate);
+
+    String targetLocationId = UUID.randomUUID().toString();
+
+    ResourceClient collegeLocationsClient = ResourceClient.forLocations(collegeOkapiClient);
+    collegeLocationsClient.emulateFailure(
+      new EndpointFailureDescriptor()
+        .setFailureExpireDate(DateTime.now().plusSeconds(5).toDate())
+        .setStatusCode(200)
+        .setContentType("application/json")
+        .setBody("")
+        .setMethod(HttpMethod.GET.name())
+        .setUrlPattern("/locations/" + targetLocationId)
+    );
+
+    JsonObject requestBody = new HoldingsRecordUpdateOwnershipRequestBuilder(instanceId,
+      new JsonArray(List.of(marcHoldingsId.toString())), UUID.fromString(targetLocationId), ApiTestSuite.COLLEGE_TENANT_ID).create();
+
+    Response response = updateHoldingsRecordsOwnership(requestBody);
+    collegeLocationsClient.disableFailureEmulation();
+
+    assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+    assertThat(response.getJson().getJsonArray("notUpdatedEntities").size(), is(0));
+
+    List<JsonObject> targetSrsRecords = collegeSourceRecordStorageClient.getMany("matchedId==" + sourceSrsId, 1);
+    assertThat(targetSrsRecords.size(), is(1));
+
+    JsonObject parsedRecord = targetSrsRecords.getFirst().getJsonObject("parsedRecord");
+    JsonObject parsedContent = getParsedContent(parsedRecord);
+    List<String> field852bValues = getField852bValues(parsedContent);
+
+    // Operation should complete and use locationId as fallback when the location response has no body at all.
+    assertThat(field852bValues.size(), is(1));
+    assertThat(field852bValues.getFirst(), is(targetLocationId));
+  }
+
+  @Test
+  public void shouldFallbackToLocationIdWhenLocationResponseHasNoCodeField() throws Exception {
+    UUID instanceId = UUID.randomUUID();
+    JsonObject instance = smallAngryPlanet(instanceId);
+    InstanceApiClient.createInstance(okapiClient, instance.copy().put("source", CONSORTIUM_FOLIO.getValue()));
+    InstanceApiClient.createInstance(consortiumOkapiClient, instance.copy().put("source", FOLIO.getValue()));
+
+    final UUID marcHoldingsId = holdingsStorageClient.create(
+        new HoldingRequestBuilder()
+          .forInstance(instanceId)
+          .withMarcSource()
+      )
+      .getId();
+
+    final JsonObject srsRecordToCreate = buildMarcSourceRecord(marcHoldingsId);
+    final String sourceSrsId = srsRecordToCreate.getString("id");
+    sourceRecordStorageClient.create(srsRecordToCreate);
+
+    String targetLocationId = UUID.randomUUID().toString();
+
+    ResourceClient collegeLocationsClient = ResourceClient.forLocations(collegeOkapiClient);
+    collegeLocationsClient.emulateFailure(
+      new EndpointFailureDescriptor()
+        .setFailureExpireDate(DateTime.now().plusSeconds(5).toDate())
+        .setStatusCode(200)
+        .setContentType("application/json")
+        .setBody(new JsonObject().put("id", targetLocationId).toString())
+        .setMethod(HttpMethod.GET.name())
+        .setUrlPattern("/locations/" + targetLocationId)
+    );
+
+    JsonObject requestBody = new HoldingsRecordUpdateOwnershipRequestBuilder(instanceId,
+      new JsonArray(List.of(marcHoldingsId.toString())), UUID.fromString(targetLocationId), ApiTestSuite.COLLEGE_TENANT_ID).create();
+
+    Response response = updateHoldingsRecordsOwnership(requestBody);
+    collegeLocationsClient.disableFailureEmulation();
+
+    assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+    assertThat(response.getJson().getJsonArray("notUpdatedEntities").size(), is(0));
+
+    List<JsonObject> targetSrsRecords = collegeSourceRecordStorageClient.getMany("matchedId==" + sourceSrsId, 1);
+    assertThat(targetSrsRecords.size(), is(1));
+
+    JsonObject parsedRecord = targetSrsRecords.getFirst().getJsonObject("parsedRecord");
+    JsonObject parsedContent = getParsedContent(parsedRecord);
+    List<String> field852bValues = getField852bValues(parsedContent);
+
+    // Operation should complete and use locationId as fallback when the location response has no "code" field at all.
+    assertThat(field852bValues.size(), is(1));
+    assertThat(field852bValues.getFirst(), is(targetLocationId));
+  }
+
+  @Test
+  public void shouldMarkHoldingAsNotUpdatedWhenSourceSrsRecordDeleteFails() throws Exception {
+    UUID instanceId = UUID.randomUUID();
+    JsonObject instance = smallAngryPlanet(instanceId);
+    InstanceApiClient.createInstance(okapiClient, instance.copy().put("source", CONSORTIUM_FOLIO.getValue()));
+    InstanceApiClient.createInstance(consortiumOkapiClient, instance.copy().put("source", FOLIO.getValue()));
+
+    final UUID marcHoldingsId = holdingsStorageClient.create(
+        new HoldingRequestBuilder()
+          .forInstance(instanceId)
+          .withMarcSource()
+      )
+      .getId();
+
+    final JsonObject srsRecordToCreate = buildMarcSourceRecord(marcHoldingsId);
+    final String sourceSrsId = srsRecordToCreate.getString("id");
+    sourceRecordStorageClient.create(srsRecordToCreate);
+
+    final JsonObject expectedErrorResponse = new JsonObject().put("message", "Internal Server Error: Delete failed");
+    sourceRecordStorageClient.emulateFailure(
+      new EndpointFailureDescriptor()
+        .setFailureExpireDate(DateTime.now().plusSeconds(5).toDate())
+        .setStatusCode(500)
+        .setContentType("application/json")
+        .setBody(expectedErrorResponse.toString())
+        .setMethod(HttpMethod.DELETE.name())
+    );
+
+    JsonObject requestBody = new HoldingsRecordUpdateOwnershipRequestBuilder(instanceId,
+      new JsonArray(List.of(marcHoldingsId.toString())), UUID.fromString(getMainLibraryLocation()), ApiTestSuite.COLLEGE_TENANT_ID).create();
+
+    Response response = updateHoldingsRecordsOwnership(requestBody);
+    sourceRecordStorageClient.disableFailureEmulation();
+
+    assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
+
+    JsonArray notUpdatedEntities = response.getJson().getJsonArray("notUpdatedEntities");
+    assertThat(notUpdatedEntities.size(), is(1));
+    assertThat(notUpdatedEntities.getJsonObject(0).getString("entityId"), is(marcHoldingsId.toString()));
+    assertThat(notUpdatedEntities.getJsonObject(0).getString("errorMessage"), containsString(expectedErrorResponse.toString()));
+
+    // Source holding is kept since the migration did not fully complete.
+    assertThat(holdingsStorageClient.getById(marcHoldingsId).getStatusCode(), is(HttpStatus.SC_OK));
+
+    // The SRS record was already posted to the target tenant before the delete step failed.
+    List<JsonObject> targetSrsRecords = collegeSourceRecordStorageClient.getMany("matchedId==" + sourceSrsId, 1);
+    assertThat(targetSrsRecords.size(), is(1));
+
+    // Source SRS record still exists because its deletion failed.
+    assertThat(sourceRecordStorageClient.getById(UUID.fromString(sourceSrsId)).getStatusCode(), is(HttpStatus.SC_OK));
+  }
+
   private JsonObject buildMarcSourceRecord(UUID holdingsId) {
     final var srsId = UUID.randomUUID();
     return new JsonObject()

--- a/src/test/java/org/folio/inventory/dataimport/cache/MappingMetadataCacheTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/cache/MappingMetadataCacheTest.java
@@ -42,7 +42,7 @@ public class MappingMetadataCacheTest {
   private final Vertx vertx = Vertx.vertx();
 
   private final MappingMetadataCache mappingMetadataCache = MappingMetadataCache.getInstance(vertx,
-    vertx.createHttpClient());
+    vertx.createHttpClient(), true);
 
   @Rule
   public WireMockRule mockServer = new WireMockRule(


### PR DESCRIPTION
…nership

The fix in UpdateOwnershipApi.java and MoveApiUtil.java:
- Adds a CollectionResourceClient for /locations on the target tenant (InventoryClientFactory.java, InventoryClientFactoryImpl.java).
- Before building the target SRS record, fetches the target holding's permanent location, reads its code, strips any existing 852 $b value(s), and writes the new code in.
- Falls back to the raw locationId if the location can't be fetched or has no code