### PR TITLE
fix(matching): Fix consortium subsequent matching

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
@@ -93,7 +93,9 @@ public abstract class AbstractMatchEventHandler implements EventHandler {
     var savedMultiMatchIds = dataImportEventPayload.getContext().get(MULTI_MATCH_IDS);
     var savedInstancesIds = dataImportEventPayload.getContext().get(INSTANCES_IDS);
     var entityJson = dataImportEventPayload.getContext().get(getEntityType().value());
-    var savedInstanceId = StringUtils.isNotEmpty(entityJson) ? new JsonObject(entityJson).getString("id") : null;
+    // Only extract an ID when the value is a JSON object; item submatch stores a JSON array here.
+    var savedInstanceId = StringUtils.isNotEmpty(entityJson) && entityJson.charAt(0) == '{'
+      ? new JsonObject(entityJson).getString("id") : null;
 
     return MatchingManager.match(dataImportEventPayload)
       .thenCompose(matchedLocal -> {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
@@ -1,6 +1,7 @@
 package org.folio.inventory.dataimport.handlers.matching;
 
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -91,11 +92,13 @@ public abstract class AbstractMatchEventHandler implements EventHandler {
 
     var savedMultiMatchIds = dataImportEventPayload.getContext().get(MULTI_MATCH_IDS);
     var savedInstancesIds = dataImportEventPayload.getContext().get(INSTANCES_IDS);
+    var entityJson = dataImportEventPayload.getContext().get(getEntityType().value());
+    var savedInstanceId = StringUtils.isNotEmpty(entityJson) ? new JsonObject(entityJson).getString("id") : null;
 
     return MatchingManager.match(dataImportEventPayload)
       .thenCompose(matchedLocal -> {
         if (isConsortiumActionAvailable()) {
-          return matchCentralTenantIfNeeded(dataImportEventPayload, matchedLocal, context, mappingMetadataDto, matchingParametersRelations, savedMultiMatchIds, savedInstancesIds);
+          return matchCentralTenantIfNeeded(dataImportEventPayload, matchedLocal, context, mappingMetadataDto, matchingParametersRelations, savedMultiMatchIds, savedInstancesIds, savedInstanceId);
         }
         return CompletableFuture.completedFuture(matchedLocal);
       });
@@ -103,7 +106,7 @@ public abstract class AbstractMatchEventHandler implements EventHandler {
 
   private CompletableFuture<Boolean> matchCentralTenantIfNeeded(DataImportEventPayload dataImportEventPayload, boolean isMatchedLocal, Context context,
                                                                 MappingMetadataDto mappingMetadataDto, MatchingParametersRelations matchingParametersRelations,
-                                                                String savedMultiMatchIds, String savedInstancesIds) {
+                                                                String savedMultiMatchIds, String savedInstancesIds, String savedInstanceId) {
     LOGGER.debug("matchCentralTenantIfNeeded :: dataImportEventPayload.tenant: {}, isMatchedLocal: {}", dataImportEventPayload.getTenant(), isMatchedLocal);
     return consortiumService.getConsortiumConfiguration(context)
       .toCompletionStage().toCompletableFuture()
@@ -114,6 +117,9 @@ public abstract class AbstractMatchEventHandler implements EventHandler {
           var localMatchedInstance = dataImportEventPayload.getContext().get(getEntityType().value());
           var localCallMultiMatchIds = dataImportEventPayload.getContext().get(MULTI_MATCH_IDS);
           var localCallInstancesIds = dataImportEventPayload.getContext().get(INSTANCES_IDS);
+          if (savedInstanceId != null && savedMultiMatchIds == null && savedInstancesIds == null) {
+            dataImportEventPayload.getContext().put(MULTI_MATCH_IDS, new JsonArray().add(savedInstanceId).encode());
+          }
           preparePayloadBeforeConsortiumProcessing(dataImportEventPayload, consortiumConfiguration.get(), mappingMetadataDto, matchingParametersRelations, savedMultiMatchIds, savedInstancesIds);
           return MatchingManager.match(dataImportEventPayload)
             .thenCompose(isMatchedConsortium -> {

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchInstanceEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchInstanceEventHandlerUnitTest.java
@@ -906,6 +906,70 @@ public class MatchInstanceEventHandlerUnitTest {
   }
 
   @Test
+  public void shouldScopeSubMatchCentralQueryBySingleInstanceIdFromPreviousMatchOnConsortium(TestContext testContext)
+    throws UnsupportedEncodingException {
+    var async = testContext.async();
+
+    var centralTenantId = "consortium";
+    var consortiumId = "consortiumId";
+
+    // SC1: same UUID as SH1 (shadow copy relationship)
+    var shadowInstance = createInstance();   // local shadow SH1, UUID = INSTANCE_ID
+    var centralInstance = createInstance();  // central original SC1, same UUID = INSTANCE_ID
+    var anotherCentralUuid = UUID.randomUUID().toString();
+    var anotherCentralInstance = new Instance(anotherCentralUuid, 5, "in9999999", "MARC", "Another", "99999");
+
+    var centralInstanceCollection = mock(InstanceCollection.class);
+    when(storage.getInstanceCollection(Mockito.argThat(ctx -> ctx.getTenantId().equals(centralTenantId))))
+      .thenReturn(centralInstanceCollection);
+
+    doAnswer(inv -> Future.succeededFuture(Optional.of(new ConsortiumConfiguration(centralTenantId, consortiumId))))
+      .when(consortiumService).getConsortiumConfiguration(any());
+
+    // Local: scoped by INSTANCE_ID -> finds SH1 (shadow, same UUID)
+    doAnswer(ans -> {
+      Consumer<Success<MultipleRecords<Instance>>> callback = ans.getArgument(2);
+      callback.accept(new Success<>(new MultipleRecords<>(singletonList(shadowInstance), 1)));
+      return null;
+    }).when(instanceCollection)
+      .findByCql(eq(format("hrid == \"%s\" AND id == \"%s\"", INSTANCE_HRID, INSTANCE_ID)),
+        any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    // Central: scoped by INSTANCE_ID (expected after fix) -> finds SC1 only
+    doAnswer(ans -> {
+      Consumer<Success<MultipleRecords<Instance>>> callback = ans.getArgument(2);
+      callback.accept(new Success<>(new MultipleRecords<>(singletonList(centralInstance), 1)));
+      return null;
+    }).when(centralInstanceCollection)
+      .findByCql(eq(format("hrid == \"%s\" AND id == (%s)", INSTANCE_HRID, INSTANCE_ID)),
+        any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    // Central: unscoped query (what happens WITHOUT Fix #3) -> 2 results -> should trigger error
+    doAnswer(ans -> {
+      Consumer<Success<MultipleRecords<Instance>>> callback = ans.getArgument(2);
+      callback.accept(new Success<>(new MultipleRecords<>(asList(centralInstance, anotherCentralInstance), 2)));
+      return null;
+    }).when(centralInstanceCollection)
+      .findByCql(eq(format("hrid == \"%s\"", INSTANCE_HRID)),
+        any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    // Context simulates state after Match 1: INSTANCE = SC1 (central original, uuid = INSTANCE_ID)
+    var context = new HashMap<String, String>();
+    context.put(INSTANCE.value(), JsonObject.mapFrom(centralInstance).encode());
+    context.put(MAPPING_PARAMS, LOCATIONS_PARAMS);
+    context.put(RELATIONS, MATCHING_RELATIONS);
+    var eventPayload = createEventPayload().withContext(context);
+
+    eventHandler.handle(eventPayload).whenComplete((processed, throwable) -> {
+      testContext.assertNull(throwable);
+      testContext.assertEquals(DI_INVENTORY_INSTANCE_MATCHED.value(), processed.getEventType());
+      testContext.assertEquals(INSTANCE_ID,
+        new JsonObject(processed.getContext().get(INSTANCE.value())).getString(ID_FIELD));
+      async.complete();
+    });
+  }
+
+  @Test
   public void shouldPreserveMultiMatchIdsScopeForCentralTenantQueryInConsortium(TestContext testContext)
     throws UnsupportedEncodingException {
     var async = testContext.async();


### PR DESCRIPTION
### Purpose
Fix case when first single match is ignored in subsequent consortium match

### Approach
Previous fix passed multi-match result into a subsequent match for a member tenant but didn't account for a case when first match yields only one result which requires another parameter passing.
Pass matched instance id

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINV-1400](https://folio-org.atlassian.net/browse/MODINV-1400)