### PR TITLE
fix(matching): Fix multi-match exception is thrown when local matched instance is null

### DIFF
--- a/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/matching/AbstractMatchEventHandler.java
@@ -126,7 +126,8 @@ public abstract class AbstractMatchEventHandler implements EventHandler {
           return MatchingManager.match(dataImportEventPayload)
             .thenCompose(isMatchedConsortium -> {
               dataImportEventPayload.setTenant(context.getTenantId());
-              if (Boolean.TRUE.equals(isMatchedConsortium) && isMatchedLocal && !isShadowEntity(localMatchedInstance, dataImportEventPayload.getContext().get(getEntityType().value()))) {
+              if (Boolean.TRUE.equals(isMatchedConsortium) && isMatchedLocal && localMatchedInstance != null
+                && !isShadowEntity(localMatchedInstance, dataImportEventPayload.getContext().get(getEntityType().value()))) {
                 LOGGER.warn("matchCentralTenantIfNeeded:: Found multiple results during matching on local tenant: {} and central tenant: {} ",
                   context.getTenantId(), consortiumConfiguration.get().getCentralTenantId());
                 return CompletableFuture.failedFuture(new MatchingException(String.format(FOUND_MULTIPLE_ENTITIES, context.getTenantId(), consortiumConfiguration.get().getCentralTenantId())));

--- a/src/test/java/org/folio/inventory/eventhandlers/MatchInstanceEventHandlerUnitTest.java
+++ b/src/test/java/org/folio/inventory/eventhandlers/MatchInstanceEventHandlerUnitTest.java
@@ -742,19 +742,36 @@ public class MatchInstanceEventHandlerUnitTest {
   @Test
   public void shouldPutMultipleMatchResultToPayloadOnHandleEventPayload(TestContext testContext)
     throws UnsupportedEncodingException {
+    // Also covers the consortium case: when central tenant has shadow copies of the same instances,
+    // both sides return MULTI_MATCH_IDS and no "Found multiple entities" error should be thrown.
     Async async = testContext.async();
+
+    String centralTenantId = "consortium";
+    String consortiumId = "consortiumId";
     List<Instance> matchedInstances = List.of(
       new Instance(UUID.randomUUID().toString(), 1, "in1", "MARC", "Wonderful", "12334"),
       new Instance(UUID.randomUUID().toString(), 1, "in2", "MARC", "Wonderful", "12334"));
 
+    doAnswer(inv -> Future.succeededFuture(Optional.of(new ConsortiumConfiguration(centralTenantId, consortiumId))))
+      .when(consortiumService).getConsortiumConfiguration(any());
+
+    // Local: unscoped query -> 2 instances -> MULTI_MATCH_IDS
     doAnswer(invocation -> {
       Consumer<Success<MultipleRecords<Instance>>> successHandler = invocation.getArgument(2);
-      Success<MultipleRecords<Instance>> result =
-        new Success<>(new MultipleRecords<>(matchedInstances, 2));
-      successHandler.accept(result);
+      successHandler.accept(new Success<>(new MultipleRecords<>(matchedInstances, 2)));
       return null;
     }).when(instanceCollection)
       .findByCql(eq(format("hrid == \"%s\"", INSTANCE_HRID)),
+        any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
+
+    // Central: same instances returned for the MULTI_MATCH_IDS-scoped query (shadow copies)
+    doAnswer(invocation -> {
+      Consumer<Success<MultipleRecords<Instance>>> successHandler = invocation.getArgument(2);
+      successHandler.accept(new Success<>(new MultipleRecords<>(matchedInstances, 2)));
+      return null;
+    }).when(instanceCollection)
+      .findByCql(eq(format("hrid == \"%s\" AND id == (%s OR %s)", INSTANCE_HRID,
+          matchedInstances.get(0).getId(), matchedInstances.get(1).getId())),
         any(PagingParameters.class), any(Consumer.class), any(Consumer.class));
 
     MatchProfile subMatchProfile = new MatchProfile()


### PR DESCRIPTION
### Purpose
Fix multi-match exception is thrown when local matched instance is null.
Shadow copy check fails because of the multi-match

### Approach
Check that local matched instance is not null before shadow copy check. In case of multi-match it would be null although found local record would be in fact shadow copies.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINV-1400](https://folio-org.atlassian.net/browse/MODINV-1400)