### PR TITLE
MODINV-1410: Imported MARC Bib with 999ff (using "Modify action") is incorrectly linked to Instance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 22.1.0-SNAPSHOT 2026-mm-dd
+* Imported MARC Bib with 999ff (using "Modify action") is incorrectly linked to Instance [MODINV-1410](https://folio-org.atlassian.net/browse/MODINV-1410)
 * Data Import profiles will map invalid statistical codes [MODINV-1391](https://folio-org.atlassian.net/browse/MODINV-1391)
 * Importing Records from BNE z39.50 - record not available error [MODINV-1395](https://folio-org.atlassian.net/browse/MODINV-1395)
 * Fix match results not passed to subsequent matches for consortium tenants [MODINV-1400](https://folio-org.atlassian.net/browse/MODINV-1400)

--- a/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/DataImportConsumerVerticle.java
@@ -81,7 +81,7 @@ public class DataImportConsumerVerticle extends KafkaConsumerVerticle {
     var consortiumDataCache = new ConsortiumDataCache(vertx, getHttpClient());
 
     var dataImportKafkaHandler = new DataImportKafkaHandler(vertx, getStorage(), getHttpClient(), getProfileSnapshotCache(),
-      getKafkaConfig(), getMappingMetadataCache(), consortiumDataCache, cancelledJobsIdsCache);
+      getKafkaConfig(), getMappingMetadataCache(), getDeleteRuleFor999FieldCache(), consortiumDataCache, cancelledJobsIdsCache);
 
     var futures = EVENT_TYPES.stream()
       .map(type -> super.createConsumer(type.value(), LOAD_LIMIT_PROPERTY))

--- a/src/main/java/org/folio/inventory/dataimport/cache/DeleteRuleFor999FieldCache.java
+++ b/src/main/java/org/folio/inventory/dataimport/cache/DeleteRuleFor999FieldCache.java
@@ -1,8 +1,11 @@
 package org.folio.inventory.dataimport.cache;
 
-import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.AsyncCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -13,20 +16,21 @@ import org.folio.rest.jaxrs.model.MarcSubfield;
 
 /**
  * Cache that memoizes, per {@link MappingProfile} id, whether the profile contains at least one
- * MARC-modification rule with action {@link MarcMappingDetail.Action#DELETE} targeting field "999" and
- * at least one of subfields $i, $s or wildcard {@code *} (all other subfields are ignored).
+ * MARC-modification rule with action {@link MarcMappingDetail.Action#DELETE} targeting field "999"
+ * and at least one of subfields $i, $s or wildcard {@code *} (all other subfields are ignored).
  * <p>
  * Keyed by MappingProfile id (stable UUID). Value is {@link Boolean}. Used by
  * {@code AbstractModifyEventHandler} to skip the {@code externalIdsHolder} synchronization step
  * when the profile does not delete 999 (i.e., typical case), avoiding the JSON decode/encode cost.
  * <p>
  * Uses the same {@link Caffeine} configuration style as {@link MappingMetadataCache}
- * (expireAfterAccess). Expiration is configurable via the {@value #CACHE_EXPIRATION_TIME_ENV}
- * system property (seconds); default {@value #DEFAULT_EXPIRATION_TIME_SECONDS} seconds.
+ * (expireAfterAccess, {@link AsyncCache} with a Vertx-bound executor). Expiration is configurable
+ * via the {@value #CACHE_EXPIRATION_TIME_ENV} system property (seconds);
+ * default {@value #DEFAULT_EXPIRATION_TIME_SECONDS} seconds.
  */
 public final class DeleteRuleFor999FieldCache {
 
-  private static final Logger LOGGER = LogManager.getLogger();
+  private static final Logger LOGGER = LogManager.getLogger(DeleteRuleFor999FieldCache.class);
   private static final String CACHE_EXPIRATION_TIME_ENV = "inventory.delete-999-rule-cache.expiration.time.seconds";
   private static final String DEFAULT_EXPIRATION_TIME_SECONDS = "3600";
   private static final String TAG_999 = "999";
@@ -39,35 +43,48 @@ public final class DeleteRuleFor999FieldCache {
    */
   private static final List<String> TARGET_999_SUBFIELDS = List.of("i", "s", "*");
 
-  private static final DeleteRuleFor999FieldCache INSTANCE = new DeleteRuleFor999FieldCache(resolveCacheExpirationSeconds());
+  private static DeleteRuleFor999FieldCache instance = null;
 
-  private final Cache<String, Boolean> cache;
+  private final AsyncCache<String, Boolean> cache;
 
-  DeleteRuleFor999FieldCache(long cacheExpirationTimeSeconds) {
+  public DeleteRuleFor999FieldCache(Vertx vertx, long cacheExpirationTimeSeconds) {
     this.cache = Caffeine.newBuilder()
       .expireAfterAccess(cacheExpirationTimeSeconds, TimeUnit.SECONDS)
-      .build();
+      .executor(task -> vertx.runOnContext(v -> task.run()))
+      .buildAsync();
     LOGGER.info("DeleteRuleFor999FieldCache initialized with expireAfterAccess={}s", cacheExpirationTimeSeconds);
   }
 
-  public static DeleteRuleFor999FieldCache getInstance() {
-    return INSTANCE;
+  public static DeleteRuleFor999FieldCache getInstance(Vertx vertx) {
+    return getInstance(vertx, false);
   }
 
   /**
-   * Returns {@code true} when the given {@link MappingProfile} contains a DELETE rule for MARC field 999
-   * targeting $i, $s or wildcard {@code *} subfield. Rules that only touch other 999 subfields
-   * (e.g. $l, $t) are ignored. Result is memoized by profile id.
+   * Used for testing.
    */
-  public boolean containsDeleteRuleFor999Field(MappingProfile mappingProfile) {
+  public static synchronized DeleteRuleFor999FieldCache getInstance(Vertx vertx, boolean returnNew) {
+    if (instance == null || returnNew) {
+      instance = new DeleteRuleFor999FieldCache(vertx, resolveCacheExpirationSeconds());
+    }
+    return instance;
+  }
+
+  /**
+   * Returns a {@link Future} completing with {@code true} when the given {@link MappingProfile}
+   * contains a DELETE rule for MARC field 999 targeting $i, $s or wildcard {@code *} subfield.
+   * Rules that only touch other 999 subfields (e.g. $l, $t) are ignored.
+   * Result is memoized by profile id.
+   */
+  public Future<Boolean> containsDeleteRuleFor999Field(MappingProfile mappingProfile) {
     if (mappingProfile == null) {
-      return false;
+      return Future.succeededFuture(false);
     }
     String key = mappingProfile.getId();
     if (StringUtils.isBlank(key)) {
-      return computeContainsDeleteRuleFor999Field(mappingProfile);
+      return Future.succeededFuture(computeContainsDeleteRuleFor999Field(mappingProfile));
     }
-    return cache.get(key, k -> computeContainsDeleteRuleFor999Field(mappingProfile));
+    return Future.fromCompletionStage(cache.get(key,
+      (k, executor) -> CompletableFuture.completedFuture(computeContainsDeleteRuleFor999Field(mappingProfile))));
   }
 
   private static boolean computeContainsDeleteRuleFor999Field(MappingProfile mappingProfile) {

--- a/src/main/java/org/folio/inventory/dataimport/cache/DeleteRuleFor999FieldCache.java
+++ b/src/main/java/org/folio/inventory/dataimport/cache/DeleteRuleFor999FieldCache.java
@@ -1,0 +1,132 @@
+package org.folio.inventory.dataimport.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.MappingProfile;
+import org.folio.rest.jaxrs.model.MarcMappingDetail;
+import org.folio.rest.jaxrs.model.MarcSubfield;
+
+/**
+ * Cache that memoizes, per {@link MappingProfile} id, whether the profile contains at least one
+ * MARC-modification rule with action {@link MarcMappingDetail.Action#DELETE} targeting field "999" and
+ * at least one of subfields $i, $s or wildcard {@code *} (all other subfields are ignored).
+ * <p>
+ * Keyed by MappingProfile id (stable UUID). Value is {@link Boolean}. Used by
+ * {@code AbstractModifyEventHandler} to skip the {@code externalIdsHolder} synchronization step
+ * when the profile does not delete 999 (i.e., typical case), avoiding the JSON decode/encode cost.
+ * <p>
+ * Uses the same {@link Caffeine} configuration style as {@link MappingMetadataCache}
+ * (expireAfterAccess). Expiration is configurable via the {@value #CACHE_EXPIRATION_TIME_ENV}
+ * system property (seconds); default {@value #DEFAULT_EXPIRATION_TIME_SECONDS} seconds.
+ */
+public final class DeleteRuleFor999FieldCache {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+  private static final String CACHE_EXPIRATION_TIME_ENV = "inventory.delete-999-rule-cache.expiration.time.seconds";
+  private static final String DEFAULT_EXPIRATION_TIME_SECONDS = "3600";
+  private static final String TAG_999 = "999";
+  /**
+   * Subfield codes that make the DELETE-999 rule relevant to {@code externalIdsHolder} sync:
+   * {@code i} (instance id backlink), {@code s} (matched id / SRS record id), and {@code *}
+   * (wildcard - whole field removal, which implicitly includes $i and $s).
+   * Any DELETE-999 rule targeting only other subfields (e.g. $l, $t) is ignored because it
+   * does not affect the 999$i value that the holder mirrors.
+   */
+  private static final List<String> TARGET_999_SUBFIELDS = List.of("i", "s", "*");
+
+  private static final DeleteRuleFor999FieldCache INSTANCE = new DeleteRuleFor999FieldCache(resolveCacheExpirationSeconds());
+
+  private final Cache<String, Boolean> cache;
+
+  DeleteRuleFor999FieldCache(long cacheExpirationTimeSeconds) {
+    this.cache = Caffeine.newBuilder()
+      .expireAfterAccess(cacheExpirationTimeSeconds, TimeUnit.SECONDS)
+      .build();
+    LOGGER.info("DeleteRuleFor999FieldCache initialized with expireAfterAccess={}s", cacheExpirationTimeSeconds);
+  }
+
+  public static DeleteRuleFor999FieldCache getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Returns {@code true} when the given {@link MappingProfile} contains a DELETE rule for MARC field 999
+   * targeting $i, $s or wildcard {@code *} subfield. Rules that only touch other 999 subfields
+   * (e.g. $l, $t) are ignored. Result is memoized by profile id.
+   */
+  public boolean containsDeleteRuleFor999Field(MappingProfile mappingProfile) {
+    if (mappingProfile == null) {
+      return false;
+    }
+    String key = mappingProfile.getId();
+    if (StringUtils.isBlank(key)) {
+      return computeContainsDeleteRuleFor999Field(mappingProfile);
+    }
+    return cache.get(key, k -> computeContainsDeleteRuleFor999Field(mappingProfile));
+  }
+
+  private static boolean computeContainsDeleteRuleFor999Field(MappingProfile mappingProfile) {
+    if (mappingProfile.getMappingDetails() == null
+        || mappingProfile.getMappingDetails().getMarcMappingDetails() == null) {
+      return false;
+    }
+    for (MarcMappingDetail detail : mappingProfile.getMappingDetails().getMarcMappingDetails()) {
+      if (detail == null || detail.getAction() != MarcMappingDetail.Action.DELETE || detail.getField() == null) {
+        continue;
+      }
+      if (!TAG_999.equals(detail.getField().getField())) {
+        continue;
+      }
+      if (ruleTargetsRelevantSubfield(detail)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns {@code true} only if the DELETE rule for tag 999 targets at least one of
+   * {@link #TARGET_999_SUBFIELDS} ($i, $s or wildcard *). Rules targeting only other subfields
+   * (e.g. $l, $t) are considered irrelevant to the {@code externalIdsHolder} synchronization.
+   * A rule with no subfields specified is treated as targeting the whole field (wildcard-equivalent)
+   * and therefore returns {@code true}.
+   */
+  private static boolean ruleTargetsRelevantSubfield(MarcMappingDetail detail) {
+    List<MarcSubfield> subfields = detail.getField().getSubfields();
+    if (subfields == null || subfields.isEmpty()) {
+      return true;
+    }
+    for (MarcSubfield subfield : subfields) {
+      if (subfield == null) {
+        continue;
+      }
+      String code = subfield.getSubfield();
+      if (code != null && TARGET_999_SUBFIELDS.contains(code)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static long resolveCacheExpirationSeconds() {
+    String raw = System.getProperty(CACHE_EXPIRATION_TIME_ENV);
+    if (StringUtils.isBlank(raw)) {
+      raw = System.getenv(CACHE_EXPIRATION_TIME_ENV.replace('.', '_').replace('-', '_').toUpperCase());
+    }
+    if (StringUtils.isBlank(raw)) {
+      raw = DEFAULT_EXPIRATION_TIME_SECONDS;
+    }
+    try {
+      return Long.parseLong(raw);
+    } catch (NumberFormatException e) {
+      LOGGER.warn("Invalid value for {} = '{}', falling back to default {}s",
+        CACHE_EXPIRATION_TIME_ENV, raw, DEFAULT_EXPIRATION_TIME_SECONDS);
+      return Long.parseLong(DEFAULT_EXPIRATION_TIME_SECONDS);
+    }
+  }
+}

--- a/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/consumers/DataImportKafkaHandler.java
@@ -25,6 +25,7 @@ import org.folio.inventory.dataimport.InstanceWriterFactory;
 import org.folio.inventory.dataimport.ItemWriterFactory;
 import org.folio.inventory.dataimport.ItemsMapperFactory;
 import org.folio.inventory.dataimport.cache.CancelledJobsIdsCache;
+import org.folio.inventory.dataimport.cache.DeleteRuleFor999FieldCache;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.cache.ProfileSnapshotCache;
 import org.folio.inventory.dataimport.handlers.actions.CreateHoldingEventHandler;
@@ -107,6 +108,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
   private final Vertx vertx;
   private final ProfileSnapshotCache profileSnapshotCache;
   private final MappingMetadataCache mappingMetadataCache;
+  private final DeleteRuleFor999FieldCache deleteRuleFor999FieldCache;
   private final KafkaConfig kafkaConfig;
   private final OrderHelperService orderHelperService;
   private final ConsortiumService consortiumService;
@@ -116,11 +118,13 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
                                 ProfileSnapshotCache profileSnapshotCache,
                                 KafkaConfig kafkaConfig,
                                 MappingMetadataCache mappingMetadataCache,
+                                DeleteRuleFor999FieldCache deleteRuleFor999FieldCache,
                                 ConsortiumDataCache consortiumDataCache,
                                 CancelledJobsIdsCache cancelledJobsIdCache) {
     this.vertx = vertx;
     this.profileSnapshotCache = profileSnapshotCache;
     this.mappingMetadataCache = mappingMetadataCache;
+    this.deleteRuleFor999FieldCache = deleteRuleFor999FieldCache;
     this.kafkaConfig = kafkaConfig;
     this.cancelledJobsIdCache = cancelledJobsIdCache;
     orderHelperService = new OrderHelperServiceImpl(profileSnapshotCache);
@@ -263,7 +267,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     EventManager.registerEventHandler(new UpdateHoldingEventHandler(storage, mappingMetadataCache));
     EventManager.registerEventHandler(new ReplaceInstanceEventHandler(storage, precedingSucceedingTitlesHelper, mappingMetadataCache, client, consortiumService, instanceLinkClient, snapshotService));
     EventManager.registerEventHandler(new MarcBibModifiedPostProcessingEventHandler(new InstanceUpdateDelegate(storage), precedingSucceedingTitlesHelper, mappingMetadataCache));
-    EventManager.registerEventHandler(new MarcBibModifyEventHandler(mappingMetadataCache, new InstanceUpdateDelegate(storage), precedingSucceedingTitlesHelper, client));
+    EventManager.registerEventHandler(new MarcBibModifyEventHandler(mappingMetadataCache, deleteRuleFor999FieldCache, new InstanceUpdateDelegate(storage), precedingSucceedingTitlesHelper, client));
   }
 
   private boolean shouldSkipEventProcessing(DataImportEventPayload eventPayload) {

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/modify/AbstractModifyEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/modify/AbstractModifyEventHandler.java
@@ -62,12 +62,15 @@ public abstract class AbstractModifyEventHandler implements EventHandler {
   private static final int MAX_RETRIES_COUNT = Integer.parseInt(System.getenv().getOrDefault("inventory.di.ol.retry.number", "1"));
   private static final String FAILED_TO_UPDATE_RECORD_ERROR_MESSAGE = "Failed to update MARC record with id: %s during modify for tenant %s. ";
   private final MappingMetadataCache mappingMetadataCache;
+  private final DeleteRuleFor999FieldCache deleteRuleFor999FieldCache;
   private final InstanceUpdateDelegate instanceUpdateDelegate;
   private final PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper;
   private final HttpClient client;
 
-  protected AbstractModifyEventHandler(MappingMetadataCache mappingMetadataCache, InstanceUpdateDelegate instanceUpdateDelegate, PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper, HttpClient client) {
+  protected AbstractModifyEventHandler(MappingMetadataCache mappingMetadataCache, DeleteRuleFor999FieldCache deleteRuleFor999FieldCache,
+                                       InstanceUpdateDelegate instanceUpdateDelegate, PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper, HttpClient client) {
     this.mappingMetadataCache = mappingMetadataCache;
+    this.deleteRuleFor999FieldCache = deleteRuleFor999FieldCache;
     this.instanceUpdateDelegate = instanceUpdateDelegate;
     this.precedingSucceedingTitlesHelper = precedingSucceedingTitlesHelper;
     this.client = client;
@@ -133,20 +136,24 @@ public abstract class AbstractModifyEventHandler implements EventHandler {
   protected abstract String modifyEventType();
 
   protected Future<Void> modifyRecord(DataImportEventPayload payload, MappingParameters mappingParameters) {
+    MappingProfile mappingProfile;
     try {
       preparePayload(payload);
-      MappingProfile mappingProfile = retrieveMappingProfile(payload);
+      mappingProfile = retrieveMappingProfile(payload);
       MarcRecordModifier marcRecordModifier = new MarcRecordModifier();
       marcRecordModifier.initialize(payload, mappingParameters, mappingProfile, modifiedEntityType());
       marcRecordModifier.modifyRecord(mappingProfile.getMappingDetails().getMarcMappingDetails());
       marcRecordModifier.getResult(payload);
-      if (DeleteRuleFor999FieldCache.getInstance().containsDeleteRuleFor999Field(mappingProfile)) {
-        syncExternalIdsHolderWithParsedRecord(payload);
-      }
     } catch (IOException e) {
       return Future.failedFuture(e);
     }
-    return Future.succeededFuture();
+    return deleteRuleFor999FieldCache.containsDeleteRuleFor999Field(mappingProfile)
+      .map(shouldSync -> {
+        if (Boolean.TRUE.equals(shouldSync)) {
+          syncExternalIdsHolderWithParsedRecord(payload);
+        }
+        return null;
+      });
   }
 
   /**

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/modify/AbstractModifyEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/modify/AbstractModifyEventHandler.java
@@ -14,6 +14,7 @@ import org.folio.MappingMetadataDto;
 import org.folio.MappingProfile;
 import org.folio.inventory.client.wrappers.SourceStorageRecordsClientWrapper;
 import org.folio.inventory.common.Context;
+import org.folio.inventory.dataimport.cache.DeleteRuleFor999FieldCache;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.exceptions.OptimisticLockingException;
 import org.folio.inventory.dataimport.handlers.actions.InstanceUpdateDelegate;
@@ -27,7 +28,6 @@ import org.folio.processing.mapping.mapper.writer.marc.MarcRecordModifier;
 import org.folio.rest.client.SourceStorageRecordsClient;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.ExternalIdsHolder;
-import org.folio.rest.jaxrs.model.MarcMappingDetail;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
 
@@ -140,35 +140,13 @@ public abstract class AbstractModifyEventHandler implements EventHandler {
       marcRecordModifier.initialize(payload, mappingParameters, mappingProfile, modifiedEntityType());
       marcRecordModifier.modifyRecord(mappingProfile.getMappingDetails().getMarcMappingDetails());
       marcRecordModifier.getResult(payload);
-      if (containsDeleteRuleFor999Field(mappingProfile)) {
+      if (DeleteRuleFor999FieldCache.getInstance().containsDeleteRuleFor999Field(mappingProfile)) {
         syncExternalIdsHolderWithParsedRecord(payload);
       }
     } catch (IOException e) {
       return Future.failedFuture(e);
     }
     return Future.succeededFuture();
-  }
-
-  /**
-   * Cheap pre-check to avoid unnecessary work: returns {@code true} only if the given MappingProfile
-   * contains at least one MARC-modification rule with action DELETE targeting field "999".
-   * When {@code false}, the parsed-record vs externalIdsHolder synchronization can be safely skipped
-   * because MODIFY did not touch 999 and the inherited holder is still consistent with the MARC content.
-   */
-  private static boolean containsDeleteRuleFor999Field(MappingProfile mappingProfile) {
-    if (mappingProfile == null || mappingProfile.getMappingDetails() == null
-        || mappingProfile.getMappingDetails().getMarcMappingDetails() == null) {
-      return false;
-    }
-    for (MarcMappingDetail detail : mappingProfile.getMappingDetails().getMarcMappingDetails()) {
-      if (detail == null || detail.getAction() != MarcMappingDetail.Action.DELETE || detail.getField() == null) {
-        continue;
-      }
-      if ("999".equals(detail.getField().getField())) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /**

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/modify/AbstractModifyEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/modify/AbstractModifyEventHandler.java
@@ -27,6 +27,7 @@ import org.folio.processing.mapping.mapper.writer.marc.MarcRecordModifier;
 import org.folio.rest.client.SourceStorageRecordsClient;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.ExternalIdsHolder;
+import org.folio.rest.jaxrs.model.MarcMappingDetail;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
 
@@ -139,10 +140,69 @@ public abstract class AbstractModifyEventHandler implements EventHandler {
       marcRecordModifier.initialize(payload, mappingParameters, mappingProfile, modifiedEntityType());
       marcRecordModifier.modifyRecord(mappingProfile.getMappingDetails().getMarcMappingDetails());
       marcRecordModifier.getResult(payload);
+      if (containsDeleteRuleFor999Field(mappingProfile)) {
+        syncExternalIdsHolderWithParsedRecord(payload);
+      }
     } catch (IOException e) {
       return Future.failedFuture(e);
     }
     return Future.succeededFuture();
+  }
+
+  /**
+   * Cheap pre-check to avoid unnecessary work: returns {@code true} only if the given MappingProfile
+   * contains at least one MARC-modification rule with action DELETE targeting field "999".
+   * When {@code false}, the parsed-record vs externalIdsHolder synchronization can be safely skipped
+   * because MODIFY did not touch 999 and the inherited holder is still consistent with the MARC content.
+   */
+  private static boolean containsDeleteRuleFor999Field(MappingProfile mappingProfile) {
+    if (mappingProfile == null || mappingProfile.getMappingDetails() == null
+        || mappingProfile.getMappingDetails().getMarcMappingDetails() == null) {
+      return false;
+    }
+    for (MarcMappingDetail detail : mappingProfile.getMappingDetails().getMarcMappingDetails()) {
+      if (detail == null || detail.getAction() != MarcMappingDetail.Action.DELETE || detail.getField() == null) {
+        continue;
+      }
+      if ("999".equals(detail.getField().getField())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Keeps {@link Record#externalIdsHolder} in sync with the modified MARC parsed content.
+   * When the MODIFY profile removes 999ff$i from parsed content, the previously inherited
+   * {@code externalIdsHolder.instanceId} becomes stale and must be cleared so that downstream
+   * handlers (e.g. CreateInstance) can re-populate it with a freshly generated instance UUID
+   * instead of persisting the old value in SRS records_lb.external_id.
+   * Minimal-impact policy: only clear when 999ff$i is missing/blank in the parsed record.
+   */
+  private void syncExternalIdsHolderWithParsedRecord(DataImportEventPayload payload) {
+    try {
+      String modifiedEntityKey = modifiedEntityType().value();
+      String recordAsString = payload.getContext().get(modifiedEntityKey);
+      if (isBlank(recordAsString)) {
+        return;
+      }
+      Record record = Json.decodeValue(recordAsString, Record.class);
+      String subfield999ffI = ParsedRecordUtil.getAdditionalSubfieldValue(record.getParsedRecord(),
+        ParsedRecordUtil.AdditionalSubfields.I);
+      ExternalIdsHolder holder = record.getExternalIdsHolder();
+      if (isBlank(subfield999ffI) && holder != null
+          && (!isBlank(holder.getInstanceId()) || !isBlank(holder.getInstanceHrid()))) {
+        LOGGER.info("syncExternalIdsHolderWithParsedRecord:: Clearing stale externalIdsHolder (instanceId='{}', instanceHrid='{}') " +
+            "because 999ff$i was removed from parsed record by MODIFY profile, jobExecutionId: {}, recordId: {}",
+          holder.getInstanceId(), holder.getInstanceHrid(), payload.getJobExecutionId(), record.getId());
+        holder.setInstanceId(null);
+        holder.setInstanceHrid(null);
+        payload.getContext().put(modifiedEntityKey, Json.encode(record));
+      }
+    } catch (Exception e) {
+      LOGGER.warn("syncExternalIdsHolderWithParsedRecord:: Failed to sync externalIdsHolder, jobExecutionId: {}",
+        payload.getJobExecutionId(), e);
+    }
   }
 
   protected Future<Void> updateRelatedEntity(DataImportEventPayload payload, MappingMetadataDto mappingMetadataDto, Context context) {
@@ -276,6 +336,6 @@ public abstract class AbstractModifyEventHandler implements EventHandler {
 
   private void preparePayload(DataImportEventPayload dataImportEventPayload) {
     dataImportEventPayload.getEventsChain().add(dataImportEventPayload.getEventType());
-    dataImportEventPayload.setCurrentNode(dataImportEventPayload.getCurrentNode().getChildSnapshotWrappers().get(0));
+    dataImportEventPayload.setCurrentNode(dataImportEventPayload.getCurrentNode().getChildSnapshotWrappers().getFirst());
   }
 }

--- a/src/main/java/org/folio/inventory/dataimport/handlers/actions/modify/MarcBibModifyEventHandler.java
+++ b/src/main/java/org/folio/inventory/dataimport/handlers/actions/modify/MarcBibModifyEventHandler.java
@@ -1,6 +1,7 @@
 package org.folio.inventory.dataimport.handlers.actions.modify;
 
 import io.vertx.core.http.HttpClient;
+import org.folio.inventory.dataimport.cache.DeleteRuleFor999FieldCache;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.handlers.actions.InstanceUpdateDelegate;
 import org.folio.inventory.dataimport.handlers.actions.PrecedingSucceedingTitlesHelper;
@@ -13,9 +14,10 @@ import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 public class MarcBibModifyEventHandler extends AbstractModifyEventHandler {
 
   public MarcBibModifyEventHandler(MappingMetadataCache mappingMetadataCache,
+                                   DeleteRuleFor999FieldCache deleteRuleFor999FieldCache,
                                    InstanceUpdateDelegate instanceUpdateDelegate,
                                    PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper, HttpClient client) {
-    super(mappingMetadataCache, instanceUpdateDelegate, precedingSucceedingTitlesHelper, client);
+    super(mappingMetadataCache, deleteRuleFor999FieldCache, instanceUpdateDelegate, precedingSucceedingTitlesHelper, client);
   }
 
   @Override

--- a/src/main/java/org/folio/inventory/support/KafkaConsumerVerticle.java
+++ b/src/main/java/org/folio/inventory/support/KafkaConsumerVerticle.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.logging.log4j.Logger;
+import org.folio.inventory.dataimport.cache.DeleteRuleFor999FieldCache;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.cache.ProfileSnapshotCache;
 import org.folio.inventory.storage.Storage;
@@ -108,6 +109,10 @@ public abstract class KafkaConsumerVerticle extends AbstractVerticle {
 
   protected MappingMetadataCache getMappingMetadataCache() {
     return MappingMetadataCache.getInstance(vertx, getHttpClient());
+  }
+
+  protected DeleteRuleFor999FieldCache getDeleteRuleFor999FieldCache() {
+    return DeleteRuleFor999FieldCache.getInstance(vertx);
   }
 
   protected ProfileSnapshotCache getProfileSnapshotCache() {

--- a/src/test/java/org/folio/inventory/dataimport/cache/DeleteRuleFor999FieldCacheTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/cache/DeleteRuleFor999FieldCacheTest.java
@@ -1,35 +1,57 @@
 package org.folio.inventory.dataimport.cache;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.vertx.core.Vertx;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.folio.MappingProfile;
 import org.folio.rest.jaxrs.model.MappingDetail;
 import org.folio.rest.jaxrs.model.MarcField;
 import org.folio.rest.jaxrs.model.MarcMappingDetail;
 import org.folio.rest.jaxrs.model.MarcSubfield;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class DeleteRuleFor999FieldCacheTest {
 
-  private final DeleteRuleFor999FieldCache cache = new DeleteRuleFor999FieldCache(60);
+  private static Vertx vertx;
+  private static DeleteRuleFor999FieldCache cache;
 
-  @Test
-  public void shouldReturnFalseForNullProfile() {
-    assertFalse(cache.containsDeleteRuleFor999Field(null));
+  @BeforeClass
+  public static void beforeClass() {
+    vertx = Vertx.vertx();
+    cache = new DeleteRuleFor999FieldCache(vertx, 60L);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    vertx.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+  }
+
+  private static boolean check(MappingProfile profile) throws Exception {
+    return cache.containsDeleteRuleFor999Field(profile)
+      .toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
   }
 
   @Test
-  public void shouldReturnFalseWhenNoMappingDetails() {
+  public void shouldReturnFalseForNullProfile() throws Exception {
+    assertFalse(check(null));
+  }
+
+  @Test
+  public void shouldReturnFalseWhenNoMappingDetails() throws Exception {
     MappingProfile p = new MappingProfile().withId(UUID.randomUUID().toString());
-    assertFalse(cache.containsDeleteRuleFor999Field(p));
+    assertFalse(check(p));
   }
 
   @Test
-  public void shouldReturnFalseWhenNoDeleteRuleFor999() {
+  public void shouldReturnFalseWhenNoDeleteRuleFor999() throws Exception {
     MarcMappingDetail addRule = new MarcMappingDetail()
       .withAction(MarcMappingDetail.Action.ADD)
       .withField(new MarcField().withField("856")
@@ -37,11 +59,11 @@ public class DeleteRuleFor999FieldCacheTest {
     MappingProfile p = new MappingProfile()
       .withId(UUID.randomUUID().toString())
       .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(addRule)));
-    assertFalse(cache.containsDeleteRuleFor999Field(p));
+    assertFalse(check(p));
   }
 
   @Test
-  public void shouldReturnTrueWhenDeleteRuleFor999Present() {
+  public void shouldReturnTrueWhenDeleteRuleFor999Present() throws Exception {
     MarcMappingDetail deleteRule = new MarcMappingDetail()
       .withAction(MarcMappingDetail.Action.DELETE)
       .withField(new MarcField().withField("999")
@@ -49,11 +71,11 @@ public class DeleteRuleFor999FieldCacheTest {
     MappingProfile p = new MappingProfile()
       .withId(UUID.randomUUID().toString())
       .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
-    assertTrue(cache.containsDeleteRuleFor999Field(p));
+    assertTrue(check(p));
   }
 
   @Test
-  public void shouldReturnTrueWhenMixedRulesIncludeDelete999() {
+  public void shouldReturnTrueWhenMixedRulesIncludeDelete999() throws Exception {
     MarcMappingDetail addRule = new MarcMappingDetail()
       .withAction(MarcMappingDetail.Action.ADD)
       .withField(new MarcField().withField("856")
@@ -65,11 +87,11 @@ public class DeleteRuleFor999FieldCacheTest {
     MappingProfile p = new MappingProfile()
       .withId(UUID.randomUUID().toString())
       .withMappingDetails(new MappingDetail().withMarcMappingDetails(Arrays.asList(addRule, deleteRule)));
-    assertTrue(cache.containsDeleteRuleFor999Field(p));
+    assertTrue(check(p));
   }
 
   @Test
-  public void shouldReturnFalseWhenDeleteRuleTargetsOtherField() {
+  public void shouldReturnFalseWhenDeleteRuleTargetsOtherField() throws Exception {
     MarcMappingDetail deleteRule = new MarcMappingDetail()
       .withAction(MarcMappingDetail.Action.DELETE)
       .withField(new MarcField().withField("856")
@@ -77,11 +99,11 @@ public class DeleteRuleFor999FieldCacheTest {
     MappingProfile p = new MappingProfile()
       .withId(UUID.randomUUID().toString())
       .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
-    assertFalse(cache.containsDeleteRuleFor999Field(p));
+    assertFalse(check(p));
   }
 
   @Test
-  public void shouldMemoizeResultByProfileId() {
+  public void shouldMemoizeResultByProfileId() throws Exception {
     String profileId = UUID.randomUUID().toString();
     MarcMappingDetail deleteRule = new MarcMappingDetail()
       .withAction(MarcMappingDetail.Action.DELETE)
@@ -90,19 +112,18 @@ public class DeleteRuleFor999FieldCacheTest {
     MappingProfile p1 = new MappingProfile()
       .withId(profileId)
       .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
-    assertTrue(cache.containsDeleteRuleFor999Field(p1));
+    assertTrue(check(p1));
 
     // Different profile object with the same id but with no delete-999 rule.
     // Cache must return the memoized value (true) - proves that value is keyed by profile id.
     MappingProfile p2 = new MappingProfile()
       .withId(profileId)
       .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.emptyList()));
-    assertTrue("memoized value should be returned for the same profile id",
-      cache.containsDeleteRuleFor999Field(p2));
+    assertTrue("memoized value should be returned for the same profile id", check(p2));
   }
 
   @Test
-  public void shouldNotCacheWhenProfileIdIsBlank() {
+  public void shouldNotCacheWhenProfileIdIsBlank() throws Exception {
     MarcMappingDetail deleteRule = new MarcMappingDetail()
       .withAction(MarcMappingDetail.Action.DELETE)
       .withField(new MarcField().withField("999")
@@ -110,37 +131,39 @@ public class DeleteRuleFor999FieldCacheTest {
     MappingProfile p = new MappingProfile()
       .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
     // profileId is null -> compute directly, no caching
-    assertTrue(cache.containsDeleteRuleFor999Field(p));
+    assertTrue(check(p));
   }
 
   @Test
-  public void shouldReturnTrueForDelete999WithSubfieldI() {
-    MappingProfile p = buildDelete999Profile("i");
-    assertTrue(cache.containsDeleteRuleFor999Field(p));
+  public void singletonAccessorReturnsSameInstance() {
+    DeleteRuleFor999FieldCache a = DeleteRuleFor999FieldCache.getInstance(vertx);
+    DeleteRuleFor999FieldCache b = DeleteRuleFor999FieldCache.getInstance(vertx);
+    assertNotNull(a);
+    assertTrue(a == b);
   }
 
   @Test
-  public void shouldReturnTrueForDelete999WithSubfieldS() {
-    MappingProfile p = buildDelete999Profile("s");
-    assertTrue(cache.containsDeleteRuleFor999Field(p));
+  public void shouldReturnTrueForDelete999WithSubfieldI() throws Exception {
+    assertTrue(check(buildDelete999Profile("i")));
   }
 
   @Test
-  public void shouldReturnFalseForDelete999WhenSubfieldIsOtherThanIsOrWildcard() {
-    // e.g. profile deletes only 999$l - has nothing to do with externalIdsHolder
-    MappingProfile p = buildDelete999Profile("l");
-    assertFalse(cache.containsDeleteRuleFor999Field(p));
+  public void shouldReturnTrueForDelete999WithSubfieldS() throws Exception {
+    assertTrue(check(buildDelete999Profile("s")));
   }
 
   @Test
-  public void shouldReturnFalseForDelete999WhenSubfieldIsT() {
-    MappingProfile p = buildDelete999Profile("t");
-    assertFalse(cache.containsDeleteRuleFor999Field(p));
+  public void shouldReturnFalseForDelete999WhenSubfieldIsOtherThanIsOrWildcard() throws Exception {
+    assertFalse(check(buildDelete999Profile("l")));
   }
 
   @Test
-  public void shouldReturnTrueForDelete999WhenAtLeastOneRelevantSubfieldAmongMany() {
-    // Rule targeting $l AND $i - $i triggers sync even though $l is irrelevant
+  public void shouldReturnFalseForDelete999WhenSubfieldIsT() throws Exception {
+    assertFalse(check(buildDelete999Profile("t")));
+  }
+
+  @Test
+  public void shouldReturnTrueForDelete999WhenAtLeastOneRelevantSubfieldAmongMany() throws Exception {
     MarcMappingDetail deleteRule = new MarcMappingDetail()
       .withAction(MarcMappingDetail.Action.DELETE)
       .withField(new MarcField().withField("999")
@@ -150,11 +173,11 @@ public class DeleteRuleFor999FieldCacheTest {
     MappingProfile p = new MappingProfile()
       .withId(UUID.randomUUID().toString())
       .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
-    assertTrue(cache.containsDeleteRuleFor999Field(p));
+    assertTrue(check(p));
   }
 
   @Test
-  public void shouldReturnFalseWhenAllSubfieldsAreIrrelevant() {
+  public void shouldReturnFalseWhenAllSubfieldsAreIrrelevant() throws Exception {
     MarcMappingDetail deleteRule = new MarcMappingDetail()
       .withAction(MarcMappingDetail.Action.DELETE)
       .withField(new MarcField().withField("999")
@@ -164,19 +187,18 @@ public class DeleteRuleFor999FieldCacheTest {
     MappingProfile p = new MappingProfile()
       .withId(UUID.randomUUID().toString())
       .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
-    assertFalse(cache.containsDeleteRuleFor999Field(p));
+    assertFalse(check(p));
   }
 
   @Test
-  public void shouldReturnTrueForDelete999WhenSubfieldsListIsNull() {
-    // No subfields specified - treated as whole-field wildcard
+  public void shouldReturnTrueForDelete999WhenSubfieldsListIsNull() throws Exception {
     MarcMappingDetail deleteRule = new MarcMappingDetail()
       .withAction(MarcMappingDetail.Action.DELETE)
       .withField(new MarcField().withField("999"));
     MappingProfile p = new MappingProfile()
       .withId(UUID.randomUUID().toString())
       .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
-    assertTrue(cache.containsDeleteRuleFor999Field(p));
+    assertTrue(check(p));
   }
 
   private static MappingProfile buildDelete999Profile(String subfieldCode) {
@@ -187,10 +209,5 @@ public class DeleteRuleFor999FieldCacheTest {
     return new MappingProfile()
       .withId(UUID.randomUUID().toString())
       .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
-  }
-
-  @Test
-  public void singletonAccessorReturnsSameInstance() {
-    assertTrue(DeleteRuleFor999FieldCache.getInstance() == DeleteRuleFor999FieldCache.getInstance());
   }
 }

--- a/src/test/java/org/folio/inventory/dataimport/cache/DeleteRuleFor999FieldCacheTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/cache/DeleteRuleFor999FieldCacheTest.java
@@ -1,0 +1,196 @@
+package org.folio.inventory.dataimport.cache;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+import org.folio.MappingProfile;
+import org.folio.rest.jaxrs.model.MappingDetail;
+import org.folio.rest.jaxrs.model.MarcField;
+import org.folio.rest.jaxrs.model.MarcMappingDetail;
+import org.folio.rest.jaxrs.model.MarcSubfield;
+import org.junit.Test;
+
+public class DeleteRuleFor999FieldCacheTest {
+
+  private final DeleteRuleFor999FieldCache cache = new DeleteRuleFor999FieldCache(60);
+
+  @Test
+  public void shouldReturnFalseForNullProfile() {
+    assertFalse(cache.containsDeleteRuleFor999Field(null));
+  }
+
+  @Test
+  public void shouldReturnFalseWhenNoMappingDetails() {
+    MappingProfile p = new MappingProfile().withId(UUID.randomUUID().toString());
+    assertFalse(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldReturnFalseWhenNoDeleteRuleFor999() {
+    MarcMappingDetail addRule = new MarcMappingDetail()
+      .withAction(MarcMappingDetail.Action.ADD)
+      .withField(new MarcField().withField("856")
+        .withSubfields(Collections.singletonList(new MarcSubfield().withSubfield("u"))));
+    MappingProfile p = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(addRule)));
+    assertFalse(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldReturnTrueWhenDeleteRuleFor999Present() {
+    MarcMappingDetail deleteRule = new MarcMappingDetail()
+      .withAction(MarcMappingDetail.Action.DELETE)
+      .withField(new MarcField().withField("999")
+        .withSubfields(Collections.singletonList(new MarcSubfield().withSubfield("*"))));
+    MappingProfile p = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
+    assertTrue(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldReturnTrueWhenMixedRulesIncludeDelete999() {
+    MarcMappingDetail addRule = new MarcMappingDetail()
+      .withAction(MarcMappingDetail.Action.ADD)
+      .withField(new MarcField().withField("856")
+        .withSubfields(Collections.singletonList(new MarcSubfield().withSubfield("u"))));
+    MarcMappingDetail deleteRule = new MarcMappingDetail()
+      .withAction(MarcMappingDetail.Action.DELETE)
+      .withField(new MarcField().withField("999")
+        .withSubfields(Collections.singletonList(new MarcSubfield().withSubfield("*"))));
+    MappingProfile p = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withMappingDetails(new MappingDetail().withMarcMappingDetails(Arrays.asList(addRule, deleteRule)));
+    assertTrue(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldReturnFalseWhenDeleteRuleTargetsOtherField() {
+    MarcMappingDetail deleteRule = new MarcMappingDetail()
+      .withAction(MarcMappingDetail.Action.DELETE)
+      .withField(new MarcField().withField("856")
+        .withSubfields(Collections.singletonList(new MarcSubfield().withSubfield("*"))));
+    MappingProfile p = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
+    assertFalse(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldMemoizeResultByProfileId() {
+    String profileId = UUID.randomUUID().toString();
+    MarcMappingDetail deleteRule = new MarcMappingDetail()
+      .withAction(MarcMappingDetail.Action.DELETE)
+      .withField(new MarcField().withField("999")
+        .withSubfields(Collections.singletonList(new MarcSubfield().withSubfield("*"))));
+    MappingProfile p1 = new MappingProfile()
+      .withId(profileId)
+      .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
+    assertTrue(cache.containsDeleteRuleFor999Field(p1));
+
+    // Different profile object with the same id but with no delete-999 rule.
+    // Cache must return the memoized value (true) - proves that value is keyed by profile id.
+    MappingProfile p2 = new MappingProfile()
+      .withId(profileId)
+      .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.emptyList()));
+    assertTrue("memoized value should be returned for the same profile id",
+      cache.containsDeleteRuleFor999Field(p2));
+  }
+
+  @Test
+  public void shouldNotCacheWhenProfileIdIsBlank() {
+    MarcMappingDetail deleteRule = new MarcMappingDetail()
+      .withAction(MarcMappingDetail.Action.DELETE)
+      .withField(new MarcField().withField("999")
+        .withSubfields(Collections.singletonList(new MarcSubfield().withSubfield("*"))));
+    MappingProfile p = new MappingProfile()
+      .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
+    // profileId is null -> compute directly, no caching
+    assertTrue(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldReturnTrueForDelete999WithSubfieldI() {
+    MappingProfile p = buildDelete999Profile("i");
+    assertTrue(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldReturnTrueForDelete999WithSubfieldS() {
+    MappingProfile p = buildDelete999Profile("s");
+    assertTrue(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldReturnFalseForDelete999WhenSubfieldIsOtherThanIsOrWildcard() {
+    // e.g. profile deletes only 999$l - has nothing to do with externalIdsHolder
+    MappingProfile p = buildDelete999Profile("l");
+    assertFalse(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldReturnFalseForDelete999WhenSubfieldIsT() {
+    MappingProfile p = buildDelete999Profile("t");
+    assertFalse(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldReturnTrueForDelete999WhenAtLeastOneRelevantSubfieldAmongMany() {
+    // Rule targeting $l AND $i - $i triggers sync even though $l is irrelevant
+    MarcMappingDetail deleteRule = new MarcMappingDetail()
+      .withAction(MarcMappingDetail.Action.DELETE)
+      .withField(new MarcField().withField("999")
+        .withSubfields(Arrays.asList(
+          new MarcSubfield().withSubfield("l"),
+          new MarcSubfield().withSubfield("i"))));
+    MappingProfile p = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
+    assertTrue(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldReturnFalseWhenAllSubfieldsAreIrrelevant() {
+    MarcMappingDetail deleteRule = new MarcMappingDetail()
+      .withAction(MarcMappingDetail.Action.DELETE)
+      .withField(new MarcField().withField("999")
+        .withSubfields(Arrays.asList(
+          new MarcSubfield().withSubfield("l"),
+          new MarcSubfield().withSubfield("t"))));
+    MappingProfile p = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
+    assertFalse(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  @Test
+  public void shouldReturnTrueForDelete999WhenSubfieldsListIsNull() {
+    // No subfields specified - treated as whole-field wildcard
+    MarcMappingDetail deleteRule = new MarcMappingDetail()
+      .withAction(MarcMappingDetail.Action.DELETE)
+      .withField(new MarcField().withField("999"));
+    MappingProfile p = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
+    assertTrue(cache.containsDeleteRuleFor999Field(p));
+  }
+
+  private static MappingProfile buildDelete999Profile(String subfieldCode) {
+    MarcMappingDetail deleteRule = new MarcMappingDetail()
+      .withAction(MarcMappingDetail.Action.DELETE)
+      .withField(new MarcField().withField("999")
+        .withSubfields(Collections.singletonList(new MarcSubfield().withSubfield(subfieldCode))));
+    return new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withMappingDetails(new MappingDetail().withMarcMappingDetails(Collections.singletonList(deleteRule)));
+  }
+
+  @Test
+  public void singletonAccessorReturnsSameInstance() {
+    assertTrue(DeleteRuleFor999FieldCache.getInstance() == DeleteRuleFor999FieldCache.getInstance());
+  }
+}

--- a/src/test/java/org/folio/inventory/dataimport/handlers/DataImportKafkaHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/DataImportKafkaHandlerTest.java
@@ -22,6 +22,7 @@ import org.folio.MappingProfile;
 import org.folio.inventory.KafkaTest;
 import org.folio.inventory.consortium.cache.ConsortiumDataCache;
 import org.folio.inventory.dataimport.cache.CancelledJobsIdsCache;
+import org.folio.inventory.dataimport.cache.DeleteRuleFor999FieldCache;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.cache.ProfileSnapshotCache;
 import org.folio.inventory.dataimport.consumers.DataImportKafkaHandler;
@@ -133,6 +134,7 @@ public class DataImportKafkaHandlerTest extends KafkaTest {
       new ProfileSnapshotCache(vertxAssistant.getVertx(), client, 3600),
       kafkaConfig,
       MappingMetadataCache.getInstance(vertxAssistant.getVertx(), client),
+      DeleteRuleFor999FieldCache.getInstance(vertxAssistant.getVertx()),
       new ConsortiumDataCache(vertxAssistant.getVertx(), client),
       cancelledJobsIdCache);
 

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/MarcBibModifyEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/MarcBibModifyEventHandlerTest.java
@@ -221,13 +221,13 @@ public class MarcBibModifyEventHandlerTest {
     Assert.assertEquals("Victorian environmental nightmares and something else/", updatedInstance.getIndexTitle());
     Assert.assertNotNull(updatedInstance.getIdentifiers().stream().filter(i -> "(OCoLC)1060180367".equals(i.value)).findFirst().get());
     Assert.assertNotNull(updatedInstance.getContributors().stream().filter(c -> "Mazzeno, Laurence W., 1234566".equals(c.name)).findFirst().get());
-    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0dd", updatedInstance.getStatisticalCodeIds().get(0));
-    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0cf", updatedInstance.getNatureOfContentTermIds().get(0));
+    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0dd", updatedInstance.getStatisticalCodeIds().getFirst());
+    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0cf", updatedInstance.getNatureOfContentTermIds().getFirst());
     Assert.assertNotNull(updatedInstance.getSubjects());
     Assert.assertEquals(1, updatedInstance.getSubjects().size());
-    assertThat(updatedInstance.getSubjects().get(0).getValue(), Matchers.containsString("additional subfield"));
+    assertThat(updatedInstance.getSubjects().getFirst().getValue(), Matchers.containsString("additional subfield"));
     Assert.assertNotNull(updatedInstance.getNotes());
-    Assert.assertEquals("Adding a note", updatedInstance.getNotes().get(0).note);
+    Assert.assertEquals("Adding a note", updatedInstance.getNotes().getFirst().note);
 
     verify(mockedInstanceCollection).update(any(), any(), any());
     verify(sourceStorageClient).putSourceStorageRecordsById(eq(record.getId()),
@@ -307,13 +307,13 @@ public class MarcBibModifyEventHandlerTest {
     Assert.assertEquals("Victorian environmental nightmares and something else/", updatedInstance.getIndexTitle());
     Assert.assertNotNull(updatedInstance.getIdentifiers().stream().filter(i -> "(OCoLC)1060180367".equals(i.value)).findFirst().get());
     Assert.assertNotNull(updatedInstance.getContributors().stream().filter(c -> "Mazzeno, Laurence W., 1234566".equals(c.name)).findFirst().get());
-    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0dd", updatedInstance.getStatisticalCodeIds().get(0));
-    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0cf", updatedInstance.getNatureOfContentTermIds().get(0));
+    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0dd", updatedInstance.getStatisticalCodeIds().getFirst());
+    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0cf", updatedInstance.getNatureOfContentTermIds().getFirst());
     Assert.assertNotNull(updatedInstance.getSubjects());
     Assert.assertEquals(1, updatedInstance.getSubjects().size());
-    assertThat(updatedInstance.getSubjects().get(0).getValue(), Matchers.containsString("additional subfield"));
+    assertThat(updatedInstance.getSubjects().getFirst().getValue(), Matchers.containsString("additional subfield"));
     Assert.assertNotNull(updatedInstance.getNotes());
-    Assert.assertEquals("Adding a note", updatedInstance.getNotes().get(0).note);
+    Assert.assertEquals("Adding a note", updatedInstance.getNotes().getFirst().note);
 
     verify(marcBibModifyEventHandler).getSourceStorageRecordsClient(argThat(context -> context.getTenantId().equals(CENTRAL_TENANT_ID)));
     verify(mockedInstanceCollection).update(any(), any(), any());
@@ -368,13 +368,13 @@ public class MarcBibModifyEventHandlerTest {
     Assert.assertEquals("Victorian environmental nightmares and something else/", updatedInstance.getIndexTitle());
     Assert.assertNotNull(updatedInstance.getIdentifiers().stream().filter(i -> "(OCoLC)1060180367".equals(i.value)).findFirst().get());
     Assert.assertNotNull(updatedInstance.getContributors().stream().filter(c -> "Mazzeno, Laurence W., 1234566".equals(c.name)).findFirst().get());
-    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0dd", updatedInstance.getStatisticalCodeIds().get(0));
-    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0cf", updatedInstance.getNatureOfContentTermIds().get(0));
+    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0dd", updatedInstance.getStatisticalCodeIds().getFirst());
+    Assert.assertEquals("b5968c9e-cddc-4576-99e3-8e60aed8b0cf", updatedInstance.getNatureOfContentTermIds().getFirst());
     Assert.assertNotNull(updatedInstance.getSubjects());
     Assert.assertEquals(1, updatedInstance.getSubjects().size());
-    assertThat(updatedInstance.getSubjects().get(0).getValue(), Matchers.containsString("additional subfield"));
+    assertThat(updatedInstance.getSubjects().getFirst().getValue(), Matchers.containsString("additional subfield"));
     Assert.assertNotNull(updatedInstance.getNotes());
-    Assert.assertEquals("Adding a note", updatedInstance.getNotes().get(0).note);
+    Assert.assertEquals("Adding a note", updatedInstance.getNotes().getFirst().note);
 
     verify(mockedInstanceCollection, times(2)).update(any(), any(), any());
     verify(sourceStorageClient).putSourceStorageRecordsById(eq(record.getId()),
@@ -382,7 +382,7 @@ public class MarcBibModifyEventHandlerTest {
   }
 
   @Test
-  public void shouldRemovePrecedingTitlesOnInstanceUpdateWhenIncomingRecordHasNot() throws InterruptedException, ExecutionException, TimeoutException {
+  public void shouldRemovePrecedingTitlesOnInstanceUpdateWhenIncomingRecordHasNot() throws InterruptedException, ExecutionException {
     // given
     JsonArray precedingTitlesJson = new JsonArray().add(new JsonObject()
       .put(PrecedingSucceedingTitle.TITLE_KEY, "Butterflies in the snow"));
@@ -557,7 +557,7 @@ public class MarcBibModifyEventHandlerTest {
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_BIB_RECORD_MODIFIED.value())
       .withContext(new HashMap<>())
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = marcBibModifyEventHandler.handle(dataImportEventPayload);
@@ -619,6 +619,99 @@ public class MarcBibModifyEventHandlerTest {
 
   private Response getOkResponse(String body) {
     return new Response(200, body, null, null);
+  }
+
+
+  @Test
+  public void shouldClearExternalIdsHolderInstanceIdWhenDeleteProfileRemoves999Field()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    // given: MODIFY profile that DELETEs the whole 999 field
+    MarcMappingDetail deleteDetail = new MarcMappingDetail()
+      .withOrder(0)
+      .withAction(MarcMappingDetail.Action.DELETE)
+      .withField(new MarcField()
+        .withField("999")
+        .withIndicator1("*")
+        .withIndicator2("*")
+        .withSubfields(Collections.singletonList(new MarcSubfield().withSubfield("*"))));
+
+    MappingProfile deleteMappingProfile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Delete 999")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(MARC_BIBLIOGRAPHIC)
+      .withMappingDetails(new MappingDetail()
+        .withMarcMappingDetails(Collections.singletonList(deleteDetail))
+        .withMarcMappingOption(MappingDetail.MarcMappingOption.MODIFY));
+
+    ProfileSnapshotWrapper deleteSnapshotWrapper = new ProfileSnapshotWrapper()
+      .withProfileId(actionProfile.getId())
+      .withContentType(ACTION_PROFILE)
+      .withContent(JsonObject.mapFrom(actionProfile).getMap())
+      .withChildSnapshotWrappers(Collections.singletonList(
+        new ProfileSnapshotWrapper()
+          .withProfileId(deleteMappingProfile.getId())
+          .withContentType(MAPPING_PROFILE)
+          .withContent(JsonObject.mapFrom(deleteMappingProfile).getMap())));
+
+    HashMap<String, String> payloadContext = new HashMap<>();
+    // record fixture has externalIdsHolder.instanceId = ddd266ef-... and 999ff$i in parsed content
+    payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(payloadContext)
+      .withOkapiUrl(OKAPI_URL)
+      .withCurrentNode(deleteSnapshotWrapper)
+      .withTenant(TENANT_ID);
+
+    // sanity precondition: holder is populated before handling
+    Record recordBefore = Json.decodeValue(payloadContext.get(MARC_BIBLIOGRAPHIC.value()), Record.class);
+    Assert.assertNotNull(recordBefore.getExternalIdsHolder());
+    Assert.assertNotNull(recordBefore.getExternalIdsHolder().getInstanceId());
+
+    // when
+    CompletableFuture<DataImportEventPayload> future = marcBibModifyEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload result = future.get(5, TimeUnit.SECONDS);
+
+    // then
+    Record actualRecord = Json.decodeValue(result.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
+    Optional<JsonObject> field999 = getFieldFromParsedRecord(actualRecord.getParsedRecord().getContent().toString(), "999");
+    Assert.assertFalse("999 field must be removed from parsed content", field999.isPresent());
+    Assert.assertTrue("externalIdsHolder.instanceId must be cleared after 999 removal",
+      actualRecord.getExternalIdsHolder() == null
+        || actualRecord.getExternalIdsHolder().getInstanceId() == null
+        || actualRecord.getExternalIdsHolder().getInstanceId().isEmpty());
+  }
+
+  @Test
+  public void shouldNotClearExternalIdsHolderInstanceIdWhenModifyProfileDoesNotRemove999Field()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    // given: default profile only ADDs 856 (does not touch 999)
+    HashMap<String, String> payloadContext = new HashMap<>();
+    payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+    String originalInstanceId = record.getExternalIdsHolder().getInstanceId();
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withEventType(DI_INCOMING_MARC_BIB_RECORD_PARSED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withContext(payloadContext)
+      .withOkapiUrl(OKAPI_URL)
+      .withCurrentNode(profileSnapshotWrapper)
+      .withTenant(TENANT_ID);
+
+    // when
+    CompletableFuture<DataImportEventPayload> future = marcBibModifyEventHandler.handle(dataImportEventPayload);
+    DataImportEventPayload result = future.get(5, TimeUnit.SECONDS);
+
+    // then: 999 must remain, holder must remain untouched
+    Record actualRecord = Json.decodeValue(result.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
+    Optional<JsonObject> field999 = getFieldFromParsedRecord(actualRecord.getParsedRecord().getContent().toString(), "999");
+    Assert.assertTrue("999 field must still be present", field999.isPresent());
+    Assert.assertNotNull(actualRecord.getExternalIdsHolder());
+    Assert.assertEquals("externalIdsHolder.instanceId must remain unchanged",
+      originalInstanceId, actualRecord.getExternalIdsHolder().getInstanceId());
   }
 
   public static Optional<JsonObject> getFieldFromParsedRecord(String parsedContent, String field) {

--- a/src/test/java/org/folio/inventory/dataimport/handlers/actions/MarcBibModifyEventHandlerTest.java
+++ b/src/test/java/org/folio/inventory/dataimport/handlers/actions/MarcBibModifyEventHandlerTest.java
@@ -17,6 +17,7 @@ import org.folio.inventory.TestUtil;
 import org.folio.inventory.common.Context;
 import org.folio.inventory.common.domain.Failure;
 import org.folio.inventory.common.domain.Success;
+import org.folio.inventory.dataimport.cache.DeleteRuleFor999FieldCache;
 import org.folio.inventory.dataimport.cache.MappingMetadataCache;
 import org.folio.inventory.dataimport.handlers.actions.modify.MarcBibModifyEventHandler;
 import org.folio.inventory.domain.instances.Instance;
@@ -181,7 +182,8 @@ public class MarcBibModifyEventHandlerTest {
       .thenReturn(Future.succeededFuture(putRecordHttpResponse));
 
     PrecedingSucceedingTitlesHelper precedingSucceedingTitlesHelper = new PrecedingSucceedingTitlesHelper(ctxt -> mockedOkapiHttpClient);
-    marcBibModifyEventHandler = spy(new MarcBibModifyEventHandler(mappingMetadataCache, new InstanceUpdateDelegate(mockedStorage), precedingSucceedingTitlesHelper, httpClient));
+    DeleteRuleFor999FieldCache deleteRuleFor999FieldCache = new DeleteRuleFor999FieldCache(vertx, 60L);
+    marcBibModifyEventHandler = spy(new MarcBibModifyEventHandler(mappingMetadataCache, deleteRuleFor999FieldCache, new InstanceUpdateDelegate(mockedStorage), precedingSucceedingTitlesHelper, httpClient));
 
     doReturn(sourceStorageClient).when(marcBibModifyEventHandler).getSourceStorageRecordsClient(any());
   }


### PR DESCRIPTION
### Purpose
Instance which was created from “.mrc” file which had 999ff by "Modify” (remove 999ff field) + create action is not linked to SRS record.

### Approach
Previous values from the marc record were stored in the `external_id` and `external_hrid` fields of the `records_lb` table. 

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
_List any Jira issues related to this pull request._

### Learning and Resources (if applicable)
[MODINV-1410](https://folio-org.atlassian.net/browse/MODINV-1410)

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
